### PR TITLE
Fix https://jira.spring.io/browse/SWS-944

### DIFF
--- a/spring-ws-core/src/main/java/org/springframework/ws/soap/addressing/server/AddressingEndpointInterceptor.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/soap/addressing/server/AddressingEndpointInterceptor.java
@@ -75,7 +75,7 @@ class AddressingEndpointInterceptor implements SoapEndpointInterceptor {
 		Assert.isInstanceOf(SoapMessage.class, messageContext.getRequest());
 		SoapMessage request = (SoapMessage) messageContext.getRequest();
 		MessageAddressingProperties requestMap = version.getMessageAddressingProperties(request);
-		if (!version.hasRequiredProperties(requestMap)) {
+		if (!version.hasRequiredProperties(requestMap, endpoint)) {
 			version.addMessageAddressingHeaderRequiredFault((SoapMessage) messageContext.getResponse());
 			return false;
 		}

--- a/spring-ws-core/src/main/java/org/springframework/ws/soap/addressing/server/annotation/OptionalMessageId.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/soap/addressing/server/annotation/OptionalMessageId.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2008 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ws.soap.addressing.server.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * If this annotation is applied, the
+ * {@link org.springframework.ws.soap.addressing.core.MessageAddressingProperties#getMessageId()}
+ * is marked as optional and is not checked in
+ * {@link org.springframework.ws.soap.addressing.version.AddressingVersion#hasRequiredProperties(org.springframework.ws.soap.addressing.core.MessageAddressingProperties, Object)
+ * hasRequiredProperties}
+ * 
+ * This annotation only MUST be applied if the endpoint method don't send any
+ * response or throws any exception.
+ *
+ * @author David Goicocheta
+ */
+
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface OptionalMessageId {
+
+}

--- a/spring-ws-core/src/main/java/org/springframework/ws/soap/addressing/version/AbstractAddressingVersion.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/soap/addressing/version/AbstractAddressingVersion.java
@@ -38,6 +38,7 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 
 import org.springframework.util.StringUtils;
+import org.springframework.ws.server.endpoint.MethodEndpoint;
 import org.springframework.ws.soap.SoapFault;
 import org.springframework.ws.soap.SoapHeader;
 import org.springframework.ws.soap.SoapHeaderElement;
@@ -45,6 +46,7 @@ import org.springframework.ws.soap.SoapMessage;
 import org.springframework.ws.soap.addressing.AddressingException;
 import org.springframework.ws.soap.addressing.core.EndpointReference;
 import org.springframework.ws.soap.addressing.core.MessageAddressingProperties;
+import org.springframework.ws.soap.addressing.server.annotation.OptionalMessageId;
 import org.springframework.ws.soap.soap11.Soap11Body;
 import org.springframework.ws.soap.soap12.Soap12Body;
 import org.springframework.ws.soap.soap12.Soap12Fault;
@@ -140,6 +142,23 @@ public abstract class AbstractAddressingVersion extends TransformerObjectSupport
 		URI action = getUri(headerElement, actionExpression);
 		URI messageId = getUri(headerElement, messageIdExpression);
 		return new MessageAddressingProperties(to, from, replyTo, faultTo, action, messageId);
+	}
+
+	protected boolean isMessageIdRequired(MessageAddressingProperties map, Object endpoint) {
+		if (endpoint != null && endpoint instanceof MethodEndpoint) {
+			MethodEndpoint methodEndpoint = (MethodEndpoint) endpoint;
+			OptionalMessageId optionalMessageId = methodEndpoint.getMethod().getAnnotation(OptionalMessageId.class);
+			if (optionalMessageId != null) {
+				return false;
+			}
+		}
+		if (hasNoneAddress(map.getReplyTo()) && hasNoneAddress(map.getFaultTo())) {
+			return false;
+		}
+		if (map.getReplyTo() == null && map.getFaultTo() == null) {
+			return false;
+		}
+		return true;
 	}
 
 	private URI getUri(Node node, XPathExpression expression) {

--- a/spring-ws-core/src/main/java/org/springframework/ws/soap/addressing/version/Addressing10.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/soap/addressing/version/Addressing10.java
@@ -44,15 +44,14 @@ public class Addressing10 extends AbstractAddressingVersion {
 	}
 
 	@Override
-	public boolean hasRequiredProperties(MessageAddressingProperties map) {
+	public boolean hasRequiredProperties(MessageAddressingProperties map, Object endpoint){
 		if (map.getAction() == null) {
 			return false;
 		}
-		if (map.getReplyTo() != null || map.getFaultTo() != null) {
+		if (isMessageIdRequired(map, endpoint)) {
 			return map.getMessageId() != null;
 		}
 		return true;
-
 	}
 
 	@Override

--- a/spring-ws-core/src/main/java/org/springframework/ws/soap/addressing/version/Addressing200408.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/soap/addressing/version/Addressing200408.java
@@ -45,14 +45,14 @@ public class Addressing200408 extends AbstractAddressingVersion {
 	}
 
 	@Override
-	public boolean hasRequiredProperties(MessageAddressingProperties map) {
+	public boolean hasRequiredProperties(MessageAddressingProperties map, Object endpoint){
 		if (map.getTo() == null) {
 			return false;
 		}
 		if (map.getAction() == null) {
 			return false;
 		}
-		if (map.getReplyTo() != null || map.getFaultTo() != null) {
+		if (isMessageIdRequired(map, endpoint)) {
 			return map.getMessageId() != null;
 		}
 		return true;

--- a/spring-ws-core/src/main/java/org/springframework/ws/soap/addressing/version/AddressingVersion.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/soap/addressing/version/AddressingVersion.java
@@ -57,12 +57,16 @@ public interface AddressingVersion {
 	boolean understands(SoapHeaderElement headerElement);
 
 	/**
-	 * Indicates whether the given {@link MessageAddressingProperties} has all required properties.
+	 * Indicates whether the given {@link MessageAddressingProperties} has all
+	 * required properties.
 	 *
-	 * @return {@code true} if the to and action properties have been set, and - if a reply or fault endpoint has
-	 *		   been set - also checks for the message id
+	 * @return {@code true} if the to and action properties have been set, if a
+	 *         reply or fault endpoint has been set and endpoint is not marked
+	 *         with
+	 *         {@link org.springframework.ws.soap.addressing.server.annotation.OptionalMessageId}
+	 *         also checks for the message id
 	 */
-	boolean hasRequiredProperties(MessageAddressingProperties map);
+	boolean hasRequiredProperties(MessageAddressingProperties map, Object endpoint);
 
 	/*
 	* Address URIs


### PR DESCRIPTION
MessageID is mandatory if reply is expected, It is impossible to know
whether an endpoint will return a value or throw an exception

OptionalMessageId, marks the endpoint method as "no return" method, and
make MessageId Optional.
