### PR TITLE
SWS-835 HttpComponentsMessageSender inintuitive constructor

### DIFF
--- a/core/src/main/java/org/springframework/ws/transport/http/HttpComponentsMessageSender.java
+++ b/core/src/main/java/org/springframework/ws/transport/http/HttpComponentsMessageSender.java
@@ -87,6 +87,9 @@ public class HttpComponentsMessageSender extends AbstractHttpWebServiceMessageSe
 
     /**
      * Create a new instance of the <code>HttpClientMessageSender</code> with the given {@link HttpClient} instance.
+     * <p>
+     * Does not add the necessary timeouts and interceptor that are set by the
+     * default constructor.
      *
      * @param httpClient the HttpClient instance to use for this sender
      */
@@ -242,10 +245,10 @@ public class HttpComponentsMessageSender extends AbstractHttpWebServiceMessageSe
 
     /**
      * HttpClient {@link org.apache.http.HttpRequestInterceptor} implementation that removes {@code Content-Length} and
-     * {@code Transfer-Encoding} headers from the request. Necessary, because SAAJ and other SOAP implementations set these
+     * {@code Transfer-Encoding} headers from the request. Necessary, because some SAAJ and other SOAP implementations set these
      * headers themselves, and HttpClient throws an exception if they have been set.
      */
-    private static class RemoveSoapHeadersInterceptor implements HttpRequestInterceptor {
+    public static class RemoveSoapHeadersInterceptor implements HttpRequestInterceptor {
 
         public void process(HttpRequest request, HttpContext context) throws HttpException, IOException {
             if (request instanceof HttpEntityEnclosingRequest) {


### PR DESCRIPTION
HttpComponentsMessageSender has two constructors, with and
without HttpClient, and the one with HttpClient omits adding a
SoapRemoveHeaderInterceptor.

This breaks in org.apache.http.protocol.RequestContent with new
ProtocolException("Content-Length header already present"), but only
in some containers (oc4j) and not in others (jetty, eclipe); this makes
the issue hard to debug.

Adding a note to the javadoc would help the developer pick the proper
constructor to avoid this issue.

Jira issue SWS-835
