### PR TITLE
Exception handled by MessageDispatcher was logged with debug level

### DIFF
--- a/spring-ws-core/src/main/java/org/springframework/ws/server/MessageDispatcher.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/server/MessageDispatcher.java
@@ -332,8 +332,8 @@ public class MessageDispatcher implements WebServiceMessageReceiver, BeanNameAwa
 		if (!CollectionUtils.isEmpty(getEndpointExceptionResolvers())) {
 			for (EndpointExceptionResolver resolver : getEndpointExceptionResolvers()) {
 				if (resolver.resolveException(messageContext, endpoint, ex)) {
-					if (logger.isDebugEnabled()) {
-						logger.debug("Endpoint invocation resulted in exception - responding with Fault", ex);
+					if (logger.isErrorEnabled()) {
+						logger.error("Endpoint invocation resulted in exception - responding with Fault", ex);
 					}
 					return;
 				}


### PR DESCRIPTION
This exception can be a serious application error which will be omitted because of to low logging level. I suggest to change level to error or at least warning.