### PR TITLE
Fixed build to use freely-available JARs

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -617,15 +617,15 @@
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>javax.jms</groupId>
-                <artifactId>jms</artifactId>
-                <version>1.1</version>
+                <groupId>org.apache.geronimo.specs</groupId>
+                <artifactId>geronimo-jms_1.1_spec</artifactId>
+                <version>1.1.1</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>javax.ejb</groupId>
-                <artifactId>ejb</artifactId>
-                <version>2.1</version>
+                <groupId>org.apache.geronimo.specs</groupId>
+                <artifactId>geronimo-ejb_2.1_spec</artifactId>
+                <version>1.1</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
@@ -699,10 +699,6 @@
                     <exclusion>
                         <groupId>javax.mail</groupId>
                         <artifactId>mail</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>javax.jms</groupId>
-                        <artifactId>jms</artifactId>
                     </exclusion>
                     <exclusion>
                         <groupId>com.sun.jdmk</groupId>

--- a/samples/airline/client/jms/pom.xml
+++ b/samples/airline/client/jms/pom.xml
@@ -45,8 +45,8 @@
     </build>    
     <dependencies>
         <dependency>
-            <groupId>javax.jms</groupId>
-            <artifactId>jms</artifactId>
+            <groupId>org.apache.geronimo.specs</groupId>
+            <artifactId>geronimo-jms_1.1_spec</artifactId>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/samples/airline/server/pom.xml
+++ b/samples/airline/server/pom.xml
@@ -195,8 +195,8 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>javax.jms</groupId>
-            <artifactId>jms</artifactId>
+            <groupId>org.apache.geronimo.specs</groupId>
+            <artifactId>geronimo-jms_1.1_spec</artifactId>
             <scope>runtime</scope>
         </dependency>
         <!-- O/R Mapping dependencies -->

--- a/sandbox/pom.xml
+++ b/sandbox/pom.xml
@@ -62,8 +62,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.jms</groupId>
-            <artifactId>jms</artifactId>
+            <groupId>org.apache.geronimo.specs</groupId>
+            <artifactId>geronimo-jms_1.1_spec</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/support/pom.xml
+++ b/support/pom.xml
@@ -75,13 +75,13 @@
         </dependency>
         <!-- Java EE dependencies -->
         <dependency>
-            <groupId>javax.jms</groupId>
-            <artifactId>jms</artifactId>
+            <groupId>org.apache.geronimo.specs</groupId>
+            <artifactId>geronimo-jms_1.1_spec</artifactId>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>javax.ejb</groupId>
-            <artifactId>ejb</artifactId>
+            <groupId>org.apache.geronimo.specs</groupId>
+            <artifactId>geronimo-ejb_2.1_spec</artifactId>
             <optional>true</optional>
         </dependency>
         <dependency>


### PR DESCRIPTION
Updated the build to use freely-available JAR files for JMS 1.1 and EJB 2.1, as the original JAR files do not exist in Maven Central and are no longer in the Spring Release repository.

Issue: SWS-644
