### PR TITLE
Wrong check if logger is enabled in WebServiceTemplate.logResponse method.

### DIFF
--- a/spring-ws-core/src/main/java/org/springframework/ws/client/core/WebServiceTemplate.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/client/core/WebServiceTemplate.java
@@ -683,7 +683,7 @@ public class WebServiceTemplate extends WebServiceAccessor implements WebService
             }
         }
         else {
-            if (logger.isDebugEnabled()) {
+            if (receivedMessageTracingLogger.isDebugEnabled()) {
                 receivedMessageTracingLogger
                         .debug("Received no response for request [" + messageContext.getRequest() + "]");
             }


### PR DESCRIPTION
Wrong check if logger is enabled in WebServiceTemplate.logResponse method.
For sure, method should check the same logger it uses to register log message.
