### PR TITLE
Make logging more extensible

### DIFF
--- a/spring-ws-core/src/main/java/org/springframework/ws/server/endpoint/AbstractLoggingInterceptor.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/server/endpoint/AbstractLoggingInterceptor.java
@@ -85,7 +85,7 @@ public abstract class AbstractLoggingInterceptor extends TransformerObjectSuppor
 	 * @throws TransformerException when the payload cannot be transformed to a string
 	 */
 	@Override
-	public final boolean handleRequest(MessageContext messageContext, Object endpoint) throws TransformerException {
+	public boolean handleRequest(MessageContext messageContext, Object endpoint) throws TransformerException {
 		if (logRequest && isLogEnabled()) {
 			logMessageSource("Request: ", getSource(messageContext.getRequest()));
 		}

--- a/spring-ws-core/src/main/java/org/springframework/ws/soap/server/endpoint/interceptor/SoapEnvelopeLoggingInterceptor.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/soap/server/endpoint/interceptor/SoapEnvelopeLoggingInterceptor.java
@@ -47,7 +47,7 @@ public class SoapEnvelopeLoggingInterceptor extends AbstractLoggingInterceptor i
 
 	@Override
 	public boolean handleFault(MessageContext messageContext, Object endpoint) throws Exception {
-		if (logFault && logger.isDebugEnabled()) {
+		if (logFault && isLogEnabled()) {
 			logMessageSource("Fault: ", getSource(messageContext.getResponse()));
 		}
 		return true;


### PR DESCRIPTION
It would be helpful to be able to override AbstractLoggingInterceptor.handleRequest(..), e.g. to put MDC values.

This seems related to SWS-400
