### PR TITLE
Fix method name in MockWebServiceClient javadoc

### DIFF
--- a/spring-ws-test/src/main/java/org/springframework/ws/test/server/MockWebServiceClient.java
+++ b/spring-ws-test/src/main/java/org/springframework/ws/test/server/MockWebServiceClient.java
@@ -91,7 +91,7 @@ import org.springframework.ws.transport.WebServiceMessageReceiver;
  *		 "&lt;customerCount&gt;42&lt;/customerCount&gt;" +
  *		 "&lt;/customerCountResponse&gt;");
  *
- *	   <strong>mockClient.sendMessage(withPayload(requestPayload)).andExpect(payload(expectedResponsePayload))</strong>;
+ *	   <strong>mockClient.sendRequest(withPayload(requestPayload)).andExpect(payload(expectedResponsePayload))</strong>;
  *	 }
  * }
  * </pre></blockquote>


### PR DESCRIPTION
There's no sendMessage method, this fixes the javadoc.
I have signed the ICLA.