### PR TITLE
Update tests to be compatible with latest version of Http Components

### DIFF
--- a/spring-ws-core/src/test/java/org/springframework/ws/transport/http/HttpComponentsMessageSenderIntegrationTest.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/transport/http/HttpComponentsMessageSenderIntegrationTest.java
@@ -18,6 +18,7 @@ package org.springframework.ws.transport.http;
 
 import static org.hamcrest.core.IsEqual.*;
 import static org.springframework.test.util.MatcherAssertionErrors.*;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.net.URI;
@@ -61,7 +62,7 @@ public class HttpComponentsMessageSenderIntegrationTest extends AbstractHttpWebS
 		HttpRoute route1 = new HttpRoute(host1, null, true);
 		assertThat(route1.isSecure(), equalTo(true));
 		assertThat(route1.getTargetHost().getHostName(), equalTo("www.example.com"));
-		assertThat(route1.getTargetHost().getPort(), equalTo(-1));
+		assertTrue((route1.getTargetHost().getPort() == -1) || (route1.getTargetHost().getPort() == 443));
 
 		final String url2 = "http://www.example.com:8080";
 		URI uri2 = new URI(url2);
@@ -77,7 +78,7 @@ public class HttpComponentsMessageSenderIntegrationTest extends AbstractHttpWebS
 		HttpRoute route3 = new HttpRoute(host3);
 		assertThat(route3.isSecure(), equalTo(false));
 		assertThat(route3.getTargetHost().getHostName(), equalTo("www.springframework.org"));
-		assertThat(route3.getTargetHost().getPort(), equalTo(-1));
+		assertTrue((route3.getTargetHost().getPort() ==  -1) || (route3.getTargetHost().getPort() == 80));
 
 		HttpComponentsMessageSender messageSender = new HttpComponentsMessageSender();
 		messageSender.setMaxTotalConnections(2);


### PR DESCRIPTION
More recent versions of HTTP components normalise an HTTPHost when it’s
used to create an HTTPRoute. As part of this normalization the host’s
port is set to the default port for the host’s scheme, i.e. an https
scheme will result in a port of 443.

This commit updates the tests so that they will accept the behaviour
of HTTP Components 4.3.x (the port is -1) and HTTP Components 4.5.x
(the port is 443). The latter allows Spring Web Services’ tests to pass
when they’re run as part of the Spring IO Platform 2.0 release process
which uses a more recent version of HTTP components than the default
Spring Web Services build.