### PR TITLE
Update Spring Security version to 3.2.9.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ configure(allprojects) {
 	group = "org.springframework.ws"
 
 	ext.springVersion = "4.0.9.RELEASE"
-	ext.springSecurityVersion = "3.2.7.RELEASE"
+	ext.springSecurityVersion = "3.2.9.RELEASE"
 	ext.axiomVersion = "1.2.14"
 
 	apply plugin: "java"


### PR DESCRIPTION
Accordingly to this CVE(http://pivotal.io/security/cve-2014-3578) Spring Security versions 3.2.0 to 3.2.8 are vulnerable.

And the mitigation are:
Users of 3.x should upgrade to 3.2.9 or later