### PR TITLE
SWS-951 - Introduce ClientInterceptorAdapter

### DIFF
--- a/spring-ws-core/src/main/java/org/springframework/ws/client/support/interceptor/ClientInterceptorAdapter.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/client/support/interceptor/ClientInterceptorAdapter.java
@@ -1,0 +1,43 @@
+package org.springframework.ws.client.support.interceptor;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.ws.client.WebServiceClientException;
+import org.springframework.ws.context.MessageContext;
+
+/**
+ *
+ * Default implementation of the {@code ClientInterceptor} interface, for simplified implementation of
+ * pre-only/post-only interceptors.
+ *
+ * @author Marten Deinum
+ * @since 2.2.5
+ */
+public abstract class ClientInterceptorAdapter implements ClientInterceptor {
+
+    /** Logger available to subclasses */
+    protected final Log logger = LogFactory.getLog(getClass());
+
+    @Override
+    public boolean handleRequest(MessageContext messageContext) throws WebServiceClientException {
+        return true;
+    }
+
+    @Override
+    public boolean handleResponse(MessageContext messageContext) throws WebServiceClientException {
+        return true;
+    }
+
+    @Override
+    public boolean handleFault(MessageContext messageContext) throws WebServiceClientException {
+        return true;
+    }
+
+    /**
+     * Does nothing by default.
+     */
+    @Override
+    public void afterCompletion(MessageContext messageContext, Exception ex) throws WebServiceClientException {
+
+    }
+}


### PR DESCRIPTION
This commit introduces a ClientInterceptorAdapter with a default implementation
of the methods and providing a protected Log instance for subclasses. This convenience
class allows for pre-/post only ClientInterceptor instances without having to
add empty methods to it.

Solves: [SWS-951](https://jira.spring.io/browse/SWS-951)