### PR TITLE
Fix invalid test cases that close the InputStream too early

### DIFF
--- a/spring-ws-security/src/test/java/org/springframework/ws/soap/security/wss4j2/Wss4jTestCase.java
+++ b/spring-ws-security/src/test/java/org/springframework/ws/soap/security/wss4j2/Wss4jTestCase.java
@@ -154,6 +154,7 @@ public abstract class Wss4jTestCase {
 
 			SOAPModelBuilder builder = OMXMLBuilderFactory.createSOAPModelBuilder(is, null);
 			org.apache.axiom.soap.SOAPMessage soapMessage = builder.getSOAPMessage();
+			builder.detach();
 			return new AxiomSoapMessage(soapMessage, "", true, true);
 		}
 		finally {
@@ -171,6 +172,7 @@ public abstract class Wss4jTestCase {
 
 			SOAPModelBuilder builder = OMXMLBuilderFactory.createSOAPModelBuilder(is, null);
 			org.apache.axiom.soap.SOAPMessage soapMessage = builder.getSOAPMessage();
+			builder.detach();
 			return new AxiomSoapMessage(soapMessage, "", true, true);
 		}
 		finally {


### PR DESCRIPTION
Since Axiom uses deferred parsing, the underlying InputStream must not
be closed before the message has been fully processed or the detach()
method on the builder has been called. That constraint was violated by a
few test cases. This doesn't cause problems with Axiom 1.2.x (presumably
because the test messages are small enough), but the build fails with
Axiom 1.3.0-SNAPSHOT.