### PR TITLE
Eliminate references to internal Axiom implementation classes

### DIFF
--- a/spring-ws-core/src/test/java/org/springframework/ws/soap/axiom/AxiomSoap11NonCachingMessageTest.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/soap/axiom/AxiomSoap11NonCachingMessageTest.java
@@ -16,7 +16,7 @@
 
 package org.springframework.ws.soap.axiom;
 
-import org.apache.axiom.om.impl.llom.OMSourcedElementImpl;
+import org.apache.axiom.om.OMSourcedElement;
 
 import org.springframework.ws.soap.SoapBody;
 import org.springframework.ws.soap.SoapMessage;
@@ -46,8 +46,8 @@ public class AxiomSoap11NonCachingMessageTest extends AbstractSoap11MessageTestC
 		super.testWriteToTransportOutputStream();
 
 		SoapBody body = soapMessage.getSoapBody();
-		OMSourcedElementImpl axiomPayloadEle =
-				(OMSourcedElementImpl) ((AxiomSoapBody) body).getAxiomElement().getFirstElement();
+		OMSourcedElement axiomPayloadEle =
+				(OMSourcedElement) ((AxiomSoapBody) body).getAxiomElement().getFirstElement();
 		assertFalse("Non-cached body should not be expanded now", axiomPayloadEle.isExpanded());
 		axiomPayloadEle.getFirstElement();
 		assertTrue("Non-cached body should now be expanded", axiomPayloadEle.isExpanded());

--- a/spring-ws-core/src/test/java/org/springframework/ws/soap/axiom/AxiomSoap12NonCachingMessageTest.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/soap/axiom/AxiomSoap12NonCachingMessageTest.java
@@ -16,7 +16,7 @@
 
 package org.springframework.ws.soap.axiom;
 
-import org.apache.axiom.om.impl.llom.OMSourcedElementImpl;
+import org.apache.axiom.om.OMSourcedElement;
 
 import org.springframework.ws.soap.SoapBody;
 import org.springframework.ws.soap.SoapMessage;
@@ -46,8 +46,8 @@ public class AxiomSoap12NonCachingMessageTest extends AbstractSoap12MessageTestC
 		super.testWriteToTransportOutputStream();
 
 		SoapBody body = soapMessage.getSoapBody();
-		OMSourcedElementImpl axiomPayloadEle =
-				(OMSourcedElementImpl) ((AxiomSoapBody) body).getAxiomElement().getFirstElement();
+		OMSourcedElement axiomPayloadEle =
+				(OMSourcedElement) ((AxiomSoapBody) body).getAxiomElement().getFirstElement();
 		assertFalse("Non-cached body should not be expanded now", axiomPayloadEle.isExpanded());
 		axiomPayloadEle.getFirstElement();
 		assertTrue("Non-cached body should now be expanded", axiomPayloadEle.isExpanded());


### PR DESCRIPTION
Instead use the corresponding public APIs.