### PR TITLE
Dependency updates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ configure(allprojects) {
 	}
 
 	dependencies {
-		compile("commons-logging:commons-logging:1.1.1")
+		compile("commons-logging:commons-logging:1.1.3")
 		compile("org.springframework:spring-core:$springVersion")
 
 		testCompile("junit:junit:4.10")
@@ -193,9 +193,8 @@ project('spring-ws-support') {
 		testCompile("org.springframework:spring-test:$springVersion")
 
 		// Transport
-		provided("org.apache.geronimo.specs:geronimo-jms_1.1_spec:1.1")
-		provided("org.apache.geronimo.specs:geronimo-ejb_2.1_spec:1.1")
-		provided("javax.mail:mail:1.4.5")
+		provided("javax.jms:jms-api:1.1-rev-1")
+		provided("javax.mail:mail:1.4.7")
 		optional("jivesoftware:smack:3.1.0")
 		testCompile("commons-httpclient:commons-httpclient:3.1")
 		testRuntime("org.apache.activemq:activemq-core:4.1.2")

--- a/spring-ws-support/template.mf
+++ b/spring-ws-support/template.mf
@@ -8,7 +8,6 @@ Import-Template:
  com.sun.net.httpserver.*;version="0";resolution:=optional,
  com.sun.mail.imap.*;version="[1.4.0, 2.0.0)";resolution:=optional,
  javax.activation.*;version="0",
- javax.ejb.*;version="[2.0.0, 4.0.0)";resolution:=optional,
  javax.jms.*;version="[1.1.0, 2.0.0)",
  javax.mail.*;version="[1.4.0, 2.0.0)",
  javax.naming.*;version="0";resolution:=optional,


### PR DESCRIPTION
- Updated Java Mail to 1.4.7
- Updated Commons Logging to 1.1.3
- Replaced JMS spec dependency to use the 'official' artifact
- Removed redundant EJB spec dependency
