### PR TITLE
Eliminate some usages of deprecated Axiom APIs

### DIFF
--- a/spring-ws-core/src/main/java/org/springframework/ws/soap/axiom/AxiomSoapMessageFactory.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/soap/axiom/AxiomSoapMessageFactory.java
@@ -35,6 +35,7 @@ import org.apache.axiom.soap.SOAP12Constants;
 import org.apache.axiom.soap.SOAP12Version;
 import org.apache.axiom.soap.SOAPFactory;
 import org.apache.axiom.soap.SOAPMessage;
+import org.apache.axiom.soap.SOAPModelBuilder;
 import org.apache.axiom.soap.impl.builder.MTOMStAXSOAPModelBuilder;
 import org.apache.axiom.soap.impl.builder.StAXSOAPModelBuilder;
 import org.apache.commons.logging.Log;
@@ -271,8 +272,8 @@ public class AxiomSoapMessageFactory implements SoapMessageFactory, Initializing
 			throws XMLStreamException {
 		XMLStreamReader reader = inputFactory.createXMLStreamReader(inputStream, getCharSetEncoding(contentType));
 		String envelopeNamespace = getSoapEnvelopeNamespace(contentType);
-		StAXSOAPModelBuilder builder = new StAXSOAPModelBuilder(reader, soapFactory, envelopeNamespace);
-		SOAPMessage soapMessage = builder.getSoapMessage();
+		SOAPModelBuilder builder = new StAXSOAPModelBuilder(reader, soapFactory, envelopeNamespace);
+		SOAPMessage soapMessage = builder.getSOAPMessage();
 		return new AxiomSoapMessage(soapMessage, soapAction, payloadCaching, langAttributeOnSoap11FaultString);
 	}
 
@@ -286,7 +287,7 @@ public class AxiomSoapMessageFactory implements SoapMessageFactory, Initializing
 						Integer.toString(attachmentCacheThreshold));
 		XMLStreamReader reader = inputFactory.createXMLStreamReader(attachments.getRootPartInputStream(),
 				getCharSetEncoding(attachments.getRootPartContentType()));
-		StAXSOAPModelBuilder builder;
+		SOAPModelBuilder builder;
 		String envelopeNamespace = getSoapEnvelopeNamespace(contentType);
 		if (MTOMConstants.SWA_TYPE.equals(attachments.getAttachmentSpecType()) ||
 				MTOMConstants.SWA_TYPE_12.equals(attachments.getAttachmentSpecType())) {
@@ -299,7 +300,7 @@ public class AxiomSoapMessageFactory implements SoapMessageFactory, Initializing
 			throw new AxiomSoapMessageCreationException(
 					"Unknown attachment type: [" + attachments.getAttachmentSpecType() + "]");
 		}
-		return new AxiomSoapMessage(builder.getSoapMessage(), attachments, soapAction, payloadCaching,
+		return new AxiomSoapMessage(builder.getSOAPMessage(), attachments, soapAction, payloadCaching,
 				langAttributeOnSoap11FaultString);
 	}
 

--- a/spring-ws-core/src/test/java/org/springframework/ws/soap/axiom/AxiomSoapFaultDetailTest.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/soap/axiom/AxiomSoapFaultDetailTest.java
@@ -17,14 +17,12 @@
 package org.springframework.ws.soap.axiom;
 
 import java.io.StringReader;
-import javax.xml.stream.XMLInputFactory;
-import javax.xml.stream.XMLStreamReader;
 
 import org.springframework.ws.soap.SoapFault;
 import org.springframework.ws.soap.SoapFaultDetail;
-
+import org.apache.axiom.om.OMXMLBuilderFactory;
 import org.apache.axiom.soap.SOAPMessage;
