### PR TITLE
Prevent AxiomSoapElement from creating attributes with invalid names

### DIFF
--- a/core/src/main/java/org/springframework/ws/soap/axiom/AxiomSoapElement.java
+++ b/core/src/main/java/org/springframework/ws/soap/axiom/AxiomSoapElement.java
@@ -72,7 +72,12 @@ class AxiomSoapElement implements SoapElement {
 
     public final void addAttribute(QName name, String value) {
         try {
-            OMNamespace namespace = getAxiomFactory().createOMNamespace(name.getNamespaceURI(), name.getPrefix());
+            String namespaceURI = name.getNamespaceURI();
+            String prefix = name.getPrefix();
+            // If a namespace is specified, but the prefix is empty, then set the prefix to null to
+            // let Axiom generate one.
+            OMNamespace namespace = getAxiomFactory().createOMNamespace(namespaceURI,
+                    namespaceURI.length() > 0 && prefix.length() == 0 ? null : prefix);
             OMAttribute attribute = getAxiomFactory().createOMAttribute(name.getLocalPart(), namespace, value);
             getAxiomElement().addAttribute(attribute);
         }


### PR DESCRIPTION
Axiom 1.2.14 allows creation of attributes with a namespace URI and an
empty prefix, but the behavior for attributes with such an invalid name
is undefined. Axiom 1.2.15 will refuse to create such an attribute. This
change modifies AxiomSoapElement#addAttribute so that it lets Axiom
generate a prefix if necessary. All tests now pass successfully with
Axiom 1.2.15-SNAPSHOT.
