### PR TITLE
SWS-1031 - wsa:to element is not optional

### DIFF
--- a/spring-ws-core/src/main/java/org/springframework/ws/soap/addressing/client/ActionCallback.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/soap/addressing/client/ActionCallback.java
@@ -58,6 +58,8 @@ public class ActionCallback implements WebServiceMessageCallback {
 	private final URI action;
 
 	private final URI to;
+	
+	private boolean shouldInitializeTo = true;
 
 	private MessageIdStrategy messageIdStrategy;
 
@@ -216,7 +218,7 @@ public class ActionCallback implements WebServiceMessageCallback {
 	 * destination was set.
 	 */
 	protected URI getTo() {
-		if (to == null) {
+		if (to == null && shouldInitializeTo) {
 			TransportContext transportContext = TransportContextHolder.getTransportContext();
 			if (transportContext != null && transportContext.getConnection() != null) {
 				try {
@@ -231,6 +233,13 @@ public class ActionCallback implements WebServiceMessageCallback {
 		else {
 			return to;
 		}
+	}
+	
+	/**
+	 * Set whether to initialize the {@code To} header by default or not
+	 */
+	public void setShouldInitializeTo(boolean shouldInitializeTo) {
+		this.shouldInitializeTo = shouldInitializeTo;
 	}
 
 	@Override

--- a/spring-ws-core/src/main/java/org/springframework/ws/soap/addressing/version/AbstractAddressingVersion.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/soap/addressing/version/AbstractAddressingVersion.java
@@ -200,7 +200,6 @@ public abstract class AbstractAddressingVersion extends TransformerObjectSupport
 		if (map.getTo() != null) {
 			SoapHeaderElement to = header.addHeaderElement(getToName());
 			to.setText(map.getTo().toString());
-			to.setMustUnderstand(true);
 		}
 		// From
 		if (map.getFrom() != null) {


### PR DESCRIPTION
Add local variable (shouldInitializeTo) at
org.springframework.ws.soap.addressing.client.ActionCallback to specify
if it should be default initialized.

Remove setMustUnderstand(true) at
org.springframework.ws.soap.addressing.version.AbstractAddressingVersion.addAddressingHeaders().