### PR TITLE
Documentation fixes

### DIFF
--- a/CODE_OF_CONDUCT.adoc
+++ b/CODE_OF_CONDUCT.adoc
@@ -40,5 +40,5 @@ appropriate to the circumstances. Maintainers are obligated to maintain confiden
 with regard to the reporter of an incident.
 
 This Code of Conduct is adapted from the
-http://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
-http://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]
+https://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
+https://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -10,8 +10,8 @@ unacceptable behavior to spring-code-of-conduct@pivotal.io.
 
 == Using JIRA issues
 We use JIRA issues to track bugs and enhancements. If you have a general usage question
-please ask on http://stackoverflow.com[Stack Overflow]. The Spring Web Services team and the
-broader community monitor the http://stackoverflow.com/tags/spring-ws[`spring-ws`]
+please ask on https://stackoverflow.com[Stack Overflow]. The Spring Web Services team and the
+broader community monitor the https://stackoverflow.com/tags/spring-ws[`spring-ws`]
 tag.
 
 If you are reporting a bug, please help to speed up problem diagnosis by providing as much

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -45,18 +45,18 @@ added after the original pull request but before a merge.
 * When writing a commit message please follow http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions].
 
 === Building from source
-This project includes the Gradle wrapper, meaning you don't have to install any CLI tools to compile. Simply clone it and do this:
+This project includes the Maven wrapper, meaning you don't have to install any CLI tools to compile. Simply clone it and do this:
 
 ==== Default build
-The project can be built from the root directory using the standard gradle wrapper command:
+The project can be built from the root directory using the standard Maven wrapper command:
 
 ----
-$ ./gradlew clean build
+$ ./mvnw clean package
 ----
 
 If you are rebuilding often, you might also want to skip the tests until you are ready
 to submit a pull request:
 
 ----
-$ ./gradlew clean build -x test
+$ ./mvnw clean package -Dmaven.test.skip=true
 ----

--- a/README.adoc
+++ b/README.adoc
@@ -60,7 +60,7 @@ You can find the documentation, issue management, support, samples, and guides f
 
 == Documentation
 
-See the current http://docs.spring.io/spring-ws/docs/current/api/[Javadoc] and http://docs.spring.io/spring-ws/docs/current/reference/htmlsingle/[reference docs].
+See the current http://docs.spring.io/spring-ws/docs/current/api/[Javadoc] and http://docs.spring.io/spring-ws/docs/current/reference/[reference docs].
 
 == Issue Tracking
 

--- a/README.adoc
+++ b/README.adoc
@@ -16,7 +16,7 @@ Please visit https://projects.spring.io/spring-ws to get the right Maven/Gradle 
 
 == Building Spring Web Services
 
-. Run `mvn clean package`
+. Run `./mvnw clean package`
 
 This will generate the artifacts.
 

--- a/README.adoc
+++ b/README.adoc
@@ -10,7 +10,7 @@ web services using one of the many ways to manipulate XML payloads.
 == Installation
 
 Releases of Spring Web Services are available for download from Maven Central,
-as well as our own repository, http://repo.spring.io/release[http://repo.springsource.org/release].
+as well as our own repository, https://repo.spring.io/release[https://repo.spring.io/release].
 
 Please visit https://projects.spring.io/spring-ws to get the right Maven/Gradle settings for your selected version.
 
@@ -56,11 +56,11 @@ By participating, you  are expected to uphold this code. Please report unaccepta
 
 = Spring Web Services Project Site
 
-You can find the documentation, issue management, support, samples, and guides for using Spring Web Services at http://projects.spring.io/spring-ws/
+You can find the documentation, issue management, support, samples, and guides for using Spring Web Services at https://projects.spring.io/spring-ws/
 
 == Documentation
 
-See the current http://docs.spring.io/spring-ws/docs/current/api/[Javadoc] and http://docs.spring.io/spring-ws/docs/current/reference/[reference docs].
+See the current https://docs.spring.io/spring-ws/docs/current/api/[Javadoc] and https://docs.spring.io/spring-ws/docs/current/reference/[reference docs].
 
 == Issue Tracking
 
@@ -68,4 +68,4 @@ Spring Web Services uses https://jira.spring.io/browse/SWS[JIRA] for issue track
 
 == License
 
-Spring Web Services is http://www.apache.org/licenses/LICENSE-2.0.html[Apache 2.0 licensed].
+Spring Web Services is https://www.apache.org/licenses/LICENSE-2.0.html[Apache 2.0 licensed].


### PR DESCRIPTION
The main goal of this PR is to fix the link to the reference docs in the README (it doesn't use the `htmlsingle` directory anymore).

However, I noticed an inconsistent use of HTTPS in the docs, as well as mentions to the Gradle wrapper when the project actually uses Maven to build, so I also fixed those.

- [x] I have signed the CLA.