### PR TITLE
SWS-1018 - Move creation of an empty SOAP 1.1 envelope to the factory.

### DIFF
--- a/spring-ws-core/src/main/java/org/springframework/ws/soap/saaj/SaajSoapMessage.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/soap/saaj/SaajSoapMessage.java
@@ -115,12 +115,6 @@ public class SaajSoapMessage extends AbstractSoapMessage {
 		saajMessage = soapMessage;
 		this.langAttributeOnSoap11FaultString = langAttributeOnSoap11FaultString;
 		this.messageFactory = messageFactory;
-		if (SoapVersion.SOAP_11.equals(getVersion())) {
-			MimeHeaders headers = soapMessage.getMimeHeaders();
-			if (ObjectUtils.isEmpty(headers.getHeader(TransportConstants.HEADER_SOAP_ACTION))) {
-				headers.addHeader(TransportConstants.HEADER_SOAP_ACTION, "\"\"");
-			}
-		}
 	}
 
 	/** Return the SAAJ {@code SOAPMessage} that this {@code SaajSoapMessage} is based on. */

--- a/spring-ws-core/src/main/java/org/springframework/ws/soap/saaj/SaajSoapMessageFactory.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/soap/saaj/SaajSoapMessageFactory.java
@@ -35,6 +35,7 @@ import org.xml.sax.SAXParseException;
 
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.util.CollectionUtils;
+import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
 import org.springframework.ws.InvalidXmlException;
 import org.springframework.ws.soap.SoapMessageCreationException;
@@ -54,6 +55,7 @@ import org.springframework.ws.transport.TransportInputStream;
  * factory is injected, the {@link #setSoapVersion(org.springframework.ws.soap.SoapVersion)} property is ignored.
  *
  * @author Arjen Poutsma
+ * @author 
  * @see org.springframework.ws.soap.saaj.SaajSoapMessage
  * @since 1.0.0
  */
@@ -288,6 +290,13 @@ public class SaajSoapMessageFactory implements SoapMessageFactory, InitializingB
 		if (!CollectionUtils.isEmpty(messageProperties)) {
 			for (Map.Entry<String, ?> entry : messageProperties.entrySet()) {
 				soapMessage.setProperty(entry.getKey(), entry.getValue());
+			}
+		}
+
+		if (SOAPConstants.SOAP_1_1_PROTOCOL.equals(this.messageFactoryProtocol)) {
+			MimeHeaders headers = soapMessage.getMimeHeaders();
+			if (ObjectUtils.isEmpty(headers.getHeader(TransportConstants.HEADER_SOAP_ACTION))) {
+				headers.addHeader(TransportConstants.HEADER_SOAP_ACTION, "\"\"");
 			}
 		}
 	}


### PR DESCRIPTION
To avoid SaajSoapMessage being created with an empty envelope, move the envelope creation process to SaajSoapMessageFactory.