### PR TITLE
SWS-921 Use varargs for XSD schemas

### DIFF
--- a/spring-ws-core/src/main/java/org/springframework/ws/client/support/interceptor/AbstractValidatingInterceptor.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/client/support/interceptor/AbstractValidatingInterceptor.java
@@ -87,7 +87,7 @@ public abstract class AbstractValidatingInterceptor extends TransformerObjectSup
 	 * #setSchemas(Resource[]) schemas} is required.
 	 */
 	public void setSchema(Resource schema) {
-		setSchemas(new Resource[]{schema});
+		setSchemas(schema);
 	}
 
 	/**
@@ -95,7 +95,7 @@ public abstract class AbstractValidatingInterceptor extends TransformerObjectSup
 	 * #setXsdSchemaCollection(XsdSchemaCollection) xsdSchemaCollection}, {@link #setSchema(Resource) schema}, or {@link
 	 * #setSchemas(Resource[]) schemas} is required.
 	 */
-	public void setSchemas(Resource[] schemas) {
+	public void setSchemas(Resource... schemas) {
 		Assert.notEmpty(schemas, "schemas must not be empty or null");
 		for (Resource schema : schemas) {
 			Assert.notNull(schema, "schema must not be null");

--- a/spring-ws-core/src/main/java/org/springframework/ws/server/endpoint/interceptor/AbstractValidatingInterceptor.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/server/endpoint/interceptor/AbstractValidatingInterceptor.java
@@ -93,7 +93,7 @@ public abstract class AbstractValidatingInterceptor extends TransformerObjectSup
 	 * #setSchemas(Resource[]) schemas} is required.
 	 */
 	public void setSchema(Resource schema) {
-		setSchemas(new Resource[]{schema});
+		setSchemas(schema);
 	}
 
 	/**
@@ -101,7 +101,7 @@ public abstract class AbstractValidatingInterceptor extends TransformerObjectSup
 	 * #setXsdSchemaCollection(XsdSchemaCollection) xsdSchemaCollection}, {@link #setSchema(Resource) schema}, or {@link
 	 * #setSchemas(Resource[]) schemas} is required.
 	 */
-	public void setSchemas(Resource[] schemas) {
+	public void setSchemas(Resource... schemas) {
 		Assert.notEmpty(schemas, "schemas must not be empty or null");
 		for (Resource schema : schemas) {
 			Assert.notNull(schema, "schema must not be null");

--- a/spring-ws-core/src/test/java/org/springframework/ws/client/support/interceptor/PayloadValidatingInterceptorTest.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/client/support/interceptor/PayloadValidatingInterceptorTest.java
@@ -30,7 +30,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import org.springframework.core.io.ClassPathResource;
-import org.springframework.core.io.Resource;
 import org.springframework.ws.MockWebServiceMessage;
 import org.springframework.ws.MockWebServiceMessageFactory;
 import org.springframework.ws.client.WebServiceClientException;
@@ -188,8 +187,8 @@ public class PayloadValidatingInterceptorTest {
 
 	@Test
 	public void testHandlerInvalidRequestMultipleSchemas() throws Exception {
-		interceptor.setSchemas(new Resource[]{new ClassPathResource(PRODUCT_SCHEMA, getClass()),
-				new ClassPathResource(SIZE_SCHEMA, getClass())});
+		interceptor.setSchemas(new ClassPathResource(PRODUCT_SCHEMA, getClass()),
+				new ClassPathResource(SIZE_SCHEMA, getClass()));
 		interceptor.afterPropertiesSet();
 		MockWebServiceMessage request = new MockWebServiceMessage(new ClassPathResource(INVALID_MESSAGE, getClass()));
 		context = new DefaultMessageContext(request, new MockWebServiceMessageFactory());
@@ -207,8 +206,8 @@ public class PayloadValidatingInterceptorTest {
 
 	@Test
 	public void testHandleValidRequestMultipleSchemas() throws Exception {
-		interceptor.setSchemas(new Resource[]{new ClassPathResource(PRODUCT_SCHEMA, getClass()),
-				new ClassPathResource(SIZE_SCHEMA, getClass())});
+		interceptor.setSchemas(new ClassPathResource(PRODUCT_SCHEMA, getClass()),
+				new ClassPathResource(SIZE_SCHEMA, getClass()));
 		interceptor.afterPropertiesSet();
 		MockWebServiceMessage request = new MockWebServiceMessage(new ClassPathResource(VALID_MESSAGE, getClass()));
 		context = new DefaultMessageContext(request, new MockWebServiceMessageFactory());
@@ -220,8 +219,8 @@ public class PayloadValidatingInterceptorTest {
 
 	@Test
 	public void testHandleInvalidResponseMultipleSchemas() throws Exception {
-		interceptor.setSchemas(new Resource[]{new ClassPathResource(PRODUCT_SCHEMA, getClass()),
-				new ClassPathResource(SIZE_SCHEMA, getClass())});
+		interceptor.setSchemas(new ClassPathResource(PRODUCT_SCHEMA, getClass()),
+				new ClassPathResource(SIZE_SCHEMA, getClass()));
 		interceptor.afterPropertiesSet();
 		MockWebServiceMessage request = new MockWebServiceMessage();
 		context = new DefaultMessageContext(request, new MockWebServiceMessageFactory());
@@ -233,8 +232,8 @@ public class PayloadValidatingInterceptorTest {
 
 	@Test
 	public void testHandleValidResponseMultipleSchemas() throws Exception {
-		interceptor.setSchemas(new Resource[]{new ClassPathResource(PRODUCT_SCHEMA, getClass()),
-				new ClassPathResource(SIZE_SCHEMA, getClass())});
+		interceptor.setSchemas(new ClassPathResource(PRODUCT_SCHEMA, getClass()),
+				new ClassPathResource(SIZE_SCHEMA, getClass()));
 		interceptor.afterPropertiesSet();
 		MockWebServiceMessage request = new MockWebServiceMessage();
 		context = new DefaultMessageContext(request, new MockWebServiceMessageFactory());

--- a/spring-ws-core/src/test/java/org/springframework/ws/soap/server/endpoint/interceptor/PayloadValidatingInterceptorTest.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/soap/server/endpoint/interceptor/PayloadValidatingInterceptorTest.java
@@ -242,8 +242,8 @@ public class PayloadValidatingInterceptorTest {
 
 	@Test
 	public void testHandlerInvalidRequestMultipleSchemas() throws Exception {
-		interceptor.setSchemas(new Resource[]{new ClassPathResource(PRODUCT_SCHEMA, getClass()),
-				new ClassPathResource(SIZE_SCHEMA, getClass())});
+		interceptor.setSchemas(new ClassPathResource(PRODUCT_SCHEMA, getClass()),
+				new ClassPathResource(SIZE_SCHEMA, getClass()));
 		interceptor.afterPropertiesSet();
 		MockWebServiceMessage request = new MockWebServiceMessage(new ClassPathResource(INVALID_MESSAGE, getClass()));
 		context = new DefaultMessageContext(request, new MockWebServiceMessageFactory());
@@ -253,8 +253,8 @@ public class PayloadValidatingInterceptorTest {
 
 	@Test
 	public void testHandleValidRequestMultipleSchemas() throws Exception {
-		interceptor.setSchemas(new Resource[]{new ClassPathResource(PRODUCT_SCHEMA, getClass()),
-				new ClassPathResource(SIZE_SCHEMA, getClass())});
+		interceptor.setSchemas(new ClassPathResource(PRODUCT_SCHEMA, getClass()),
+				new ClassPathResource(SIZE_SCHEMA, getClass()));
 		interceptor.afterPropertiesSet();
 		MockWebServiceMessage request = new MockWebServiceMessage(new ClassPathResource(VALID_MESSAGE, getClass()));
 		context = new DefaultMessageContext(request, new MockWebServiceMessageFactory());
@@ -266,8 +266,8 @@ public class PayloadValidatingInterceptorTest {
 
 	@Test
 	public void testHandleInvalidResponseMultipleSchemas() throws Exception {
-		interceptor.setSchemas(new Resource[]{new ClassPathResource(PRODUCT_SCHEMA, getClass()),
-				new ClassPathResource(SIZE_SCHEMA, getClass())});
+		interceptor.setSchemas(new ClassPathResource(PRODUCT_SCHEMA, getClass()),
+				new ClassPathResource(SIZE_SCHEMA, getClass()));
 		interceptor.afterPropertiesSet();
 		MockWebServiceMessage request = new MockWebServiceMessage();
 		context = new DefaultMessageContext(request, new MockWebServiceMessageFactory());
@@ -279,8 +279,8 @@ public class PayloadValidatingInterceptorTest {
 
 	@Test
 	public void testHandleValidResponseMultipleSchemas() throws Exception {
-		interceptor.setSchemas(new Resource[]{new ClassPathResource(PRODUCT_SCHEMA, getClass()),
-				new ClassPathResource(SIZE_SCHEMA, getClass())});
+		interceptor.setSchemas(new ClassPathResource(PRODUCT_SCHEMA, getClass()),
+				new ClassPathResource(SIZE_SCHEMA, getClass()));
 		interceptor.afterPropertiesSet();
 		MockWebServiceMessage request = new MockWebServiceMessage();
 		context = new DefaultMessageContext(request, new MockWebServiceMessageFactory());

--- a/spring-ws-core/src/test/java/org/springframework/ws/wsdl/wsdl11/DefaultWsdl11DefinitionTest.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/wsdl/wsdl11/DefaultWsdl11DefinitionTest.java
@@ -79,7 +79,7 @@ public class DefaultWsdl11DefinitionTest {
 	@Test
 	public void testInclude() throws Exception {
 		ClassPathResource resource = new ClassPathResource("including.xsd", getClass());
-		CommonsXsdSchemaCollection schemaCollection = new CommonsXsdSchemaCollection(new Resource[]{resource});
+		CommonsXsdSchemaCollection schemaCollection = new CommonsXsdSchemaCollection(resource);
 		schemaCollection.setInline(true);
 		schemaCollection.afterPropertiesSet();
 		definition.setSchemaCollection(schemaCollection);
@@ -100,7 +100,7 @@ public class DefaultWsdl11DefinitionTest {
 	@Test
 	public void testImport() throws Exception {
 		ClassPathResource resource = new ClassPathResource("importing.xsd", getClass());
-		CommonsXsdSchemaCollection schemaCollection = new CommonsXsdSchemaCollection(new Resource[]{resource});
+		CommonsXsdSchemaCollection schemaCollection = new CommonsXsdSchemaCollection(resource);
 		schemaCollection.setInline(true);
 		schemaCollection.afterPropertiesSet();
 		definition.setSchemaCollection(schemaCollection);

--- a/spring-ws-core/src/test/java/org/springframework/ws/wsdl/wsdl11/provider/InliningXsdSchemaTypesProviderTest.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/wsdl/wsdl11/provider/InliningXsdSchemaTypesProviderTest.java
@@ -76,7 +76,7 @@ public class InliningXsdSchemaTypesProviderTest {
 		definition.addNamespace("schema", schemaNamespace);
 
 		Resource resource = new ClassPathResource("A.xsd", getClass());
-		CommonsXsdSchemaCollection collection = new CommonsXsdSchemaCollection(new Resource[]{resource});
+		CommonsXsdSchemaCollection collection = new CommonsXsdSchemaCollection(resource);
 		collection.setInline(true);
 		collection.afterPropertiesSet();
 

--- a/spring-xml/src/main/java/org/springframework/xml/xsd/commons/CommonsXsdSchemaCollection.java
+++ b/spring-xml/src/main/java/org/springframework/xml/xsd/commons/CommonsXsdSchemaCollection.java
@@ -87,7 +87,7 @@ public class CommonsXsdSchemaCollection implements XsdSchemaCollection, Initiali
 	 *
 	 * @param resources the schema resources to load
 	 */
-	public CommonsXsdSchemaCollection(Resource[] resources) {
+	public CommonsXsdSchemaCollection(Resource... resources) {
 		this.xsdResources = resources;
 	}
 
@@ -96,7 +96,7 @@ public class CommonsXsdSchemaCollection implements XsdSchemaCollection, Initiali
 	 *
 	 * @param xsdResources the schema resources to be loaded
 	 */
-	public void setXsds(Resource[] xsdResources) {
+	public void setXsds(Resource... xsdResources) {
 		this.xsdResources = xsdResources;
 	}
 

--- a/spring-xml/src/test/java/org/springframework/xml/xsd/commons/CommonsXsdSchemaCollectionTest.java
+++ b/spring-xml/src/test/java/org/springframework/xml/xsd/commons/CommonsXsdSchemaCollectionTest.java
@@ -59,7 +59,7 @@ public class CommonsXsdSchemaCollectionTest {
 	@Test
 	public void testSingle() throws Exception {
 		Resource resource = new ClassPathResource("single.xsd", AbstractXsdSchemaTestCase.class);
-		collection.setXsds(new Resource[]{resource});
+		collection.setXsds(resource);
 		collection.afterPropertiesSet();
 		Assert.assertEquals("Invalid amount of XSDs loaded", 1, collection.getXsdSchemas().length);
 	}
@@ -67,7 +67,7 @@ public class CommonsXsdSchemaCollectionTest {
 	@Test
 	public void testInlineComplex() throws Exception {
 		Resource a = new ClassPathResource("A.xsd", AbstractXsdSchemaTestCase.class);
-		collection.setXsds(new Resource[]{a});
+		collection.setXsds(a);
 		collection.setInline(true);
 		collection.afterPropertiesSet();
 		XsdSchema[] schemas = collection.getXsdSchemas();
@@ -91,7 +91,7 @@ public class CommonsXsdSchemaCollectionTest {
 	@Test
 	public void testCircular() throws Exception {
 		Resource resource = new ClassPathResource("circular-1.xsd", AbstractXsdSchemaTestCase.class);
-		collection.setXsds(new Resource[]{resource});
+		collection.setXsds(resource);
 		collection.setInline(true);
 		collection.afterPropertiesSet();
 		XsdSchema[] schemas = collection.getXsdSchemas();
@@ -101,7 +101,7 @@ public class CommonsXsdSchemaCollectionTest {
 	@Test
 	public void testXmlNamespace() throws Exception {
 		Resource resource = new ClassPathResource("xmlNamespace.xsd", AbstractXsdSchemaTestCase.class);
-		collection.setXsds(new Resource[]{resource});
+		collection.setXsds(resource);
 		collection.setInline(true);
 		collection.afterPropertiesSet();
 		XsdSchema[] schemas = collection.getXsdSchemas();
@@ -111,7 +111,7 @@ public class CommonsXsdSchemaCollectionTest {
 	@Test
 	public void testCreateValidator() throws Exception {
 		Resource a = new ClassPathResource("A.xsd", AbstractXsdSchemaTestCase.class);
-		collection.setXsds(new Resource[]{a});
+		collection.setXsds(a);
 		collection.setInline(true);
 		collection.afterPropertiesSet();
 
@@ -122,7 +122,7 @@ public class CommonsXsdSchemaCollectionTest {
 	@Test
 	public void testInvalidSchema() throws Exception {
 		Resource invalid = new ClassPathResource("invalid.xsd", AbstractXsdSchemaTestCase.class);
-		collection.setXsds(new Resource[]{invalid});
+		collection.setXsds(invalid);
 		try {
 			collection.afterPropertiesSet();
 			Assert.fail("CommonsXsdSchemaException expected");
@@ -135,7 +135,7 @@ public class CommonsXsdSchemaCollectionTest {
 	@Test
 	public void testIncludesAndImports() throws Exception {
 		Resource hr = new ClassPathResource("hr.xsd", getClass());
-		collection.setXsds(new Resource[]{hr});
+		collection.setXsds(hr);
 		collection.setInline(true);
 		collection.afterPropertiesSet();
 


### PR DESCRIPTION
XML schema validation accepting multiple schemas currently uses arrays
of Resource objects. They would be a bit easier and more succinct to
use if the setters were switched to varargs. Such a change would be
backwards compatible.

This change includes:

 * change AbstractValidatingInterceptor#setSchemas to use varargs
 * change the CommonsXsdSchemaCollection constructor to use varargs
 * change CommonsXsdSchemaCollection.setXsds to use varargs
 * update the tests to use varargs

Issue: SWS-921
https://jira.spring.io/browse/SWS-921