### PR TITLE
Make AxiomSoapHeader compatible with the future Axiom 1.3

### DIFF
--- a/spring-ws-core/src/main/java/org/springframework/ws/soap/axiom/AxiomSoapHeader.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/soap/axiom/AxiomSoapHeader.java
@@ -114,9 +114,9 @@ abstract class AxiomSoapHeader extends AxiomSoapElement implements SoapHeader {
 
 	protected class AxiomSoapHeaderElementIterator implements Iterator<SoapHeaderElement> {
 
-		private final Iterator<SOAPHeaderBlock> axiomIterator;
+		private final Iterator<? extends OMElement> axiomIterator;
 
-		protected AxiomSoapHeaderElementIterator(Iterator<SOAPHeaderBlock> axiomIterator) {
+		protected AxiomSoapHeaderElementIterator(Iterator<? extends OMElement> axiomIterator) {
 			this.axiomIterator = axiomIterator;
 		}
 
@@ -128,7 +128,7 @@ abstract class AxiomSoapHeader extends AxiomSoapElement implements SoapHeader {
 		@Override
 		public SoapHeaderElement next() {
 			try {
-				SOAPHeaderBlock axiomHeaderBlock = axiomIterator.next();
+				SOAPHeaderBlock axiomHeaderBlock = (SOAPHeaderBlock) axiomIterator.next();
 				return new AxiomSoapHeaderElement(axiomHeaderBlock, getAxiomFactory());
 			}
 			catch (OMException ex) {


### PR DESCRIPTION
AxiomSoapHeaderElementIterator expects an Iterator<SOAPHeaderBlock> as
input. However, it is also used together with getChildrenWithName, which
(since it's defined by OMContainer), will actually return an
Iterator<OMElement> in Axiom 1.3. Therefore it should use Iterator<?
extends OMElement>.