### PR TITLE
Improve Eclipse setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,6 @@ atlassian-ide-plugin*.xml
 out
 
 /build
+/spring-*/bin
 /spring-*/build
 .gradle

--- a/build.gradle
+++ b/build.gradle
@@ -10,13 +10,12 @@ buildscript {
 
 configure(allprojects) {
 	group = "org.springframework.ws"
-	
+
 	ext.springVersion = "3.2.4.RELEASE"
 	ext.axiomVersion = "1.2.14"
 
 	apply plugin: "java"
 	apply plugin: "propdeps-idea"
-	apply plugin: "eclipse"
 	apply plugin: "propdeps"
 
 /*	[compileJava, compileTestJava]*.options*.compilerArgs = [
@@ -80,6 +79,8 @@ configure(allprojects) {
 
 configure(subprojects) { subproject ->
 
+	apply plugin: "eclipse"
+
 	jar {
 		manifest.attributes["Created-By"] =
 			"${System.getProperty("java.version")} (${System.getProperty("java.specification.vendor")})"
@@ -128,7 +129,7 @@ configure(subprojects) { subproject ->
 
 project('spring-xml') {
 	description = "Spring XML"
-	
+
 	dependencies {
 		// Spring
 		compile("org.springframework:spring-beans:$springVersion")


### PR DESCRIPTION
Only apply the Eclipse plugin to subprojects. This prevents the creation of an Eclipse project for the root Gradle project which was masking the Eclipse projects for all of the Gradle sub-projects.

Update .gitignore to ignore the bin folder created by builds in Eclipse.
