### PR TITLE
Refactored method AbstractPortTypesProvider.createOperations().

### DIFF
--- a/spring-ws-core/src/main/java/org/springframework/ws/wsdl/wsdl11/provider/AbstractPortTypesProvider.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/wsdl/wsdl11/provider/AbstractPortTypesProvider.java
@@ -16,7 +16,6 @@
 
 package org.springframework.ws.wsdl.wsdl11.provider;
 
-import java.util.Iterator;
 import java.util.List;
 import javax.wsdl.Definition;
 import javax.wsdl.Fault;
@@ -33,9 +32,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import org.springframework.util.Assert;
-import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
-import org.springframework.util.StringUtils;
 
 /**
  * Abstract base class for {@link PortTypesProvider} implementations.
@@ -94,14 +91,9 @@ public abstract class AbstractPortTypesProvider implements PortTypesProvider {
     }
 
     private void createOperations(Definition definition, PortType portType) throws WSDLException {
-        MultiValueMap<String, Message> operations = new LinkedMultiValueMap<String, Message>();
-        for (Iterator<?> iterator = definition.getMessages().values().iterator(); iterator.hasNext();) {
-            Message message = (Message) iterator.next();
-            String operationName = getOperationName(message);
-            if (StringUtils.hasText(operationName)) {
-                operations.add(operationName,message);
-            }
-        }
+
+        MultiValueMap<String, Message> operations = groupByOperations(definition, portType);
+
         if (operations.isEmpty() && logger.isWarnEnabled()) {
             logger.warn("No operations were created, make sure the WSDL contains messages");
         }
@@ -140,13 +132,16 @@ public abstract class AbstractPortTypesProvider implements PortTypesProvider {
     }
 
     /**
-     * Template method that returns the name of the operation coupled to the given {@link Message}. Subclasses can
-     * return {@code null} to indicate that a message should not be coupled to an operation.
+     * Template method that groups messages contained in specified WSDL definition into operations.
      *
-     * @param message the WSDL4J {@code Message}
-     * @return the operation name; or {@code null}
+     * <p>It's possible to share messages between operations (e.g. share common FaultMessage)</p>
+     *
+     * @param definition the WSDL4J {@code Definition}
+     * @param portType the WSDL4J {@code PortType}
+     * @return MultiValueMap where key is operation name and value is a list of messages.
      */
-    protected abstract String getOperationName(Message message);
+    protected abstract MultiValueMap<String, Message> groupByOperations(Definition definition, PortType portType);
+
 
     /**
      * Indicates whether the given name name should be included as {@link Input} message in the definition.

--- a/spring-ws-core/src/main/java/org/springframework/ws/wsdl/wsdl11/provider/SuffixBasedPortTypesProvider.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/wsdl/wsdl11/provider/SuffixBasedPortTypesProvider.java
@@ -16,9 +16,16 @@
 
 package org.springframework.ws.wsdl.wsdl11.provider;
 
+import java.util.Iterator;
+
+import javax.wsdl.Definition;
 import javax.wsdl.Message;
+import javax.wsdl.PortType;
 
 import org.springframework.util.Assert;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.util.StringUtils;
 
 /**
  * Implementation of the {@link  PortTypesProvider} interface that is based on suffixes.
@@ -101,6 +108,26 @@ public class SuffixBasedPortTypesProvider extends AbstractPortTypesProvider {
     }
 
     @Override
+    protected MultiValueMap<String, Message> groupByOperations(Definition definition, PortType portType) {
+        MultiValueMap<String, Message> operations = new LinkedMultiValueMap<String, Message>();
+
+        for (Iterator<?> iterator = definition.getMessages().values().iterator(); iterator.hasNext();) {
+            Message message = (Message) iterator.next();
+            String operationName = getOperationName(message);
+            if (StringUtils.hasText(operationName)) {
+                operations.add(operationName,message);
+            }
+        }
+        return operations;
+    }
+
+    /**
+     * Template method that returns the name of the operation coupled to the given {@link Message}. Subclasses can
+     * return {@code null} to indicate that a message should not be coupled to an operation.
+     *
+     * @param message the WSDL4J {@code Message}
+     * @return the operation name; or {@code null}
+     */
     protected String getOperationName(Message message) {
         String messageName = getMessageName(message);
         if (messageName != null) {


### PR DESCRIPTION
- Code that grouping messages by operations factored out from createOperations() to separate method getByOperations(). This gives subclasses more control on how to create operations. E.g. operations may share messages.
- Method getByOperations() made abstract and implementation moved to subclass. This is because name based operation grouping is too specific for AbstractPortTypesProvider.
