### PR TITLE
Use correct default content type for SOAP 1.2 with Axiom

### DIFF
--- a/spring-ws-core/src/main/java/org/springframework/ws/soap/axiom/AxiomSoapMessageFactory.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/soap/axiom/AxiomSoapMessageFactory.java
@@ -75,6 +75,7 @@ import org.springframework.ws.transport.TransportInputStream;
  * distribution.
  *
  * @author Arjen Poutsma
+ * @author Andreas Veithen
  * @see AxiomSoapMessage
  * @see #setPayloadCaching(boolean)
  * @since 1.0.0
@@ -227,9 +228,9 @@ public class AxiomSoapMessageFactory implements SoapMessageFactory, Initializing
 		if (!StringUtils.hasLength(contentType)) {
 			if (logger.isDebugEnabled()) {
 				logger.debug("TransportInputStream has no Content-Type header; defaulting to \"" +
-						SoapVersion.SOAP_11.getContentType() + "\"");
+						soapFactory.getSOAPVersion().getMediaType() + "\"");
 			}
-			contentType = SoapVersion.SOAP_11.getContentType();
+			contentType = soapFactory.getSOAPVersion().getMediaType().toString();
 		}
 		String soapAction = getHeaderValue(transportInputStream, TransportConstants.HEADER_SOAP_ACTION);
 		if (!StringUtils.hasLength(soapAction)) {

--- a/spring-ws-core/src/test/java/org/springframework/ws/soap/AbstractSoapMessageFactoryTestCase.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/soap/AbstractSoapMessageFactoryTestCase.java
@@ -43,4 +43,7 @@ public abstract class AbstractSoapMessageFactoryTestCase extends AbstractWebServ
 
 	@Test
 	public abstract void testCreateSoapMessageMtom() throws Exception;
+
+	@Test
+	public abstract void testCreateSoapMessageMissingContentType() throws Exception;
 }

--- a/spring-ws-core/src/test/java/org/springframework/ws/soap/soap11/AbstractSoap11MessageFactoryTestCase.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/soap/soap11/AbstractSoap11MessageFactoryTestCase.java
@@ -17,6 +17,7 @@
 package org.springframework.ws.soap.soap11;
 
 import java.io.InputStream;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -163,6 +164,17 @@ public abstract class AbstractSoap11MessageFactoryTestCase extends AbstractSoapM
 
 		SoapMessage message = (SoapMessage) messageFactory.createWebServiceMessage(tis);
 		assertEquals("Invalid soap version", SoapVersion.SOAP_11, message.getVersion());
+	}
+
+	@Override
+	public void testCreateSoapMessageMissingContentType() throws Exception {
+		InputStream is = AbstractSoap11MessageFactoryTestCase.class.getResourceAsStream("soap11.xml");
+		TransportInputStream tis = new MockTransportInputStream(is, Collections.emptyMap());
+		
+		WebServiceMessage message = messageFactory.createWebServiceMessage(tis);
+		assertTrue("Not a SoapMessage", message instanceof SoapMessage);
+		SoapMessage soapMessage = (SoapMessage) message;
+		assertEquals("Invalid soap version", SoapVersion.SOAP_11, soapMessage.getVersion());
 	}
 
 

--- a/spring-ws-core/src/test/java/org/springframework/ws/soap/soap12/AbstractSoap12MessageFactoryTestCase.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/soap/soap12/AbstractSoap12MessageFactoryTestCase.java
@@ -17,6 +17,7 @@
 package org.springframework.ws.soap.soap12;
 
 import java.io.InputStream;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -107,5 +108,15 @@ public abstract class AbstractSoap12MessageFactoryTestCase extends AbstractSoapM
 		assertNotNull("No attachment read", attachment);
 	}
 
+	@Override
+	public void testCreateSoapMessageMissingContentType() throws Exception {
+		InputStream is = AbstractSoap12MessageFactoryTestCase.class.getResourceAsStream("soap12.xml");
+		TransportInputStream tis = new MockTransportInputStream(is, Collections.emptyMap());
+		
+		WebServiceMessage message = messageFactory.createWebServiceMessage(tis);
+		assertTrue("Not a SoapMessage", message instanceof SoapMessage);
+		SoapMessage soapMessage = (SoapMessage) message;
+		assertEquals("Invalid soap version", SoapVersion.SOAP_12, soapMessage.getVersion());
+	}
 
 }


### PR DESCRIPTION
SaajSoapMessageFactory consistently accepts SOAP messages without
Content-Type header, but AxiomSoapMessageFactory triggers an error with
SOAP 1.2 in this case. This change fixes this and ensures consistency
between the two message factories.