### PR TITLE
Make full use of the propdeps plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@ configure(allprojects) {
 	apply plugin: "maven"
 	apply plugin: "propdeps-idea"
 	apply plugin: "propdeps"
+	apply plugin: "propdeps-maven"
 
 	compileJava.options*.compilerArgs = [
 		"-Xlint:serial", "-Xlint:varargs", "-Xlint:cast", "-Xlint:classfile",
@@ -133,8 +134,8 @@ project('spring-xml') {
 		compile("org.springframework:spring-context:$springVersion")
 
 		//XML
-		compile("org.apache.ws.xmlschema:xmlschema-core:2.1.0", optional)
-		compile("jaxen:jaxen:1.1.4", optional)
+		optional("org.apache.ws.xmlschema:xmlschema-core:2.1.0")
+		optional("jaxen:jaxen:1.1.4")
 	}
 }
 
@@ -152,30 +153,28 @@ project('spring-ws-core') {
 		testCompile("org.springframework:spring-test:$springVersion")
 
 		// XML
-		compile("org.jdom:jdom:2.0.1", optional)
-		compile("dom4j:dom4j:1.6.1", optional)
-		compile("xom:xom:1.2.5") {
-			optional
+		optional("org.jdom:jdom:2.0.1")
+		optional("dom4j:dom4j:1.6.1")
+		optional("xom:xom:1.2.5") {
 			exclude group: 'xml-apis', module: 'xml-apis'
 			exclude group: 'xerces', module: 'xercesImpl'
 			exclude group: 'xalan', module: 'xalan'
 		}
-		compile("org.apache.ws.xmlschema:xmlschema-core:2.1.0", optional)
+		optional("org.apache.ws.xmlschema:xmlschema-core:2.1.0")
 
 		// SOAP
-		compile("org.apache.ws.commons.axiom:axiom-api:$axiomVersion", optional)
-		compile("org.apache.ws.commons.axiom:axiom-impl:$axiomVersion") {
-			optional
+		optional("org.apache.ws.commons.axiom:axiom-api:$axiomVersion")
+		optional("org.apache.ws.commons.axiom:axiom-impl:$axiomVersion") {
 			exclude group: 'org.codehaus.woodstox', module: 'wstx-asl'
 		}
 
 		// WSDL
-		compile("wsdl4j:wsdl4j:1.6.1", optional)
+		optional("wsdl4j:wsdl4j:1.6.1")
 
 		// Transport
-		compile("javax.servlet:javax.servlet-api:3.0.1", provided)
-		compile("org.apache.httpcomponents:httpclient:4.2.5", optional)
-		compile("commons-httpclient:commons-httpclient:3.1", optional)
+		provided("javax.servlet:javax.servlet-api:3.0.1")
+		optional("org.apache.httpcomponents:httpclient:4.2.5")
+		optional("commons-httpclient:commons-httpclient:3.1")
 		testCompile("org.mortbay.jetty:jetty:6.1.26")
 
 		testCompile("log4j:log4j:1.2.16")
@@ -196,10 +195,10 @@ project('spring-ws-support') {
 		testCompile("org.springframework:spring-test:$springVersion")
 
 		// Transport
-		compile("javax.jms:jms-api:1.1-rev-1", provided)
-		compile("javax.mail:javax.mail-api:1.4.7", provided)
-		compile("com.sun.mail:javax.mail:1.4.7", provided)
-		compile("org.igniterealtime.smack:smack:3.2.1", optional)
+		provided("javax.jms:jms-api:1.1-rev-1")
+		provided("javax.mail:javax.mail-api:1.4.7")
+		provided("com.sun.mail:javax.mail:1.4.7")
+		optional("org.igniterealtime.smack:smack:3.2.1")
 		testCompile("commons-httpclient:commons-httpclient:3.1")
 		testRuntime("org.apache.activemq:activemq-core:4.1.2") {
 			exclude group:'org.apache.geronimo.specs', module:'geronimo-jms_1.1_spec'
@@ -222,20 +221,18 @@ project('spring-ws-security') {
 
 		// Spring Security
 		compile("org.springframework.security:spring-security-core:3.2.3.RELEASE")
-		compile("net.sf.ehcache:ehcache-core:2.6.9", optional)
+		optional("net.sf.ehcache:ehcache-core:2.6.9")
 
 		// WS-Security
-		compile("com.sun.xml.wss:xws-security:3.0") {
-			optional
+		optional("com.sun.xml.wss:xws-security:3.0") {
 			exclude group: 'javax.xml.crypto', module: 'xmldsig'
 		}
-		compile("org.apache.ws.security:wss4j:1.6.15", optional)
+		optional("org.apache.ws.security:wss4j:1.6.15")
 
 		// SOAP
-		compile("com.sun.xml.messaging.saaj:saaj-impl:1.3.19", provided) // required for XWSS
-		compile("org.apache.ws.commons.axiom:axiom-api:$axiomVersion", optional)
-		compile("org.apache.ws.commons.axiom:axiom-impl:$axiomVersion") {
-			optional
+		provided("com.sun.xml.messaging.saaj:saaj-impl:1.3.19") // required for XWSS
+		optional("org.apache.ws.commons.axiom:axiom-api:$axiomVersion")
+		optional("org.apache.ws.commons.axiom:axiom-impl:$axiomVersion") {
 			exclude group: 'org.codehaus.woodstox', module: 'wstx-asl'
 		}
 

--- a/publish-maven.gradle
+++ b/publish-maven.gradle
@@ -1,11 +1,5 @@
 apply plugin: 'maven'
 
-ext.optionalDeps = []
-ext.providedDeps = []
-
-ext.optional = { optionalDeps << it }
-ext.provided = { providedDeps << it }
-
 install {
 	repositories.mavenInstaller {
 		customizePom(pom, project)
@@ -14,17 +8,14 @@ install {
 
 def customizePom(pom, gradleProject) {
 	pom.whenConfigured { generatedPom ->
-		// respect 'optional' and 'provided' dependencies
-		gradleProject.optionalDeps.each { dep ->
-			generatedPom.dependencies.find { it.artifactId == dep.name }?.optional = true
-		}
-		gradleProject.providedDeps.each { dep ->
-			generatedPom.dependencies.find { it.artifactId == dep.name }?.scope = 'provided'
-		}
-
 		// eliminate test-scoped dependencies (no need in maven central poms)
 		generatedPom.dependencies.removeAll { dep ->
 			dep.scope == 'test'
+		}
+
+		// Ensure consistent ordering of dependencies to ease comparison with older poms
+		generatedPom.dependencies = generatedPom.dependencies.sort { dep ->
+			"$dep.scope:$dep.groupId:$dep.artifactId"
 		}
 
 		// add all items necessary for maven central publication


### PR DESCRIPTION
Sorry for the noise. This is an improved version of #18. It should be functionally equivalent. It allows the optional and provided configurations to be used, rather than the confusing `compile("foo", optional)` syntax.
