### PR TITLE
Add the Spring IO plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ buildscript {
 	dependencies {
 		classpath 'org.springframework.build.gradle:propdeps-plugin:0.0.6'
 		classpath 'org.springframework.build.gradle:docbook-reference-plugin:0.2.7'
+		classpath 'org.springframework.build.gradle:spring-io-plugin:0.0.3.RELEASE'
 	}
 }
 
@@ -42,7 +43,7 @@ configure(allprojects) {
 
 	sourceSets.test.resources.srcDirs = ['src/test/resources', 'src/test/java']
 
-	test {
+	tasks.withType(Test).all {
 		systemProperty("java.awt.headless", "true")
 		systemProperty("testGroups", project.properties.get("testGroups"))
 		scanForTestClasses = false
@@ -78,6 +79,18 @@ configure(subprojects) { subproject ->
 	apply plugin: "eclipse"
 	apply plugin: "maven"
 	apply from: "${rootProject.projectDir}/publish-maven.gradle"
+
+	 if (project.hasProperty('platformVersion')) {
+		apply plugin: 'spring-io'
+
+		repositories {
+			maven { url "https://repo.spring.io/libs-snapshot" }
+		}
+
+		dependencies {
+			springIoVersions "io.spring.platform:platform-versions:${platformVersion}@properties"
+		}
+	}
 
 	jar {
 		manifest.attributes["Created-By"] =


### PR DESCRIPTION
Configure the Spring IO plugin such that it's only applied when the build is run with `-PplatformVersion=<version>`. This `platformVersion` property is used to determine the version of the Platform that will
be used when running the `springIoCheck` task. The plugin can be used by running a build as follows:

```
./gradlew clean springIoCheck -PplatformVersion=1.0.0.BUILD-SNAPSHOT -PJDK8_HOME=…
```

This will test the project on JDK 8 using the dependencies defined in the latest snapshot of Spring IO Platform 1.0.0.
