### PR TITLE
Fixed typo in SimpleWsdl11Definition

### DIFF
--- a/core/src/main/java/org/springframework/ws/wsdl/wsdl11/SimpleWsdl11Definition.java
+++ b/core/src/main/java/org/springframework/ws/wsdl/wsdl11/SimpleWsdl11Definition.java
@@ -63,7 +63,7 @@ public class SimpleWsdl11Definition implements Wsdl11Definition, InitializingBea
 
     public void afterPropertiesSet() throws Exception {
         Assert.notNull(this.wsdlResource, "wsdl is required");
-        Assert.isTrue(this.wsdlResource.exists(), "wsdl '" + this.wsdlResource + "' does not exit");
+        Assert.isTrue(this.wsdlResource.exists(), "wsdl '" + this.wsdlResource + "' does not exist");
     }
 
     public Source getSource() {


### PR DESCRIPTION
Changed the word 'exit' in a log message to 'exist' as it was referring to a non-existent file.

Note: I couldn't successfully run the included tests before or after making the change. I'm pretty sure this change won't break the build though ;-). 
