### PR TITLE
Consider @RequestBody annotation in XmlRootElement mapping.

### DIFF
--- a/spring-ws-core/src/main/java/org/springframework/ws/server/endpoint/mapping/jaxb/XmlRootElementEndpointMapping.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/server/endpoint/mapping/jaxb/XmlRootElementEndpointMapping.java
@@ -65,6 +65,16 @@ public class XmlRootElementEndpointMapping extends AbstractAnnotationMethodEndpo
 		this.transformerHelper = transformerHelper;
 	}
 
+	/**
+	 * Set whether to only consider {@link RequestBody} annotated parameters.
+	 *
+	 * <p>Default is "false": All methods that take an {@link XmlRootElement} annotated
+	 * type as parameter will be resolved as valid endpoint.
+	 *
+	 * <p>Switch this flag on to require the {@link XmlRootElement} parameter to be annotated with
+	 * {@link RequestBody} to prevent duplicate endpoint registrations when having additional methods
+	 * that receive the {@link XmlRootElement} parameter.
+	 */
 	public void setRequiresRequestBodyAnnotation(boolean requiresRequestBodyAnnotation) {
 		this.requiresRequestBodyAnnotation = requiresRequestBodyAnnotation;
 	}

--- a/spring-ws-core/src/test/java/org/springframework/ws/server/endpoint/mapping/jaxb/XmlRootElementEndpointMappingTest.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/server/endpoint/mapping/jaxb/XmlRootElementEndpointMappingTest.java
@@ -20,10 +20,13 @@ import java.lang.reflect.Method;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.namespace.QName;
 
+import org.springframework.web.bind.annotation.RequestBody;
+
 import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class XmlRootElementEndpointMappingTest {
 
@@ -41,7 +44,28 @@ public class XmlRootElementEndpointMappingTest {
 		assertEquals(new QName("myNamespace", "myRoot"), name);
 	}
 
+	@Test
+	public void testRequiredRequestBodyAnnotationMissing() throws NoSuchMethodException {
+		mapping.setRequiresRequestBodyAnnotation(true);
+
+		Method rootElement = getClass().getMethod("rootElement", MyRootElement.class);
+		QName name = mapping.getLookupKeyForMethod(rootElement);
+		assertNull(name);
+	}
+
+	@Test
+	public void testRequiredRequestBodyAnnotationPresent() throws NoSuchMethodException {
+		mapping.setRequiresRequestBodyAnnotation(true);
+
+		Method rootElement = getClass().getMethod("requestBodyRootElement", MyRootElement.class);
+		QName name = mapping.getLookupKeyForMethod(rootElement);
+		assertEquals(new QName("myNamespace", "myRoot"), name);
+	}
+
 	public void rootElement(MyRootElement rootElement) {
+	}
+
+	public void requestBodyRootElement(@RequestBody MyRootElement rootElement) {
 	}
 
 	@XmlRootElement(name = "myRoot", namespace = "myNamespace")


### PR DESCRIPTION
It is now possible to have additional (private) methods that take the
@XmlRootElement annotated Request parameter, which currently would
result in a duplicate endpoint registration exception.

Upon including `XmlRootElementEndpointMapping` as a bean I got a duplicate endpoint exception as I was using a method with the same type signature as the intended endpoint. The difference between the methods was that the intended endpoint was annotated with `@RequestBody` (and private) and I would therefore like to take this annotation into consideration when determining endpoints from `XmlRootElement` annotated method parameter types.

I went with opt-in behaviour given that this would otherwise be a breaking change.
