### PR TITLE
Fix namespace prefix handling with StreamingPayload

### DIFF
--- a/spring-ws-core/src/main/java/org/springframework/ws/soap/axiom/AxiomSoapBody.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/soap/axiom/AxiomSoapBody.java
@@ -16,6 +16,7 @@
 
 package org.springframework.ws.soap.axiom;
 
+import javax.xml.namespace.QName;
 import javax.xml.transform.Result;
 import javax.xml.transform.Source;
 
@@ -71,7 +72,11 @@ abstract class AxiomSoapBody extends AxiomSoapElement implements SoapBody {
 	public void setStreamingPayload(StreamingPayload payload) {
 		Assert.notNull(payload, "'payload' must not be null");
 		OMDataSource dataSource = new StreamingOMDataSource(payload);
-		OMElement payloadElement = getAxiomFactory().createOMElement(dataSource, payload.getName());
+		SOAPFactory factory = getAxiomFactory();
+		QName name = payload.getName();
+		// Ignore the prefix; only the namespace URI and local name are significant
+		OMElement payloadElement = factory.createOMElement(dataSource, name.getLocalPart(),
+				factory.createOMNamespace(name.getNamespaceURI(), null));
 
 		SOAPBody soapBody = getAxiomBody();
 		AxiomUtils.removeContents(soapBody);

--- a/spring-ws-core/src/main/java/org/springframework/ws/stream/StreamingPayload.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/stream/StreamingPayload.java
@@ -30,7 +30,9 @@ import javax.xml.stream.XMLStreamWriter;
 public interface StreamingPayload {
 
 	/**
-	 * Returns the qualified name of the payload.
+	 * Returns the qualified name of the payload. Only the namespace URI and local part of the
+	 * returned qualified name are significant; they must match the name of the root element
+	 * produced by {@link #writeTo(XMLStreamWriter)}.
 	 *
 	 * @return the qualified name
 	 */

--- a/spring-ws-core/src/test/java/org/springframework/ws/soap/AbstractSoapMessageTestCase.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/soap/AbstractSoapMessageTestCase.java
@@ -94,14 +94,15 @@ public abstract class AbstractSoapMessageTestCase extends AbstractMimeMessageTes
 		}
 		StreamingWebServiceMessage streamingMessage = (StreamingWebServiceMessage) soapMessage;
 
-		final QName name = new QName("http://springframework.org", "root", "prefix");
+		final QName name = new QName("http://springframework.org", "root", "");
 		streamingMessage.setStreamingPayload(new StreamingPayload() {
 			public QName getName() {
 				return name;
 			}
 
 			public void writeTo(XMLStreamWriter streamWriter) throws XMLStreamException {
-				streamWriter.writeStartElement(name.getPrefix(), name.getLocalPart(), name.getNamespaceURI());
+				// Use a prefix that is different from the one reported by getName()
+				streamWriter.writeStartElement("prefix", name.getLocalPart(), name.getNamespaceURI());
 				streamWriter.writeNamespace("prefix", name.getNamespaceURI());
 				streamWriter.writeStartElement(name.getNamespaceURI(), "child");
 				streamWriter.writeCharacters("Foo");


### PR DESCRIPTION
The getName() method in JaxbStreamingPayload doesn't report the actual
namespace prefix that is later generated by the writeTo method. With
Axiom 1.2.13 that didn't cause problems, but 1.2.14 is less lenient,
causing an error as described in AXIOM-463.

This change:
* Updates the StreamingPayload documentation to specify that the
namespace prefix in the QName returned by getName() has no significance
(which is effectively how things are currently).
* Updates AxiomSoapBody so that it Axiom is aware that the namespace
prefix of the created OMSourcedElement is unknown.
* Modifies the unit test for setStreamingPayload so that it uses a
StreamingPayload with a prefix mismatch.