-import org.apache.axiom.soap.impl.builder.StAXSOAPModelBuilder;
+import org.apache.axiom.soap.SOAPModelBuilder;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -58,15 +56,13 @@ public class AxiomSoapFaultDetailTest {
 
 	@Before
 	public void setUp() throws Exception {
-		XMLStreamReader parser = XMLInputFactory.newInstance().createXMLStreamReader(new StringReader(FAILING_FAULT));
-		StAXSOAPModelBuilder builder = new StAXSOAPModelBuilder(parser);
-		SOAPMessage soapMessage = builder.getSoapMessage();
+		SOAPModelBuilder builder = OMXMLBuilderFactory.createSOAPModelBuilder(new StringReader(FAILING_FAULT));
+		SOAPMessage soapMessage = builder.getSOAPMessage();
 
 		failingMessage = new AxiomSoapMessage(soapMessage, null, false, true);
 
-		parser = XMLInputFactory.newInstance().createXMLStreamReader(new StringReader(SUCCEEDING_FAULT));
-		builder = new StAXSOAPModelBuilder(parser);
-		soapMessage = builder.getSoapMessage();
+		builder = OMXMLBuilderFactory.createSOAPModelBuilder(new StringReader(SUCCEEDING_FAULT));
+		soapMessage = builder.getSOAPMessage();
 
 		succeedingMessage = new AxiomSoapMessage(soapMessage, null, false, true);
 

--- a/spring-ws-core/src/test/java/org/springframework/ws/soap/axiom/support/AxiomUtilsTest.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/soap/axiom/support/AxiomUtilsTest.java
@@ -21,8 +21,6 @@ import java.util.Locale;
 import javax.xml.namespace.QName;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.stream.XMLInputFactory;
-import javax.xml.stream.XMLStreamReader;
 
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
@@ -33,10 +31,10 @@ import org.apache.axiom.om.OMAbstractFactory;
 import org.apache.axiom.om.OMElement;
 import org.apache.axiom.om.OMFactory;
 import org.apache.axiom.om.OMNamespace;
-import org.apache.axiom.soap.SOAP11Constants;
+import org.apache.axiom.om.OMXMLBuilderFactory;
 import org.apache.axiom.soap.SOAPEnvelope;
 import org.apache.axiom.soap.SOAPMessage;
-import org.apache.axiom.soap.impl.builder.StAXSOAPModelBuilder;
+import org.apache.axiom.soap.SOAPModelBuilder;
 import org.custommonkey.xmlunit.XMLUnit;
 import org.junit.Assert;
 import org.junit.Before;
@@ -114,11 +112,8 @@ public class AxiomUtilsTest {
 		DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
 		Document expected = documentBuilder.parse(SaxUtils.createInputSource(resource));
 
-		XMLInputFactory inputFactory = XMLInputFactory.newInstance();
-		XMLStreamReader reader = inputFactory.createXMLStreamReader(resource.getInputStream());
-		StAXSOAPModelBuilder builder =
-				new StAXSOAPModelBuilder(reader, OMAbstractFactory.getSOAP11Factory(), SOAP11Constants.SOAP_ENVELOPE_NAMESPACE_URI);
-		SOAPMessage soapMessage = builder.getSoapMessage();
+		SOAPModelBuilder builder = OMXMLBuilderFactory.createSOAPModelBuilder(resource.getInputStream(), null);
+		SOAPMessage soapMessage = builder.getSOAPMessage();
 
 		Document result = AxiomUtils.toDocument(soapMessage.getSOAPEnvelope());
 

--- a/spring-ws-security/src/test/java/org/springframework/ws/soap/security/wss4j2/Wss4jTestCase.java
+++ b/spring-ws-security/src/test/java/org/springframework/ws/soap/security/wss4j2/Wss4jTestCase.java
@@ -23,12 +23,10 @@ import javax.xml.soap.MessageFactory;
 import javax.xml.soap.MimeHeaders;
 import javax.xml.soap.SOAPConstants;
 import javax.xml.soap.SOAPMessage;
-import javax.xml.stream.XMLInputFactory;
-import javax.xml.stream.XMLStreamReader;
 import javax.xml.transform.dom.DOMSource;
 
-import org.apache.axiom.soap.SOAP12Constants;
-import org.apache.axiom.soap.impl.builder.StAXSOAPModelBuilder;
+import org.apache.axiom.om.OMXMLBuilderFactory;
+import org.apache.axiom.soap.SOAPModelBuilder;
 import org.junit.Assert;
 import org.junit.Before;
 import org.w3c.dom.Document;
@@ -154,9 +152,8 @@ public abstract class Wss4jTestCase {
 			assertTrue("Could not load Axiom message [" + resource + "]", resource.exists());
 			is = resource.getInputStream();
 
-			XMLStreamReader parser = XMLInputFactory.newInstance().createXMLStreamReader(is);
-			StAXSOAPModelBuilder builder = new StAXSOAPModelBuilder(parser, null);
-			org.apache.axiom.soap.SOAPMessage soapMessage = builder.getSoapMessage();
+			SOAPModelBuilder builder = OMXMLBuilderFactory.createSOAPModelBuilder(is, null);
+			org.apache.axiom.soap.SOAPMessage soapMessage = builder.getSOAPMessage();
 			return new AxiomSoapMessage(soapMessage, "", true, true);
 		}
 		finally {
@@ -172,9 +169,8 @@ public abstract class Wss4jTestCase {
 			assertTrue("Could not load Axiom message [" + resource + "]", resource.exists());
 			is = resource.getInputStream();
 
-			XMLStreamReader parser = XMLInputFactory.newInstance().createXMLStreamReader(is);
-			StAXSOAPModelBuilder builder = new StAXSOAPModelBuilder(parser, SOAP12Constants.SOAP_ENVELOPE_NAMESPACE_URI);
-			org.apache.axiom.soap.SOAPMessage soapMessage = builder.getSoapMessage();
+			SOAPModelBuilder builder = OMXMLBuilderFactory.createSOAPModelBuilder(is, null);
+			org.apache.axiom.soap.SOAPMessage soapMessage = builder.getSOAPMessage();
 			return new AxiomSoapMessage(soapMessage, "", true, true);
 		}
 		finally {


### PR DESCRIPTION
This change only addresses some trivial cases. There are other cases
that require more work.