### PR TITLE
Adds UserDetails to Authentication

### DIFF
--- a/spring-ws-security/src/main/java/org/springframework/ws/soap/security/wss4j2/callback/SpringSecurityPasswordValidationCallbackHandler.java
+++ b/spring-ws-security/src/main/java/org/springframework/ws/soap/security/wss4j2/callback/SpringSecurityPasswordValidationCallbackHandler.java
@@ -94,6 +94,7 @@ public class SpringSecurityPasswordValidationCallbackHandler extends AbstractWsP
 		if (logger.isDebugEnabled()) {
 			logger.debug("Authentication success: " + authRequest.toString());
 		}
+		authRequest.setDetails(user);
 		SecurityContextHolder.getContext().setAuthentication(authRequest);
 	}
 


### PR DESCRIPTION
Adding the `UserDetails` object to the `Authentication` of the session allows more flexibility; e.g. custom loaded data can be use along the session by doing
```
CustomUserDetails details = (CustomUserDetails) SecurityContextHolder.getContext().getAuthentication().getDetails();
Object value = details.getSpecialAttribute();
details.doCustomAction();
//etc.
```