### PR TITLE
Enable easy installation into local Maven repo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,6 +80,7 @@ configure(allprojects) {
 configure(subprojects) { subproject ->
 
 	apply plugin: "eclipse"
+	apply plugin: "maven"
 
 	jar {
 		manifest.attributes["Created-By"] =


### PR DESCRIPTION
To allow easy installation of the built artifacts into the local Maven repository, this commit applies the Maven plugin to all Gradle subprojects. As a result, the install task can now be used to perform the installation
