### PR TITLE
SWS-1035 - XMLUnit migration from 1.5 to 2.6.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
 		<wss4j.version>2.2.0</wss4j.version>
 		<xmlsec.version>2.1.0</xmlsec.version>
 		<xml-schema-core.version>2.2.2</xml-schema-core.version>
-		<xmlunit.version>1.5</xmlunit.version>
+		<xmlunit.version>2.6.2</xmlunit.version>
 		<xws-security.version>3.0</xws-security.version>
 		<xom.version>1.2.5</xom.version>
 	</properties>
@@ -169,8 +169,14 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>xmlunit</groupId>
-			<artifactId>xmlunit</artifactId>
+			<groupId>org.xmlunit</groupId>
+			<artifactId>xmlunit-core</artifactId>
+			<version>${xmlunit.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.xmlunit</groupId>
+			<artifactId>xmlunit-assertj</artifactId>
 			<version>${xmlunit.version}</version>
 			<scope>test</scope>
 		</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -179,6 +179,12 @@
 			<artifactId>xmlunit-assertj</artifactId>
 			<version>${xmlunit.version}</version>
 			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+          			<groupId>org.assertj</groupId>
+          			<artifactId>assertj-core</artifactId>
+        		</exclusion>
+        	</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.assertj</groupId>

--- a/spring-ws-core/src/test/java/org/springframework/ws/AbstractWebServiceMessageTestCase.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/AbstractWebServiceMessageTestCase.java
@@ -47,7 +47,6 @@ import org.springframework.util.xml.StaxUtils;
 import org.springframework.xml.sax.SaxUtils;
 import org.springframework.xml.transform.StringResult;
 
-import org.custommonkey.xmlunit.XMLUnit;
 import org.junit.Before;
 import org.junit.Test;
 import org.w3c.dom.Document;
@@ -56,7 +55,7 @@ import org.xml.sax.XMLReader;
 import org.xml.sax.helpers.DefaultHandler;
 import org.xml.sax.helpers.XMLReaderFactory;
 
-import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
+import static org.xmlunit.assertj.XmlAssert.assertThat;
 
 public abstract class AbstractWebServiceMessageTestCase {
 
@@ -78,7 +77,6 @@ public abstract class AbstractWebServiceMessageTestCase {
 		transformer = transformerFactory.newTransformer();
 		webServiceMessage = createWebServiceMessage();
 		payload = new ClassPathResource("payload.xml", AbstractWebServiceMessageTestCase.class);
-		XMLUnit.setIgnoreWhitespace(true);
 	}
 
 	@Test
@@ -92,7 +90,7 @@ public abstract class AbstractWebServiceMessageTestCase {
 		Document resultDocument = documentBuilder.newDocument();
 		DOMResult domResult = new DOMResult(resultDocument);
 		transformer.transform(webServiceMessage.getPayloadSource(), domResult);
-		assertXMLEqual(payloadDocument, resultDocument);
+		assertThat(resultDocument).and(payloadDocument).areIdentical();
 		validateMessage();
 	}
 
@@ -108,7 +106,7 @@ public abstract class AbstractWebServiceMessageTestCase {
 		Result staxResult = StaxUtils.createCustomStaxResult(eventWriter);
 		transformer.transform(webServiceMessage.getPayloadSource(), staxResult);
 		eventWriter.flush();
-		assertXMLEqual(getExpectedString(), stringWriter.toString());
+		assertThat(stringWriter.toString()).and(getExpectedString()).areIdentical();
 		validateMessage();
 	}
 
@@ -120,7 +118,7 @@ public abstract class AbstractWebServiceMessageTestCase {
 		StringWriter resultWriter = new StringWriter();
 		StreamResult streamResult = new StreamResult(resultWriter);
 		transformer.transform(webServiceMessage.getPayloadSource(), streamResult);
-		assertXMLEqual(getExpectedString(), resultWriter.toString());
+		assertThat(resultWriter.toString()).and(getExpectedString()).areSimilar();
 	}
 
 	@Test
@@ -129,7 +127,7 @@ public abstract class AbstractWebServiceMessageTestCase {
 		transformer.transform(saxSource, webServiceMessage.getPayloadResult());
 		StringResult stringResult = new StringResult();
 		transformer.transform(webServiceMessage.getPayloadSource(), stringResult);
-		assertXMLEqual(getExpectedString(), stringResult.toString());
+		assertThat(stringResult.toString()).and(getExpectedString()).areSimilar();
 		validateMessage();
 	}
 
@@ -142,7 +140,7 @@ public abstract class AbstractWebServiceMessageTestCase {
 		transformer.transform(webServiceMessage.getPayloadSource(), streamResult);
 		ByteArrayOutputStream expectedStream = new ByteArrayOutputStream();
 		FileCopyUtils.copy(payload.getInputStream(), expectedStream);
-		assertXMLEqual(expectedStream.toString("UTF-8"), resultStream.toString("UTF-8"));
+		assertThat(resultStream.toString("UTF-8")).and(expectedStream.toString("UTF-8")).areSimilar();
 		validateMessage();
 	}
 
@@ -158,7 +156,7 @@ public abstract class AbstractWebServiceMessageTestCase {
 		Result staxResult = StaxUtils.createCustomStaxResult(streamWriter);
 		transformer.transform(webServiceMessage.getPayloadSource(), staxResult);
 		streamWriter.flush();
-		assertXMLEqual(getExpectedString(), stringWriter.toString());
+		assertThat(stringWriter.toString()).and(getExpectedString()).areSimilar();
 		validateMessage();
 	}
 

--- a/spring-ws-core/src/test/java/org/springframework/ws/AbstractWebServiceMessageTestCase.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/AbstractWebServiceMessageTestCase.java
@@ -90,7 +90,7 @@ public abstract class AbstractWebServiceMessageTestCase {
 		Document resultDocument = documentBuilder.newDocument();
 		DOMResult domResult = new DOMResult(resultDocument);
 		transformer.transform(webServiceMessage.getPayloadSource(), domResult);
-		assertThat(resultDocument).and(payloadDocument).areIdentical();
+		assertThat(resultDocument).and(payloadDocument).areSimilar();
 		validateMessage();
 	}
 
@@ -106,7 +106,7 @@ public abstract class AbstractWebServiceMessageTestCase {
 		Result staxResult = StaxUtils.createCustomStaxResult(eventWriter);
 		transformer.transform(webServiceMessage.getPayloadSource(), staxResult);
 		eventWriter.flush();
-		assertThat(stringWriter.toString()).and(getExpectedString()).areIdentical();
+		assertThat(stringWriter.toString()).and(getExpectedString()).areSimilar();
 		validateMessage();
 	}
 

--- a/spring-ws-core/src/test/java/org/springframework/ws/client/core/AbstractSoap11WebServiceTemplateIntegrationTestCase.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/client/core/AbstractSoap11WebServiceTemplateIntegrationTestCase.java
@@ -41,7 +41,7 @@ import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
 
-import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
+import static org.xmlunit.assertj.XmlAssert.assertThat;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import static org.junit.Assert.assertEquals;
@@ -118,7 +118,7 @@ public abstract class AbstractSoap11WebServiceTemplateIntegrationTestCase {
 		boolean b = template.sendSourceAndReceiveToResult(baseUrl + "/soap/echo",
 				new StringSource(messagePayload), result);
 		Assert.assertTrue("Invalid result", b);
-		assertXMLEqual(messagePayload, result.toString());
+		assertThat(result.toString()).and(messagePayload).areSimilar();
 	}
 
 	@Test

--- a/spring-ws-core/src/test/java/org/springframework/ws/client/core/AbstractSoap12WebServiceTemplateIntegrationTestCase.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/client/core/AbstractSoap12WebServiceTemplateIntegrationTestCase.java
@@ -43,7 +43,7 @@ import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
 
-import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
+import static org.xmlunit.assertj.XmlAssert.assertThat;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import static org.junit.Assert.assertEquals;
@@ -129,7 +129,7 @@ public abstract class AbstractSoap12WebServiceTemplateIntegrationTestCase {
 		boolean b = template.sendSourceAndReceiveToResult(baseUrl + "/soap/echo",
 				new StringSource(messagePayload), result);
 		Assert.assertTrue("Invalid result", b);
-		assertXMLEqual(messagePayload, result.toString());
+		assertThat(result.toString()).and(messagePayload).areSimilar();
 	}
 
 	@Test

--- a/spring-ws-core/src/test/java/org/springframework/ws/client/core/DomPoxWebServiceTemplateIntegrationTest.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/client/core/DomPoxWebServiceTemplateIntegrationTest.java
@@ -29,7 +29,7 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
-import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
+import static org.xmlunit.assertj.XmlAssert.assertThat;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -79,7 +79,7 @@ public class DomPoxWebServiceTemplateIntegrationTest {
 		StringResult result = new StringResult();
 		template.sendSourceAndReceiveToResult(baseUrl + "/pox", new StringSource(content),
 				result);
-		assertXMLEqual(content, result.toString());
+		assertThat(result.toString()).and(content).areSimilar();
 		try {
 			template.sendSourceAndReceiveToResult(baseUrl + "/errors/notfound",
 					new StringSource(content), new StringResult());

--- a/spring-ws-core/src/test/java/org/springframework/ws/pox/dom/DomPoxMessageTest.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/pox/dom/DomPoxMessageTest.java
@@ -29,7 +29,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.w3c.dom.Document;
 
-import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
+import static org.xmlunit.assertj.XmlAssert.assertThat;
 
 public class DomPoxMessageTest {
 
@@ -54,7 +54,7 @@ public class DomPoxMessageTest {
 		transformer.transform(source, message.getPayloadResult());
 		StringResult stringResult = new StringResult();
 		transformer.transform(message.getPayloadSource(), stringResult);
-		assertXMLEqual(content, stringResult.toString());
+		assertThat(stringResult.toString()).and(content).areSimilar();
 	}
 
 	@Test
@@ -64,7 +64,7 @@ public class DomPoxMessageTest {
 		transformer.transform(new StringSource(content), message.getPayloadResult());
 		StringResult stringResult = new StringResult();
 		transformer.transform(message.getPayloadSource(), stringResult);
-		assertXMLEqual(content, stringResult.toString());
+		assertThat(stringResult.toString()).and(content).areSimilar();
 	}
 
 	@Test
@@ -74,6 +74,6 @@ public class DomPoxMessageTest {
 		transformer.transform(source, message.getPayloadResult());
 		ByteArrayOutputStream os = new ByteArrayOutputStream();
 		message.writeTo(os);
-		assertXMLEqual(content, os.toString("UTF-8"));
+		assertThat(os.toString("UTF-8")).and(content).areSimilar();
 	}
 }

--- a/spring-ws-core/src/test/java/org/springframework/ws/server/endpoint/AbstractMessageEndpointTestCase.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/server/endpoint/AbstractMessageEndpointTestCase.java
@@ -27,7 +27,7 @@ import org.springframework.xml.transform.StringSource;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
+import static org.xmlunit.assertj.XmlAssert.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -67,7 +67,7 @@ public abstract class AbstractMessageEndpointTestCase extends AbstractEndpointTe
 				new DefaultMessageContext(new MockWebServiceMessage(requestSource), new MockWebServiceMessageFactory());
 		endpoint.invoke(context);
 		assertTrue("No response message created", context.hasResponse());
-		assertXMLEqual(RESPONSE, ((MockWebServiceMessage) context.getResponse()).getPayloadAsString());
+		assertThat(((MockWebServiceMessage) context.getResponse()).getPayloadAsString()).and(RESPONSE).areSimilar();
 	}
 
 	protected abstract MessageEndpoint createNoResponseEndpoint();

--- a/spring-ws-core/src/test/java/org/springframework/ws/server/endpoint/AbstractPayloadEndpointTestCase.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/server/endpoint/AbstractPayloadEndpointTestCase.java
@@ -26,7 +26,7 @@ import org.springframework.xml.transform.StringSource;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
+import static org.xmlunit.assertj.XmlAssert.assertThat;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
@@ -63,7 +63,7 @@ public abstract class AbstractPayloadEndpointTestCase extends AbstractEndpointTe
 		assertNotNull("No response source returned", responseSource);
 		StringResult result = new StringResult();
 		transformer.transform(responseSource, result);
-		assertXMLEqual(RESPONSE, result.toString());
+		assertThat(result.toString()).and(RESPONSE).areSimilar();
 	}
 
 	protected abstract PayloadEndpoint createNoResponseEndpoint() throws Exception;

--- a/spring-ws-core/src/test/java/org/springframework/ws/server/endpoint/MarshallingPayloadEndpointTest.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/server/endpoint/MarshallingPayloadEndpointTest.java
@@ -27,7 +27,7 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
 
-import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
+import static org.xmlunit.assertj.XmlAssert.assertThat;
 import static org.easymock.EasyMock.*;
 import org.junit.Assert;
 import static org.junit.Assert.fail;
@@ -73,7 +73,7 @@ public class MarshallingPayloadEndpointTest {
 				try {
 					StringWriter writer = new StringWriter();
 					transformer.transform(source, new StreamResult(writer));
-					assertXMLEqual("Invalid source", "<request/>", writer.toString());
+					assertThat(writer.toString()).and("<request/>").areSimilar();
 					return 42L;
 				}
 				catch (Exception e) {
@@ -112,7 +112,7 @@ public class MarshallingPayloadEndpointTest {
 		endpoint.invoke(context);
 		MockWebServiceMessage response = (MockWebServiceMessage) context.getResponse();
 		Assert.assertNotNull("Invalid result", response);
-		assertXMLEqual("Invalid response", "<result/>", response.getPayloadAsString());
+		assertThat(response.getPayloadAsString()).and("<result/>").areSimilar();
 
 		verify(factoryMock);
 	}
@@ -125,7 +125,7 @@ public class MarshallingPayloadEndpointTest {
 				try {
 					StringWriter writer = new StringWriter();
 					transformer.transform(source, new StreamResult(writer));
-					assertXMLEqual("Invalid source", "<request/>", writer.toString());
+					assertThat(writer.toString()).and("<request/>").areSimilar();
 					return (long) 42;
 				}
 				catch (Exception e) {

--- a/spring-ws-core/src/test/java/org/springframework/ws/server/endpoint/StaxStreamPayloadEndpointTest.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/server/endpoint/StaxStreamPayloadEndpointTest.java
@@ -37,7 +37,7 @@ import org.apache.axiom.om.OMAbstractFactory;
 import org.apache.axiom.soap.SOAPFactory;
 import org.junit.Test;
 
-import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
+import static org.xmlunit.assertj.XmlAssert.assertThat;
 import static org.junit.Assert.*;
 
 /**
@@ -114,7 +114,7 @@ public class StaxStreamPayloadEndpointTest extends AbstractMessageEndpointTestCa
 		assertTrue("context has not response", context.hasResponse());
 		StringResult stringResult = new StringResult();
 		transformer.transform(context.getResponse().getPayloadSource(), stringResult);
-		assertXMLEqual(RESPONSE, stringResult.toString());
+		assertThat(stringResult.toString()).and(RESPONSE).areSimilar();
 	}
 
 	@Test
@@ -132,7 +132,7 @@ public class StaxStreamPayloadEndpointTest extends AbstractMessageEndpointTestCa
 		assertTrue("context has not response", context.hasResponse());
 		StringResult stringResult = new StringResult();
 		transformer.transform(context.getResponse().getPayloadSource(), stringResult);
-		assertXMLEqual(RESPONSE, stringResult.toString());
+		assertThat(stringResult.toString()).and(RESPONSE).areSimilar();
 	}
 
 	@Test
@@ -167,7 +167,7 @@ public class StaxStreamPayloadEndpointTest extends AbstractMessageEndpointTestCa
 
 		StringResult stringResult = new StringResult();
 		transformer.transform(context.getResponse().getPayloadSource(), stringResult);
-		assertXMLEqual(RESPONSE, stringResult.toString());
+		assertThat(stringResult.toString()).and(RESPONSE).areSimilar();
 	}
 
 	@Test

--- a/spring-ws-core/src/test/java/org/springframework/ws/server/endpoint/adapter/PayloadEndpointAdapterTest.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/server/endpoint/adapter/PayloadEndpointAdapterTest.java
@@ -34,7 +34,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
+import static org.xmlunit.assertj.XmlAssert.assertThat;
 import static org.easymock.EasyMock.*;
 
 public class PayloadEndpointAdapterTest {
@@ -62,7 +62,7 @@ public class PayloadEndpointAdapterTest {
 			public Source invoke(Source request) throws Exception {
 				StringWriter writer = new StringWriter();
 				transformer.transform(request, new StreamResult(writer));
-				assertXMLEqual("Invalid request", "<request/>", writer.toString());
+				assertThat(writer.toString()).and("<request/>").areSimilar();
 				return new StreamSource(new StringReader("<response/>"));
 			}
 		};
@@ -71,7 +71,7 @@ public class PayloadEndpointAdapterTest {
 		adapter.invoke(messageContext, endpoint);
 		MockWebServiceMessage response = (MockWebServiceMessage) messageContext.getResponse();
 		Assert.assertNotNull("No response created", response);
-		assertXMLEqual("Invalid payload", "<response/>", response.getPayloadAsString());
+		assertThat(response.getPayloadAsString()).and("<response/>").areSimilar();
 	}
 
 	@Test

--- a/spring-ws-core/src/test/java/org/springframework/ws/server/endpoint/adapter/method/AbstractPayloadMethodProcessorTestCase.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/server/endpoint/adapter/method/AbstractPayloadMethodProcessorTestCase.java
@@ -25,7 +25,7 @@ import org.springframework.xml.transform.StringResult;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
+import static org.xmlunit.assertj.XmlAssert.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -135,7 +135,7 @@ public abstract class AbstractPayloadMethodProcessorTestCase extends AbstractMet
 			Source responsePayload = messageContext.getResponse().getPayloadSource();
 			StringResult result = new StringResult();
 			transform(responsePayload, result);
-			assertXMLEqual(XML, result.toString());
+			assertThat(result.toString()).and(XML).areSimilar();
 		}
 	}
 

--- a/spring-ws-core/src/test/java/org/springframework/ws/server/endpoint/adapter/method/jaxb/JaxbElementPayloadMethodProcessorTest.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/server/endpoint/adapter/method/jaxb/JaxbElementPayloadMethodProcessorTest.java
@@ -40,7 +40,7 @@ import org.springframework.ws.soap.axiom.AxiomSoapMessage;
 import org.springframework.ws.soap.axiom.AxiomSoapMessageFactory;
 import org.springframework.xml.transform.StringResult;
 
-import static org.custommonkey.xmlunit.XMLAssert.*;
+import static org.xmlunit.assertj.XmlAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -96,7 +96,7 @@ public class JaxbElementPayloadMethodProcessorTest {
 		processor.handleReturnValue(messageContext, supportedReturnType, element);
 		assertTrue("context has no response", messageContext.hasResponse());
 		MockWebServiceMessage response = (MockWebServiceMessage) messageContext.getResponse();
-		assertXMLEqual("<type xmlns='http://springframework.org'><string>Foo</string></type>", response.getPayloadAsString());
+		assertThat(response.getPayloadAsString()).and("<type xmlns='http://springframework.org'><string>Foo</string></type>").ignoreWhitespace().areSimilar();
 	}
 
 	@Test
@@ -108,7 +108,7 @@ public class JaxbElementPayloadMethodProcessorTest {
 		processor.handleReturnValue(messageContext, stringReturnType, element);
 		assertTrue("context has no response", messageContext.hasResponse());
 		MockWebServiceMessage response = (MockWebServiceMessage) messageContext.getResponse();
-		assertXMLEqual("<string xmlns='http://springframework.org'>Foo</string>", response.getPayloadAsString());
+		assertThat(response.getPayloadAsString()).and("<string xmlns='http://springframework.org'>Foo</string>").ignoreWhitespace().areSimilar();
 	}
 
 	@Test
@@ -137,17 +137,15 @@ public class JaxbElementPayloadMethodProcessorTest {
 		StringResult payloadResult = new StringResult();
 		transformer.transform(response.getPayloadSource(), payloadResult);
 
-		assertXMLEqual("<type xmlns='http://springframework.org'><string>Foo</string></type>",
-				payloadResult.toString());
+		assertThat(payloadResult.toString()).and("<type xmlns='http://springframework.org'><string>Foo</string></type>").areSimilar();
 
 		ByteArrayOutputStream bos = new ByteArrayOutputStream();
 		response.writeTo(bos);
 		String messageResult = bos.toString("UTF-8");
 
-		assertXMLEqual("<soapenv:Envelope xmlns:soapenv='http://schemas.xmlsoap.org/soap/envelope/'><soapenv:Header/><soapenv:Body>" +
+		assertThat(messageResult).and("<soapenv:Envelope xmlns:soapenv='http://schemas.xmlsoap.org/soap/envelope/'><soapenv:Header/><soapenv:Body>" +
 				"<type xmlns='http://springframework.org'><string>Foo</string></type>" +
-				"</soapenv:Body></soapenv:Envelope>", messageResult);
-
+				"</soapenv:Body></soapenv:Envelope>").areSimilar();
 	}
 
 

--- a/spring-ws-core/src/test/java/org/springframework/ws/server/endpoint/adapter/method/jaxb/XmlRootElementPayloadMethodProcessorTest.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/server/endpoint/adapter/method/jaxb/XmlRootElementPayloadMethodProcessorTest.java
@@ -50,7 +50,7 @@ import org.springframework.ws.soap.axiom.AxiomSoapMessageFactory;
 import org.springframework.xml.sax.AbstractXmlReader;
 import org.springframework.xml.transform.StringResult;
 
-import static org.custommonkey.xmlunit.XMLAssert.*;
+import static org.xmlunit.assertj.XmlAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -175,7 +175,7 @@ public class XmlRootElementPayloadMethodProcessorTest {
 		processor.handleReturnValue(messageContext, rootElementReturnType, rootElement);
 		assertTrue("context has no response", messageContext.hasResponse());
 		MockWebServiceMessage response = (MockWebServiceMessage) messageContext.getResponse();
-		assertXMLEqual("<root xmlns='http://springframework.org'><string>Foo</string></root>", response.getPayloadAsString());
+		assertThat(response.getPayloadAsString()).and("<root xmlns='http://springframework.org'><string>Foo</string></root>").ignoreWhitespace().areSimilar();
 	}
 
 	@Test
@@ -203,17 +203,15 @@ public class XmlRootElementPayloadMethodProcessorTest {
 		StringResult payloadResult = new StringResult();
 		transformer.transform(response.getPayloadSource(), payloadResult);
 
-		assertXMLEqual("<root xmlns='http://springframework.org'><string>Foo</string></root>",
-				payloadResult.toString());
+		assertThat(payloadResult.toString()).and("<root xmlns='http://springframework.org'><string>Foo</string></root>").areSimilar();
 
 		ByteArrayOutputStream bos = new ByteArrayOutputStream();
 		response.writeTo(bos);
 		String messageResult = bos.toString("UTF-8");
 		
-		assertXMLEqual("<soapenv:Envelope xmlns:soapenv='http://schemas.xmlsoap.org/soap/envelope/'><soapenv:Header/><soapenv:Body>" +
+		assertThat(messageResult).and("<soapenv:Envelope xmlns:soapenv='http://schemas.xmlsoap.org/soap/envelope/'><soapenv:Header/><soapenv:Body>" +
 				"<root xmlns='http://springframework.org'><string>Foo</string></root>" +
-				"</soapenv:Body></soapenv:Envelope>", messageResult);
-
+				"</soapenv:Body></soapenv:Envelope>").ignoreWhitespace().areSimilar();
 	}
 
 	@Test
@@ -233,10 +231,9 @@ public class XmlRootElementPayloadMethodProcessorTest {
 		response.writeTo(bos);
 		String messageResult = bos.toString("UTF-8");
 
-		assertXMLEqual("<soapenv:Envelope xmlns:soapenv='http://schemas.xmlsoap.org/soap/envelope/'><soapenv:Header/><soapenv:Body>" +
+		assertThat(messageResult).and("<soapenv:Envelope xmlns:soapenv='http://schemas.xmlsoap.org/soap/envelope/'><soapenv:Header/><soapenv:Body>" +
 				"<root xmlns='http://springframework.org'><string>Foo</string></root>" +
-				"</soapenv:Body></soapenv:Envelope>", messageResult);
-
+				"</soapenv:Body></soapenv:Envelope>").areSimilar();
 	}
 
 	@ResponsePayload

--- a/spring-ws-core/src/test/java/org/springframework/ws/server/endpoint/interceptor/PayloadTransformingInterceptorTest.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/server/endpoint/interceptor/PayloadTransformingInterceptorTest.java
@@ -22,8 +22,7 @@ import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.sax.SAXSource;
 
-import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
-import org.custommonkey.xmlunit.XMLUnit;
+import static org.xmlunit.assertj.XmlAssert.assertThat;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -62,7 +61,6 @@ public class PayloadTransformingInterceptorTest {
 		input = new ClassPathResource("transformInput.xml", getClass());
 		output = new ClassPathResource("transformOutput.xml", getClass());
 		xslt = new ClassPathResource("transformation.xslt", getClass());
-		XMLUnit.setIgnoreWhitespace(true);
 	}
 
 	@Test
@@ -76,7 +74,7 @@ public class PayloadTransformingInterceptorTest {
 		Assert.assertTrue("Invalid interceptor result", result);
 		StringResult expected = new StringResult();
 		transformer.transform(new SAXSource(SaxUtils.createInputSource(output)), expected);
-		assertXMLEqual(expected.toString(), request.getPayloadAsString());
+		assertThat(request.getPayloadAsString()).and(expected.toString()).ignoreWhitespace().areSimilar();
 	}
 
 	@Test
@@ -90,7 +88,7 @@ public class PayloadTransformingInterceptorTest {
 		Assert.assertTrue("Invalid interceptor result", result);
 		StringResult expected = new StringResult();
 		transformer.transform(new SAXSource(SaxUtils.createInputSource(input)), expected);
-		assertXMLEqual(expected.toString(), request.getPayloadAsString());
+		assertThat(request.getPayloadAsString()).and(expected.toString()).areSimilar();
 	}
 
 	@Test
@@ -106,7 +104,7 @@ public class PayloadTransformingInterceptorTest {
 		Assert.assertTrue("Invalid interceptor result", result);
 		StringResult expected = new StringResult();
 		transformer.transform(new SAXSource(SaxUtils.createInputSource(output)), expected);
-		assertXMLEqual(expected.toString(), response.getPayloadAsString());
+		assertThat(response.getPayloadAsString()).and(expected.toString()).ignoreWhitespace().areSimilar();
 	}
 
 	@Test
@@ -122,7 +120,7 @@ public class PayloadTransformingInterceptorTest {
 		Assert.assertTrue("Invalid interceptor result", result);
 		StringResult expected = new StringResult();
 		transformer.transform(new SAXSource(SaxUtils.createInputSource(input)), expected);
-		assertXMLEqual(expected.toString(), response.getPayloadAsString());
+		assertThat(response.getPayloadAsString()).and(expected.toString()).areSimilar();
 	}
 
 	@Test
@@ -140,8 +138,7 @@ public class PayloadTransformingInterceptorTest {
 		transformer.transform(new SAXSource(SaxUtils.createInputSource(output)), expected);
 		StringResult result = new StringResult();
 		transformer.transform(message.getPayloadSource(), result);
-		assertXMLEqual(expected.toString(), result.toString());
-
+		assertThat(result.toString()).and(expected.toString()).ignoreWhitespace().areSimilar();
 	}
 
 	@Test
@@ -158,8 +155,7 @@ public class PayloadTransformingInterceptorTest {
 		transformer.transform(new SAXSource(SaxUtils.createInputSource(output)), expected);
 		StringResult result = new StringResult();
 		transformer.transform(message.getPayloadSource(), result);
-		assertXMLEqual(expected.toString(), result.toString());
-
+		assertThat(result.toString()).and(expected.toString()).ignoreWhitespace().areSimilar();
 	}
 
 	@Test

--- a/spring-ws-core/src/test/java/org/springframework/ws/soap/AbstractSoapBodyTestCase.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/soap/AbstractSoapBodyTestCase.java
@@ -27,7 +27,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 
-import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
+import static org.xmlunit.assertj.XmlAssert.assertThat;
 import static org.junit.Assert.*;
 
 public abstract class AbstractSoapBodyTestCase extends AbstractSoapElementTestCase {
@@ -77,7 +77,7 @@ public abstract class AbstractSoapBodyTestCase extends AbstractSoapElementTestCa
 	protected void assertPayloadEqual(String expectedPayload) throws Exception {
 		StringResult result = new StringResult();
 		transformer.transform(soapBody.getPayloadSource(), result);
-		assertXMLEqual("Invalid payload contents", expectedPayload, result.toString());
+		assertThat(result.toString()).and(expectedPayload).areSimilar();
 	}
 
 }

--- a/spring-ws-core/src/test/java/org/springframework/ws/soap/AbstractSoapHeaderTestCase.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/soap/AbstractSoapHeaderTestCase.java
@@ -24,7 +24,7 @@ import org.springframework.xml.transform.StringSource;
 
 import org.junit.Test;
 
-import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
+import static org.xmlunit.assertj.XmlAssert.assertThat;
 import static org.junit.Assert.*;
 
 public abstract class AbstractSoapHeaderTestCase extends AbstractSoapElementTestCase {
@@ -82,9 +82,7 @@ public abstract class AbstractSoapHeaderTestCase extends AbstractSoapElementTest
 		assertEquals("Invalid qName for element", qName, headerElement.getName());
 		StringResult result = new StringResult();
 		transformer.transform(headerElement.getSource(), result);
-		assertXMLEqual("Invalid contents of header element",
-				"<spring:localName xmlns:spring='http://www.springframework.org'><spring:content/></spring:localName>",
-				result.toString());
+		assertThat(result.toString()).and("<spring:localName xmlns:spring='http://www.springframework.org'><spring:content/></spring:localName>").areSimilar();
 		assertFalse("header element iterator has too many elements", iterator.hasNext());
 	}
 
@@ -137,8 +135,6 @@ public abstract class AbstractSoapHeaderTestCase extends AbstractSoapElementTest
 	protected void assertHeaderElementEqual(SoapHeaderElement headerElement, String expected) throws Exception {
 		StringResult result = new StringResult();
 		transformer.transform(headerElement.getSource(), result);
-		assertXMLEqual("Invalid contents of header element", expected, result.toString());
+		assertThat(result.toString()).and(expected).areSimilar();
 	}
-
-
 }

--- a/spring-ws-core/src/test/java/org/springframework/ws/soap/AbstractSoapMessageTestCase.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/soap/AbstractSoapMessageTestCase.java
@@ -39,7 +39,7 @@ import org.springframework.xml.transform.StringResult;
 import org.springframework.xml.validation.XmlValidator;
 import org.springframework.xml.validation.XmlValidatorFactory;
 
-import static org.custommonkey.xmlunit.XMLAssert.*;
+import static org.xmlunit.assertj.XmlAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -123,7 +123,7 @@ public abstract class AbstractSoapMessageTestCase extends AbstractMimeMessageTes
 		transformer.transform(streamingMessage.getPayloadSource(), result);
 
 		String expected = "<root xmlns='http://springframework.org'><child>Foo</child></root>";
-		assertXMLEqual(expected, result.toString());
+		assertThat(result.toString()).and(expected).areSimilar();
 
 		soapMessage.writeTo(new ByteArrayOutputStream());
 	}

--- a/spring-ws-core/src/test/java/org/springframework/ws/soap/addressing/AbstractWsAddressingTestCase.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/soap/addressing/AbstractWsAddressingTestCase.java
@@ -23,13 +23,12 @@ import javax.xml.soap.MimeHeaders;
 import javax.xml.soap.SOAPConstants;
 import javax.xml.soap.SOAPException;
 
-import org.custommonkey.xmlunit.XMLUnit;
 import org.junit.Before;
 import org.w3c.dom.Document;
 
 import org.springframework.ws.soap.saaj.SaajSoapMessage;
 
-import static org.custommonkey.xmlunit.XMLUnit.compareXML;
+import static org.xmlunit.assertj.XmlAssert.assertThat;
 import static org.junit.Assert.*;
 
 public abstract class AbstractWsAddressingTestCase {
@@ -39,9 +38,7 @@ public abstract class AbstractWsAddressingTestCase {
 	@Before
 	public void createMessageFactory() throws Exception {
 		messageFactory = MessageFactory.newInstance(SOAPConstants.SOAP_1_2_PROTOCOL);
-		XMLUnit.setIgnoreWhitespace(true);
 	}
-
 
 	protected SaajSoapMessage loadSaajMessage(String fileName) throws SOAPException, IOException {
 		MimeHeaders mimeHeaders = new MimeHeaders();
@@ -56,15 +53,9 @@ public abstract class AbstractWsAddressingTestCase {
 		}
 	}
 
-	protected void assertXMLEqual(String message, SaajSoapMessage expected, SaajSoapMessage result) {
+	protected void assertXMLSimilar(SaajSoapMessage expected, SaajSoapMessage result) {
 		Document expectedDocument = expected.getSaajMessage().getSOAPPart();
 		Document resultDocument = result.getSaajMessage().getSOAPPart();
-		org.custommonkey.xmlunit.XMLAssert.assertXMLEqual(message, expectedDocument, resultDocument);
-	}
-
-	protected void assertXMLSimilar(String message, SaajSoapMessage expected, SaajSoapMessage result) {
-		Document expectedDocument = expected.getSaajMessage().getSOAPPart();
-		Document resultDocument = result.getSaajMessage().getSOAPPart();
-		org.custommonkey.xmlunit.XMLAssert.assertXMLEqual(compareXML(expectedDocument, resultDocument), false);
+		assertThat(resultDocument).and(expectedDocument).ignoreWhitespace().areSimilar();
 	}
 }

--- a/spring-ws-core/src/test/java/org/springframework/ws/soap/addressing/client/AbstractActionCallbackTestCase.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/soap/addressing/client/AbstractActionCallbackTestCase.java
@@ -78,7 +78,7 @@ public abstract class AbstractActionCallbackTestCase extends AbstractWsAddressin
 		callback.doWithMessage(message);
 
 		SaajSoapMessage expected = loadSaajMessage(getTestPath() + "/valid.xml");
-		assertXMLSimilar("Invalid message", expected, message);
+		assertXMLSimilar(expected, message);
 
 		verify(strategyMock, connectionMock);
 	}
@@ -100,7 +100,7 @@ public abstract class AbstractActionCallbackTestCase extends AbstractWsAddressin
 		callback.doWithMessage(message);
 
 		SaajSoapMessage expected = loadSaajMessage(getTestPath() + "/valid.xml");
-		assertXMLSimilar("Invalid message", expected, message);
+		assertXMLSimilar(expected, message);
 		verify(strategyMock, connectionMock);
 	}
 
@@ -108,7 +108,7 @@ public abstract class AbstractActionCallbackTestCase extends AbstractWsAddressin
 		SOAPMessage saajMessage = messageFactory.createMessage();
 		SOAPBody saajBody = saajMessage.getSOAPBody();
 		SOAPBodyElement delete = saajBody.addBodyElement(new QName("http://example.com/fabrikam", "Delete"));
-		SOAPElement maxCount = delete.addChildElement(new QName("maxCount"));
+		SOAPElement maxCount = delete.addChildElement("maxCount");
 		maxCount.setTextContent("42");
 		return new SaajSoapMessage(saajMessage);
 	}

--- a/spring-ws-core/src/test/java/org/springframework/ws/soap/addressing/server/AbstractAddressingInterceptorTestCase.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/soap/addressing/server/AbstractAddressingInterceptorTestCase.java
@@ -96,8 +96,7 @@ public abstract class AbstractAddressingInterceptorTestCase extends AbstractWsAd
 		assertFalse("Request with no MessageID handled", result);
 		assertTrue("Message Context has no response", context.hasResponse());
 		SaajSoapMessage expectedResponse = loadSaajMessage(getTestPath() + "/response-no-message-id.xml");
-		assertXMLEqual("Invalid response for message with no MessageID", expectedResponse,
-				(SaajSoapMessage) context.getResponse());
+		assertXMLSimilar(expectedResponse, (SaajSoapMessage) context.getResponse());
 
 		verify(strategyMock);
 	}
@@ -115,8 +114,7 @@ public abstract class AbstractAddressingInterceptorTestCase extends AbstractWsAd
 		assertTrue("Request with no ReplyTo not handled", result);
 		assertTrue("Message Context has no response", context.hasResponse());
 		SaajSoapMessage expectedResponse = loadSaajMessage(getTestPath() + "/response-anonymous.xml");
-		assertXMLEqual("Invalid response for message with invalid MAP", expectedResponse,
-				(SaajSoapMessage) context.getResponse());
+		assertXMLSimilar(expectedResponse, (SaajSoapMessage) context.getResponse());
 
 		verify(strategyMock);
 	}
@@ -133,8 +131,7 @@ public abstract class AbstractAddressingInterceptorTestCase extends AbstractWsAd
 		boolean result = interceptor.handleResponse(context, null);
 		assertTrue("Request with anonymous ReplyTo not handled", result);
 		SaajSoapMessage expectedResponse = loadSaajMessage(getTestPath() + "/response-anonymous.xml");
-		assertXMLEqual("Invalid response for message with invalid MAP", expectedResponse,
-				(SaajSoapMessage) context.getResponse());
+		assertXMLSimilar(expectedResponse, (SaajSoapMessage) context.getResponse());
 
 		verify(strategyMock);
 	}
@@ -162,8 +159,7 @@ public abstract class AbstractAddressingInterceptorTestCase extends AbstractWsAd
 		boolean result = interceptor.handleFault(context, null);
 		assertTrue("Request with anonymous FaultTo not handled", result);
 		SaajSoapMessage expectedResponse = loadSaajMessage(getTestPath() + "/response-fault-to.xml");
-		assertXMLEqual("Invalid response for message with invalid MAP", expectedResponse,
-				(SaajSoapMessage) context.getResponse());
+		assertXMLSimilar(expectedResponse, (SaajSoapMessage) context.getResponse());
 		verify(strategyMock);
 	}
 

--- a/spring-ws-core/src/test/java/org/springframework/ws/soap/addressing/server/AddressingInterceptor10Test.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/soap/addressing/server/AddressingInterceptor10Test.java
@@ -28,6 +28,7 @@ import org.springframework.ws.soap.saaj.SaajSoapMessageFactory;
 
 import static org.easymock.EasyMock.*;
 import static org.junit.Assert.assertTrue;
+import static org.xmlunit.assertj.XmlAssert.assertThat;
 
 public class AddressingInterceptor10Test extends AbstractAddressingInterceptorTestCase {
 
@@ -51,9 +52,7 @@ public class AddressingInterceptor10Test extends AbstractAddressingInterceptorTe
 		assertTrue("Request with no To not handled", result);
 		assertTrue("Message Context has no response", context.hasResponse());
 		SaajSoapMessage expectedResponse = loadSaajMessage(getTestPath() + "/response-anonymous.xml");
-		assertXMLEqual("Invalid response for message with invalid MAP", expectedResponse,
-				(SaajSoapMessage) context.getResponse());
+		assertThat(context.getResponse()).and(expectedResponse).areSimilar();
 		verify(strategyMock);
 	}
-
 }

--- a/spring-ws-core/src/test/java/org/springframework/ws/soap/addressing/server/AnnotationActionMethodEndpointMappingTest.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/soap/addressing/server/AnnotationActionMethodEndpointMappingTest.java
@@ -16,7 +16,6 @@
 
 package org.springframework.ws.soap.addressing.server;
 
-import org.custommonkey.xmlunit.XMLUnit;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.context.support.StaticApplicationContext;
@@ -56,7 +55,6 @@ public class AnnotationActionMethodEndpointMappingTest {
 	@Before
 	public void setUp() throws Exception {
 		messageFactory = MessageFactory.newInstance(SOAPConstants.SOAP_1_2_PROTOCOL);
-		XMLUnit.setIgnoreWhitespace(true);
 		applicationContext = new StaticApplicationContext();
 		applicationContext.registerSingleton("mapping", AnnotationActionEndpointMapping.class);
 		applicationContext.registerSingleton("interceptor", MyInterceptor.class);

--- a/spring-ws-core/src/test/java/org/springframework/ws/soap/axiom/AxiomSoap11MessageFactoryTest.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/soap/axiom/AxiomSoap11MessageFactoryTest.java
@@ -30,12 +30,12 @@ import org.springframework.ws.transport.MockTransportInputStream;
 import org.springframework.ws.transport.TransportInputStream;
 import org.springframework.xml.transform.StringResult;
 
-import org.custommonkey.xmlunit.XMLAssert;
-import org.custommonkey.xmlunit.XMLUnit;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
+
+import static org.xmlunit.assertj.XmlAssert.assertThat;
 
 public class AxiomSoap11MessageFactoryTest extends AbstractSoap11MessageFactoryTestCase {
 
@@ -130,7 +130,6 @@ public class AxiomSoap11MessageFactoryTest extends AbstractSoap11MessageFactoryT
 		StringResult result = new StringResult();
 		transformer.transform(message.getPayloadSource(), result);
 
-		XMLUnit.setIgnoreWhitespace(true);
 		String expectedPayload =
 				"<ns1:sendMessageResponse xmlns:ns1='urn:Sole' xmlns:soapenv='http://schemas.xmlsoap.org/soap/envelope/' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' soapenv:encodingStyle='http://schemas.xmlsoap.org/soap/encoding/'>" +
 						"<sendMessageReturn xsi:type='soapenc:string' xmlns:soapenc='http://schemas.xmlsoap.org/soap/encoding/'>" +
@@ -138,8 +137,6 @@ public class AxiomSoap11MessageFactoryTest extends AbstractSoap11MessageFactoryT
 						"<isStatusOK>true</isStatusOK>" + "<status>0</status>" +
 						"<payLoad><![CDATA[<?xml version='1.0' encoding='UTF-8'?><response>ok</response>]]]]>><![CDATA[</payLoad>" +
 						"</PDresponse>]]></sendMessageReturn>" + "</ns1:sendMessageResponse>";
-		XMLAssert.assertXMLEqual(expectedPayload, result.toString());
-
+		assertThat(result.toString()).and(expectedPayload).areSimilar();
 	}
-
 }

--- a/spring-ws-core/src/test/java/org/springframework/ws/soap/axiom/NonCachingPayloadTest.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/soap/axiom/NonCachingPayloadTest.java
@@ -27,7 +27,7 @@ import org.apache.axiom.soap.SOAPFactory;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
+import static org.xmlunit.assertj.XmlAssert.assertThat;
 
 @SuppressWarnings("Since15")
 public class NonCachingPayloadTest {
@@ -63,7 +63,7 @@ public class NonCachingPayloadTest {
 		String expected = "<soapenv:Body xmlns:soapenv='http://schemas.xmlsoap.org/soap/envelope/'>" +
 				"<root xmlns='http://springframework.org/spring-ws'>" + "<child>text</child>" + "</root></soapenv:Body>"
 				;
-		assertXMLEqual(expected, writer.toString());
+		assertThat(writer.toString()).and(expected).areSimilar();
 	}
 
 	@Test
@@ -85,7 +85,7 @@ public class NonCachingPayloadTest {
 		String expected = "<soapenv:Body xmlns:soapenv='http://schemas.xmlsoap.org/soap/envelope/'>" +
 				"<root xmlns='http://springframework.org/spring-ws'>" + "<child>text</child>" + "</root></soapenv:Body>"
 				;
-		assertXMLEqual(expected, writer.toString());
+		assertThat(writer.toString()).and(expected).areSimilar();
 	}
 
 	@Test
@@ -105,6 +105,6 @@ public class NonCachingPayloadTest {
 
 		String expected = "<soapenv:Body xmlns:soapenv='http://schemas.xmlsoap.org/soap/envelope/'>" +
 				"<root xmlns='http://springframework.org/spring-ws'>" + "<child />" + "</root></soapenv:Body>";
-		assertXMLEqual(expected, writer.toString());
+		assertThat(writer.toString()).and(expected).areSimilar();
 	}
 }

--- a/spring-ws-core/src/test/java/org/springframework/ws/soap/axiom/support/AxiomUtilsTest.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/soap/axiom/support/AxiomUtilsTest.java
@@ -35,13 +35,12 @@ import org.apache.axiom.om.OMXMLBuilderFactory;
 import org.apache.axiom.soap.SOAPEnvelope;
 import org.apache.axiom.soap.SOAPMessage;
 import org.apache.axiom.soap.SOAPModelBuilder;
-import org.custommonkey.xmlunit.XMLUnit;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.w3c.dom.Document;
 
-import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
+import static org.xmlunit.assertj.XmlAssert.assertThat;
 
 public class AxiomUtilsTest {
 
@@ -52,7 +51,6 @@ public class AxiomUtilsTest {
 		OMFactory factory = OMAbstractFactory.getOMFactory();
 		OMNamespace namespace = factory.createOMNamespace("http://www.springframework.org", "prefix");
 		element = factory.createOMElement("element", namespace);
-		XMLUnit.setIgnoreWhitespace(true);
 	}
 
 	@Test
@@ -117,7 +115,7 @@ public class AxiomUtilsTest {
 
 		Document result = AxiomUtils.toDocument(soapMessage.getSOAPEnvelope());
 
-		assertXMLEqual("Invalid document generated from SOAPEnvelope", expected, result);
+		assertThat(result).and(expected).areSimilar();
 	}
 
 	@Test
@@ -137,6 +135,6 @@ public class AxiomUtilsTest {
 		envelope.serialize(writer);
 		String result = writer.toString();
 
-		assertXMLEqual("Invalid SOAPEnvelope generated from document", expected, result);
+		assertThat(result).and(expected).areSimilar();
 	}
 }

--- a/spring-ws-core/src/test/java/org/springframework/ws/soap/saaj/SaajSoap11MessageTest.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/soap/saaj/SaajSoap11MessageTest.java
@@ -32,7 +32,7 @@ import org.springframework.ws.soap.soap11.AbstractSoap11MessageTestCase;
 import org.springframework.xml.transform.StringResult;
 import org.springframework.xml.transform.StringSource;
 
-import static org.custommonkey.xmlunit.XMLAssert.*;
+import static org.xmlunit.assertj.XmlAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -64,7 +64,7 @@ public class SaajSoap11MessageTest extends AbstractSoap11MessageTestCase {
 		Source source = soapMessage.getPayloadSource();
 		StringResult result = new StringResult();
 		transformer.transform(source, result);
-		assertXMLEqual("Invalid source", "<child/>", result.toString());
+		assertThat(result.toString()).and("<child/>").areSimilar();
 	}
 
 	@Test
@@ -75,7 +75,7 @@ public class SaajSoap11MessageTest extends AbstractSoap11MessageTestCase {
 		Source source = soapMessage.getPayloadSource();
 		StringResult result = new StringResult();
 		transformer.transform(source, result);
-		assertXMLEqual("Invalid source", "<child/>", result.toString());
+		assertThat(result.toString()).and("<child/>").areSimilar();
 	}
 
 	@Test

--- a/spring-ws-core/src/test/java/org/springframework/ws/soap/saaj/SaajSoap12MessageTest.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/soap/saaj/SaajSoap12MessageTest.java
@@ -27,7 +27,7 @@ import org.springframework.ws.soap.soap12.AbstractSoap12MessageTestCase;
 import org.springframework.xml.transform.StringResult;
 import org.springframework.xml.transform.StringSource;
 
-import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
+import static org.xmlunit.assertj.XmlAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -58,7 +58,7 @@ public class SaajSoap12MessageTest extends AbstractSoap12MessageTestCase {
 		Source source = soapMessage.getPayloadSource();
 		StringResult result = new StringResult();
 		transformer.transform(source, result);
-		assertXMLEqual("Invalid source", "<child/>", result.toString());
+		assertThat(result.toString()).and("<child/>").areSimilar();
 	}
 
 	public void testGetPayloadSourceText() throws Exception {
@@ -67,7 +67,7 @@ public class SaajSoap12MessageTest extends AbstractSoap12MessageTestCase {
 		Source source = soapMessage.getPayloadSource();
 		StringResult result = new StringResult();
 		transformer.transform(source, result);
-		assertXMLEqual("Invalid source", "<child/>", result.toString());
+		assertThat(result.toString()).and("<child/>").areSimilar();
 	}
 
 	public void testGetPayloadResult() throws Exception {

--- a/spring-ws-core/src/test/java/org/springframework/ws/soap/saaj/support/SaajUtilsTest.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/soap/saaj/support/SaajUtilsTest.java
@@ -36,7 +36,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.w3c.dom.Document;
 
-import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
+import static org.xmlunit.assertj.XmlAssert.assertThat;
 
 public class SaajUtilsTest {
 
@@ -125,7 +125,7 @@ public class SaajUtilsTest {
 		Document document = builder.parse(getClass().getResourceAsStream("soapMessage.xml"));
 		SOAPMessage soapMessage =
 				SaajUtils.loadMessage(new ClassPathResource("soapMessage.xml", getClass()), messageFactory);
-		assertXMLEqual(soapMessage.getSOAPPart(), document);
+		assertThat(document).and(soapMessage.getSOAPPart()).areSimilar();
 	}
 
 	@Test

--- a/spring-ws-core/src/test/java/org/springframework/ws/soap/saaj/support/SaajXmlReaderTest.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/soap/saaj/support/SaajXmlReaderTest.java
@@ -31,7 +31,7 @@ import org.junit.Test;
 import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
 
-import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
+import static org.xmlunit.assertj.XmlAssert.assertThat;
 
 public class SaajXmlReaderTest {
 
@@ -59,7 +59,7 @@ public class SaajXmlReaderTest {
 		transformer.transform(source, result);
 		DOMResult expected = new DOMResult();
 		transformer.transform(new DOMSource(message.getSOAPPart().getEnvelope()), expected);
-		assertXMLEqual((Document) expected.getNode(), (Document) result.getNode());
+		assertThat(result.getNode()).and(expected.getNode()).areSimilar();
 	}
 
 	@Test
@@ -71,6 +71,6 @@ public class SaajXmlReaderTest {
 		transformer.transform(source, result);
 		DOMResult expected = new DOMResult();
 		transformer.transform(new DOMSource(message.getSOAPPart().getEnvelope()), expected);
-		assertXMLEqual((Document) expected.getNode(), (Document) result.getNode());
+		assertThat(result.getNode()).and(expected.getNode()).areSimilar();
 	}
 }

--- a/spring-ws-core/src/test/java/org/springframework/ws/soap/server/endpoint/interceptor/PayloadValidatingInterceptorTest.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/soap/server/endpoint/interceptor/PayloadValidatingInterceptorTest.java
@@ -54,7 +54,7 @@ import org.springframework.ws.transport.TransportInputStream;
 import org.springframework.xml.validation.ValidationErrorHandler;
 import org.springframework.xml.xsd.SimpleXsdSchema;
 
-import static org.custommonkey.xmlunit.XMLAssert.*;
+import static org.xmlunit.assertj.XmlAssert.assertThat;
 
 public class PayloadValidatingInterceptorTest {
 
@@ -302,14 +302,12 @@ public class PayloadValidatingInterceptorTest {
 		interceptor.handleRequestValidationErrors(messageContext, exceptions);
 		ByteArrayOutputStream os = new ByteArrayOutputStream();
 		messageContext.getResponse().writeTo(os);
-		assertXMLEqual(
-				"<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\">" + "<soapenv:Header/>" + "<soapenv:Body>" +
+		assertThat(os.toString()).and("<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\">" + "<soapenv:Header/>" + "<soapenv:Body>" +
 						"<soapenv:Fault>" + "<faultcode>soapenv:Client</faultcode>" +
 						"<faultstring xml:lang='en'>Validation error</faultstring>" + "<detail>" +
 						"<spring-ws:ValidationError xmlns:spring-ws=\"http://springframework.org/spring-ws\">Message 1</spring-ws:ValidationError>" +
 						"<spring-ws:ValidationError xmlns:spring-ws=\"http://springframework.org/spring-ws\">Message 2</spring-ws:ValidationError>" +
-						"</detail>" + "</soapenv:Fault>" + "</soapenv:Body>" + "</soapenv:Envelope>", os.toString());
-
+						"</detail>" + "</soapenv:Fault>" + "</soapenv:Body>" + "</soapenv:Envelope>").areSimilar();
 	}
 
 	@Test

--- a/spring-ws-core/src/test/java/org/springframework/ws/soap/soap11/AbstractSoap11BodyTestCase.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/soap/soap11/AbstractSoap11BodyTestCase.java
@@ -29,7 +29,7 @@ import org.springframework.xml.transform.StringSource;
 
 import org.junit.Test;
 
-import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
+import static org.xmlunit.assertj.XmlAssert.assertThat;
 import static org.junit.Assert.*;
 
 public abstract class AbstractSoap11BodyTestCase extends AbstractSoapBodyTestCase {
@@ -48,8 +48,7 @@ public abstract class AbstractSoap11BodyTestCase extends AbstractSoapBodyTestCas
 	public void testGetSource() throws Exception {
 		StringResult result = new StringResult();
 		transformer.transform(soapBody.getSource(), result);
-		assertXMLEqual("Invalid contents of body", "<Body xmlns='http://schemas.xmlsoap.org/soap/envelope/' />",
-				result.toString());
+		assertThat(result.toString()).and("<Body xmlns='http://schemas.xmlsoap.org/soap/envelope/' />").areSimilar();
 	}
 
 	@Test

--- a/spring-ws-core/src/test/java/org/springframework/ws/soap/soap11/AbstractSoap11EnvelopeTestCase.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/soap/soap11/AbstractSoap11EnvelopeTestCase.java
@@ -24,7 +24,7 @@ import org.springframework.xml.transform.StringResult;
 
 import org.junit.Test;
 
-import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
+import static org.xmlunit.assertj.XmlAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 
 public abstract class AbstractSoap11EnvelopeTestCase extends AbstractSoapEnvelopeTestCase {
@@ -40,8 +40,6 @@ public abstract class AbstractSoap11EnvelopeTestCase extends AbstractSoapEnvelop
 	public void testGetContent() throws Exception {
 		StringResult result = new StringResult();
 		transformer.transform(soapEnvelope.getSource(), result);
-		assertXMLEqual("<Envelope xmlns='http://schemas.xmlsoap.org/soap/envelope/'><Header/><Body/></Envelope>",
-				result.toString());
+		assertThat(result.toString()).and("<Envelope xmlns='http://schemas.xmlsoap.org/soap/envelope/'><Header/><Body/></Envelope>").areSimilar();
 	}
-
 }

--- a/spring-ws-core/src/test/java/org/springframework/ws/soap/soap11/AbstractSoap11HeaderTestCase.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/soap/soap11/AbstractSoap11HeaderTestCase.java
@@ -19,7 +19,7 @@ package org.springframework.ws.soap.soap11;
 import java.util.Iterator;
 import javax.xml.namespace.QName;
 
-import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
+import static org.xmlunit.assertj.XmlAssert.assertThat;
 import static org.junit.Assert.*;
 import org.junit.Test;
 
@@ -47,8 +47,7 @@ public abstract class AbstractSoap11HeaderTestCase extends AbstractSoapHeaderTes
 	public void testGetSource() throws Exception {
 		StringResult result = new StringResult();
 		transformer.transform(soapHeader.getSource(), result);
-		assertXMLEqual("Invalid contents of header",
-				"<SOAP-ENV:Header xmlns:SOAP-ENV='http://schemas.xmlsoap.org/soap/envelope/' />", result.toString());
+		assertThat(result.toString()).and("<SOAP-ENV:Header xmlns:SOAP-ENV='http://schemas.xmlsoap.org/soap/envelope/' />").areSimilar();
 	}
 
 	@Test

--- a/spring-ws-core/src/test/java/org/springframework/ws/soap/soap11/AbstractSoap11MessageTestCase.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/soap/soap11/AbstractSoap11MessageTestCase.java
@@ -37,7 +37,7 @@ import org.springframework.ws.soap.SoapVersion;
 import org.springframework.ws.transport.MockTransportOutputStream;
 import org.springframework.xml.transform.StringSource;
 
-import static org.custommonkey.xmlunit.XMLAssert.*;
+import static org.xmlunit.assertj.XmlAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -66,9 +66,7 @@ public abstract class AbstractSoap11MessageTestCase extends AbstractSoapMessageT
 		soapMessage.setSoapAction(soapAction);
 		soapMessage.writeTo(tos);
 		String result = bos.toString("UTF-8");
-		assertXMLEqual(
-				"<" + getNS() + ":Envelope xmlns:" + getNS() + "='http://schemas.xmlsoap.org/soap/envelope/'>" + getHeader() + "<" + getNS() + ":Body><payload xmlns='http://www.springframework.org' /></" + getNS() + ":Body></" + getNS() + ":Envelope>",
-				result);
+		assertThat(result).and("<" + getNS() + ":Envelope xmlns:" + getNS() + "='http://schemas.xmlsoap.org/soap/envelope/'>" + getHeader() + "<" + getNS() + ":Body><payload xmlns='http://www.springframework.org' /></" + getNS() + ":Body></" + getNS() + ":Envelope>").areSimilar();
 		String contentType = tos.getHeaders().get("Content-Type");
 		assertTrue("Invalid Content-Type set", contentType.indexOf(SoapVersion.SOAP_11.getContentType()) != -1);
 		String resultSoapAction = tos.getHeaders().get("SOAPAction");
@@ -115,7 +113,7 @@ public abstract class AbstractSoap11MessageTestCase extends AbstractSoapMessageT
 
 		Document result = soapMessage.getDocument();
 
-		assertXMLEqual(expected, result);
+		assertThat(result).and(expected).areSimilar();
 	}
 
 	@Override
@@ -131,9 +129,7 @@ public abstract class AbstractSoap11MessageTestCase extends AbstractSoapMessageT
 		soapMessage.writeTo(bos);
 
 		String result = bos.toString("UTF-8");
-		assertXMLEqual(
-				"<" + getNS() + ":Envelope xmlns:" + getNS() + "='http://schemas.xmlsoap.org/soap/envelope/'>" + getHeader() + "<" + getNS() + ":Body><payload xmlns='http://www.springframework.org' /></" + getNS() + ":Body></" + getNS() + ":Envelope>",
-				result);
+		assertThat(result).and("<" + getNS() + ":Envelope xmlns:" + getNS() + "='http://schemas.xmlsoap.org/soap/envelope/'>" + getHeader() + "<" + getNS() + ":Body><payload xmlns='http://www.springframework.org' /></" + getNS() + ":Body></" + getNS() + ":Envelope>").areSimilar();
 	}
 
 	@Override
@@ -156,9 +152,7 @@ public abstract class AbstractSoap11MessageTestCase extends AbstractSoapMessageT
 		soapMessage.writeTo(bos);
 
 		String result = bos.toString("UTF-8");
-		assertXMLEqual(
-				"<" + getNS() + ":Envelope xmlns:" + getNS() + "='http://schemas.xmlsoap.org/soap/envelope/'>" + getHeader() + "<" + getNS() + ":Body><payload xmlns='http://www.springframework.org' /></" + getNS() + ":Body></" + getNS() + ":Envelope>",
-				result);
+		assertThat(result).and("<" + getNS() + ":Envelope xmlns:" + getNS() + "='http://schemas.xmlsoap.org/soap/envelope/'>" + getHeader() + "<" + getNS() + ":Body><payload xmlns='http://www.springframework.org' /></" + getNS() + ":Body></" + getNS() + ":Envelope>").areSimilar();
 	}
 
 }

--- a/spring-ws-core/src/test/java/org/springframework/ws/soap/soap12/AbstractSoap12BodyTestCase.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/soap/soap12/AbstractSoap12BodyTestCase.java
@@ -30,7 +30,7 @@ import org.springframework.xml.transform.StringSource;
 
 import org.junit.Test;
 
-import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
+import static org.xmlunit.assertj.XmlAssert.assertThat;
 import static org.junit.Assert.*;
 
 public abstract class AbstractSoap12BodyTestCase extends AbstractSoapBodyTestCase {
@@ -50,8 +50,7 @@ public abstract class AbstractSoap12BodyTestCase extends AbstractSoapBodyTestCas
 	public void testGetSource() throws Exception {
 		StringResult result = new StringResult();
 		transformer.transform(soapBody.getSource(), result);
-		assertXMLEqual("Invalid contents of body", "<Body xmlns='http://www.w3.org/2003/05/soap-envelope' />",
-				result.toString());
+		assertThat(result.toString()).and("<Body xmlns='http://www.w3.org/2003/05/soap-envelope' />").areSimilar();
 	}
 
 	@Test
@@ -61,12 +60,11 @@ public abstract class AbstractSoap12BodyTestCase extends AbstractSoapBodyTestCas
 				fault.getFaultCode());
 		StringResult result = new StringResult();
 		transformer.transform(fault.getSource(), result);
-		assertXMLEqual("Invalid contents of body",
-				"<soapenv:Fault xmlns:soapenv='http://www.w3.org/2003/05/soap-envelope'>" +
+		assertThat(result.toString()).and("<soapenv:Fault xmlns:soapenv='http://www.w3.org/2003/05/soap-envelope'>" +
 						"<soapenv:Code><soapenv:Value>" + soapBody.getName().getPrefix() +
 						":MustUnderstand</soapenv:Value></soapenv:Code>" +
 						"<soapenv:Reason><soapenv:Text xml:lang='en'>SOAP Must Understand Error</soapenv:Text>" +
-						"</soapenv:Reason></soapenv:Fault>", result.toString());
+						"</soapenv:Reason></soapenv:Fault>").areSimilar();
 	}
 
 	@Test
@@ -76,12 +74,11 @@ public abstract class AbstractSoap12BodyTestCase extends AbstractSoapBodyTestCas
 				fault.getFaultCode());
 		StringResult result = new StringResult();
 		transformer.transform(fault.getSource(), result);
-		assertXMLEqual("Invalid contents of body",
-				"<soapenv:Fault xmlns:soapenv='http://www.w3.org/2003/05/soap-envelope'>" +
+		assertThat(result.toString()).and("<soapenv:Fault xmlns:soapenv='http://www.w3.org/2003/05/soap-envelope'>" +
 						"<soapenv:Code><soapenv:Value>" + soapBody.getName().getPrefix() +
 						":Sender</soapenv:Value></soapenv:Code>" +
 						"<soapenv:Reason><soapenv:Text xml:lang='en'>faultString</soapenv:Text></soapenv:Reason>" +
-						"</soapenv:Fault>", result.toString());
+						"</soapenv:Fault>").areSimilar();
 	}
 
 	@Test
@@ -91,12 +88,11 @@ public abstract class AbstractSoap12BodyTestCase extends AbstractSoapBodyTestCas
 				fault.getFaultCode());
 		StringResult result = new StringResult();
 		transformer.transform(fault.getSource(), result);
-		assertXMLEqual("Invalid contents of body",
-				"<soapenv:Fault xmlns:soapenv='http://www.w3.org/2003/05/soap-envelope'>" +
+		assertThat(result.toString()).and("<soapenv:Fault xmlns:soapenv='http://www.w3.org/2003/05/soap-envelope'>" +
 						"<soapenv:Code><soapenv:Value>" + soapBody.getName().getPrefix() +
 						":Receiver</soapenv:Value></soapenv:Code>" +
 						"<soapenv:Reason><soapenv:Text xml:lang='en'>faultString</soapenv:Text></soapenv:Reason>" +
-						"</soapenv:Fault>", result.toString());
+						"</soapenv:Fault>").areSimilar();
 	}
 
 	@Test
@@ -109,13 +105,12 @@ public abstract class AbstractSoap12BodyTestCase extends AbstractSoapBodyTestCas
 		transformer.transform(detailContents, detailElement.getResult());
 		StringResult result = new StringResult();
 		transformer.transform(fault.getSource(), result);
-		assertXMLEqual("Invalid source for body",
-				"<soapenv:Fault xmlns:soapenv='http://www.w3.org/2003/05/soap-envelope'>" +
-						"<soapenv:Code><soapenv:Value>" + soapBody.getName().getPrefix() + ":Receiver</soapenv:Value>" +
-						"</soapenv:Code>" +
-						"<soapenv:Reason><soapenv:Text xml:lang='en'>faultString</soapenv:Text></soapenv:Reason>" +
-						"<soapenv:Detail><prefix:localPart xmlns:prefix='namespace'><detailContents xmlns='namespace'/>" +
-						"</prefix:localPart></soapenv:Detail></soapenv:Fault>", result.toString());
+		assertThat(result.toString()).and("<soapenv:Fault xmlns:soapenv='http://www.w3.org/2003/05/soap-envelope'>" +
+				"<soapenv:Code><soapenv:Value>" + soapBody.getName().getPrefix() + ":Receiver</soapenv:Value>" +
+				"</soapenv:Code>" +
+				"<soapenv:Reason><soapenv:Text xml:lang='en'>faultString</soapenv:Text></soapenv:Reason>" +
+				"<soapenv:Detail><prefix:localPart xmlns:prefix='namespace'><detailContents xmlns='namespace'/>" +
+				"</prefix:localPart></soapenv:Detail></soapenv:Fault>").areSimilar();
 	}
 
 	@Test
@@ -126,13 +121,12 @@ public abstract class AbstractSoap12BodyTestCase extends AbstractSoapBodyTestCas
 		transformer.transform(new StringSource("<detailContents xmlns='namespace'/>"), detail.getResult());
 		StringResult result = new StringResult();
 		transformer.transform(fault.getSource(), result);
-		assertXMLEqual("Invalid source for body",
-				"<soapenv:Fault xmlns:soapenv='http://www.w3.org/2003/05/soap-envelope'>" +
+		assertThat(result.toString()).and("<soapenv:Fault xmlns:soapenv='http://www.w3.org/2003/05/soap-envelope'>" +
 						"<soapenv:Code><soapenv:Value>" + soapBody.getName().getPrefix() + ":Receiver</soapenv:Value>" +
 						"</soapenv:Code>" +
 						"<soapenv:Reason><soapenv:Text xml:lang='en'>faultString</soapenv:Text></soapenv:Reason>" +
 						"<soapenv:Detail>" + "<detailContents xmlns='namespace'/>" +
-						"<detailContents xmlns='namespace'/>" + "</soapenv:Detail></soapenv:Fault>", result.toString());
+						"<detailContents xmlns='namespace'/>" + "</soapenv:Detail></soapenv:Fault>").areSimilar();
 	}
 
 	@Test
@@ -150,14 +144,13 @@ public abstract class AbstractSoap12BodyTestCase extends AbstractSoapBodyTestCas
 		assertFalse("Subcode found", iterator.hasNext());
 		StringResult result = new StringResult();
 		transformer.transform(fault.getSource(), result);
-		assertXMLEqual("Invalid source for body",
-				"<soapenv:Fault xmlns:soapenv='http://www.w3.org/2003/05/soap-envelope'>" +
+		assertThat(result.toString()).and("<soapenv:Fault xmlns:soapenv='http://www.w3.org/2003/05/soap-envelope'>" +
 						"<soapenv:Code><soapenv:Value>" + soapBody.getName().getPrefix() + ":Receiver</soapenv:Value>" +
 						"<soapenv:Subcode><soapenv:Value xmlns:spring-ws='http://www.springframework.org'>spring-ws:Subcode1</soapenv:Value>" +
 						"<soapenv:Subcode><soapenv:Value xmlns:spring-ws='http://www.springframework.org'>spring-ws:Subcode2</soapenv:Value>" +
 						"</soapenv:Subcode></soapenv:Subcode></soapenv:Code>" +
 						"<soapenv:Reason><soapenv:Text xml:lang='en'>faultString</soapenv:Text></soapenv:Reason>" +
-						"</soapenv:Fault>", result.toString());
+						"</soapenv:Fault>").areSimilar();
 	}
 
 }

--- a/spring-ws-core/src/test/java/org/springframework/ws/soap/soap12/AbstractSoap12EnvelopeTestCase.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/soap/soap12/AbstractSoap12EnvelopeTestCase.java
@@ -24,7 +24,7 @@ import org.springframework.xml.transform.StringResult;
 
 import org.junit.Test;
 
-import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
+import static org.xmlunit.assertj.XmlAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 
 public abstract class AbstractSoap12EnvelopeTestCase extends AbstractSoapEnvelopeTestCase {
@@ -39,8 +39,7 @@ public abstract class AbstractSoap12EnvelopeTestCase extends AbstractSoapEnvelop
 	public void testGetSource() throws Exception {
 		StringResult result = new StringResult();
 		transformer.transform(soapEnvelope.getSource(), result);
-		assertXMLEqual("<Envelope xmlns='http://www.w3.org/2003/05/soap-envelope'><Header/>" + "<Body/></Envelope>",
-				result.toString());
+		assertThat(result.toString()).and("<Envelope xmlns='http://www.w3.org/2003/05/soap-envelope'><Header/>" + "<Body/></Envelope>").areSimilar();
 	}
 
 }

--- a/spring-ws-core/src/test/java/org/springframework/ws/soap/soap12/AbstractSoap12HeaderTestCase.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/soap/soap12/AbstractSoap12HeaderTestCase.java
@@ -19,7 +19,7 @@ package org.springframework.ws.soap.soap12;
 import java.util.Iterator;
 import javax.xml.namespace.QName;
 
-import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
+import static org.xmlunit.assertj.XmlAssert.assertThat;
 import static org.junit.Assert.*;
 import org.junit.Test;
 
@@ -45,8 +45,7 @@ public abstract class AbstractSoap12HeaderTestCase extends AbstractSoapHeaderTes
 	public void testGetSource() throws Exception {
 		StringResult result = new StringResult();
 		transformer.transform(soapHeader.getSource(), result);
-		assertXMLEqual("Invalid contents of header", "<Header xmlns='http://www.w3.org/2003/05/soap-envelope' />",
-				result.toString());
+		assertThat(result.toString()).and("<Header xmlns='http://www.w3.org/2003/05/soap-envelope' />").areSimilar();
 	}
 
 	@Test
@@ -56,9 +55,9 @@ public abstract class AbstractSoap12HeaderTestCase extends AbstractSoapHeaderTes
 		soap12Header.addNotUnderstoodHeaderElement(headerName);
 		StringResult result = new StringResult();
 		transformer.transform(soapHeader.getSource(), result);
-		assertXMLEqual("Invalid contents of header", "<Header xmlns='http://www.w3.org/2003/05/soap-envelope' >" +
+		assertThat(result.toString()).and("<Header xmlns='http://www.w3.org/2003/05/soap-envelope' >" +
 				"<NotUnderstood qname='spring-ws:NotUnderstood' xmlns:spring-ws='http://www.springframework.org' />" +
-				"</Header>", result.toString());
+				"</Header>").areSimilar();
 	}
 
 	@Test

--- a/spring-ws-core/src/test/java/org/springframework/ws/soap/soap12/AbstractSoap12MessageTestCase.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/soap/soap12/AbstractSoap12MessageTestCase.java
@@ -38,7 +38,7 @@ import org.springframework.ws.transport.MockTransportOutputStream;
 import org.springframework.ws.transport.TransportConstants;
 import org.springframework.xml.transform.StringSource;
 
-import static org.custommonkey.xmlunit.XMLAssert.*;
+import static org.xmlunit.assertj.XmlAssert.assertThat;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -68,9 +68,7 @@ public abstract class AbstractSoap12MessageTestCase extends AbstractSoapMessageT
 		soapMessage.setSoapAction(soapAction);
 		soapMessage.writeTo(tos);
 		String result = bos.toString("UTF-8");
-		assertXMLEqual(
-				"<" + getNS() + ":Envelope xmlns:" + getNS() + "='http://www.w3.org/2003/05/soap-envelope'>" + getHeader() + "<" + getNS() + ":Body><payload xmlns='http://www.springframework.org' /></" + getNS() + ":Body></" + getNS() + ":Envelope>",
-				result);
+		assertThat(result).and("<" + getNS() + ":Envelope xmlns:" + getNS() + "='http://www.w3.org/2003/05/soap-envelope'>" + getHeader() + "<" + getNS() + ":Body><payload xmlns='http://www.springframework.org' /></" + getNS() + ":Body></" + getNS() + ":Envelope>").areSimilar();
 		String contentType = tos.getHeaders().get(TransportConstants.HEADER_CONTENT_TYPE);
 		assertTrue("Invalid Content-Type set",
 				contentType.contains(SoapVersion.SOAP_12.getContentType()));
@@ -119,7 +117,7 @@ public abstract class AbstractSoap12MessageTestCase extends AbstractSoapMessageT
 
 		Document result = soapMessage.getDocument();
 
-		assertXMLEqual(expected, result);
+		assertThat(result).and(expected).areSimilar();
 	}
 
 	@Override
@@ -135,9 +133,7 @@ public abstract class AbstractSoap12MessageTestCase extends AbstractSoapMessageT
 		soapMessage.writeTo(bos);
 
 		String result = bos.toString("UTF-8");
-		assertXMLEqual(
-				"<" + getNS() + ":Envelope xmlns:" + getNS() + "='http://www.w3.org/2003/05/soap-envelope'>" + getHeader() + "<" + getNS() + ":Body><payload xmlns='http://www.springframework.org' /></" + getNS() + ":Body></" + getNS() + ":Envelope>",
-				result);
+		assertThat(result).and("<" + getNS() + ":Envelope xmlns:" + getNS() + "='http://www.w3.org/2003/05/soap-envelope'>" + getHeader() + "<" + getNS() + ":Body><payload xmlns='http://www.springframework.org' /></" + getNS() + ":Body></" + getNS() + ":Envelope>").areSimilar();
 	}
 
 	@Override
@@ -160,12 +156,6 @@ public abstract class AbstractSoap12MessageTestCase extends AbstractSoapMessageT
 		soapMessage.writeTo(bos);
 
 		String result = bos.toString("UTF-8");
-		assertXMLEqual(
-				"<" + getNS() + ":Envelope xmlns:" + getNS() + "='http://www.w3.org/2003/05/soap-envelope'>" + getHeader() + "<" + getNS() + ":Body><payload xmlns='http://www.springframework.org' /></" + getNS() + ":Body></" + getNS() + ":Envelope>",
-				result);
+		assertThat(result).and("<" + getNS() + ":Envelope xmlns:" + getNS() + "='http://www.w3.org/2003/05/soap-envelope'>" + getHeader() + "<" + getNS() + ":Body><payload xmlns='http://www.springframework.org' /></" + getNS() + ":Body></" + getNS() + ":Envelope>").areSimilar();
 	}
-
-
-
-
 }

--- a/spring-ws-core/src/test/java/org/springframework/ws/transport/http/AbstractHttpWebServiceMessageSenderIntegrationTestCase.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/transport/http/AbstractHttpWebServiceMessageSenderIntegrationTestCase.java
@@ -36,7 +36,6 @@ import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMResult;
 
-import org.custommonkey.xmlunit.XMLUnit;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -57,7 +56,7 @@ import org.springframework.ws.transport.support.FreePortScanner;
 import org.springframework.xml.transform.StringResult;
 import org.springframework.xml.transform.StringSource;
 
-import static org.custommonkey.xmlunit.XMLAssert.*;
+import static org.xmlunit.assertj.XmlAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 
 public abstract class AbstractHttpWebServiceMessageSenderIntegrationTestCase<T extends AbstractHttpWebServiceMessageSender> {
@@ -106,7 +105,6 @@ public abstract class AbstractHttpWebServiceMessageSenderIntegrationTestCase<T e
 		if (messageSender instanceof InitializingBean) {
 			((InitializingBean) messageSender).afterPropertiesSet();
 		}
-		XMLUnit.setIgnoreWhitespace(true);
 		saajMessageFactory = MessageFactory.newInstance(SOAPConstants.SOAP_1_1_PROTOCOL);
 		messageFactory = new SaajSoapMessageFactory(saajMessageFactory);
 		transformerFactory = TransformerFactory.newInstance();
@@ -209,7 +207,7 @@ public abstract class AbstractHttpWebServiceMessageSenderIntegrationTestCase<T e
 			StringResult result = new StringResult();
 			Transformer transformer = transformerFactory.newTransformer();
 			transformer.transform(response.getPayloadSource(), result);
-			assertXMLEqual("Invalid response", RESPONSE, result.toString());
+			assertThat(result.toString()).and(RESPONSE).areSimilar();
 		}
 		finally {
 			connection.close();
@@ -276,7 +274,7 @@ public abstract class AbstractHttpWebServiceMessageSenderIntegrationTestCase<T e
 						httpServletRequest.getHeader(REQUEST_HEADER_NAME));
 				String receivedRequest =
 						new String(FileCopyUtils.copyToByteArray(httpServletRequest.getInputStream()), "UTF-8");
-				assertXMLEqual("Invalid request received", SOAP_REQUEST, receivedRequest);
+				assertThat(receivedRequest).and(SOAP_REQUEST).areSimilar();
 				if (gzip) {
 					assertEquals("Invalid Accept-Encoding header value received on server side", "gzip",
 							httpServletRequest.getHeader("Accept-Encoding"));

--- a/spring-ws-core/src/test/java/org/springframework/ws/transport/http/HttpServletConnectionTest.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/transport/http/HttpServletConnectionTest.java
@@ -24,7 +24,7 @@ import javax.xml.soap.SOAPMessage;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerFactory;
 
-import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
+import static org.xmlunit.assertj.XmlAssert.assertThat;
 import org.junit.Assert;
 import static org.junit.Assert.assertEquals;
 import org.junit.Before;
@@ -82,7 +82,7 @@ public class HttpServletConnectionTest {
 		StringResult result = new StringResult();
 		Transformer transformer = transformerFactory.newTransformer();
 		transformer.transform(message.getPayloadSource(), result);
-		assertXMLEqual("Invalid message", CONTENT, result.toString());
+		assertThat(result.toString()).and(CONTENT).areSimilar();
 		SOAPMessage saajMessage = message.getSaajMessage();
 		String[] headerValues = saajMessage.getMimeHeaders().getHeader(HEADER_NAME);
 		Assert.assertNotNull("Response has no header", headerValues);
@@ -103,7 +103,7 @@ public class HttpServletConnectionTest {
 
 		assertEquals("Invalid header", HEADER_VALUE,
 				httpServletResponse.getHeader(HEADER_NAME));
-		assertXMLEqual("Invalid content", SOAP_CONTENT, httpServletResponse.getContentAsString());
+		assertThat(httpServletResponse.getContentAsString()).and(SOAP_CONTENT).areSimilar();
 	}
 
 	@Test

--- a/spring-ws-core/src/test/java/org/springframework/ws/transport/http/MessageDispatcherServletIntegrationTest.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/transport/http/MessageDispatcherServletIntegrationTest.java
@@ -36,7 +36,7 @@ import org.mortbay.jetty.Server;
 import org.mortbay.jetty.servlet.Context;
 import org.mortbay.jetty.servlet.ServletHolder;
 
-import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
+import static org.xmlunit.assertj.XmlAssert.assertThat;
 
 /**
  * @author Arjen Poutsma
@@ -89,8 +89,6 @@ public class MessageDispatcherServletIntegrationTest {
 
 		SOAPMessage response = connection.call(request, url);
 
-		assertXMLEqual(request.getSOAPPart(), response.getSOAPPart());
+		assertThat(response.getSOAPPart()).and(request.getSOAPPart()).areSimilar();
 	}
-
-
 }

--- a/spring-ws-core/src/test/java/org/springframework/ws/transport/http/MessageDispatcherServletTest.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/transport/http/MessageDispatcherServletTest.java
@@ -37,13 +37,12 @@ import org.springframework.ws.server.endpoint.mapping.PayloadRootQNameEndpointMa
 import org.springframework.ws.soap.server.endpoint.SimpleSoapExceptionResolver;
 import org.springframework.ws.wsdl.wsdl11.SimpleWsdl11Definition;
 
-import org.custommonkey.xmlunit.XMLUnit;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.w3c.dom.Document;
 
-import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
+import static org.xmlunit.assertj.XmlAssert.assertThat;
 
 public class MessageDispatcherServletTest {
 
@@ -95,8 +94,7 @@ public class MessageDispatcherServletTest {
 		DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
 		Document result = documentBuilder.parse(new ByteArrayInputStream(response.getContentAsByteArray()));
 		Document expected = documentBuilder.parse(getClass().getResourceAsStream("wsdl11-input.wsdl"));
-		XMLUnit.setIgnoreWhitespace(true);
-		assertXMLEqual("Invalid WSDL written", expected, result);
+		assertThat(result).and(expected).areSimilar();
 	}
 
 	private static class DetectWebApplicationContext extends StaticWebApplicationContext {

--- a/spring-ws-core/src/test/java/org/springframework/ws/transport/http/WsdlDefinitionHandlerAdapterTest.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/transport/http/WsdlDefinitionHandlerAdapterTest.java
@@ -35,7 +35,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.w3c.dom.Document;
 
-import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
+import static org.xmlunit.assertj.XmlAssert.assertThat;
 import static org.easymock.EasyMock.*;
 
 public class WsdlDefinitionHandlerAdapterTest {
@@ -66,7 +66,7 @@ public class WsdlDefinitionHandlerAdapterTest {
 		replay(definitionMock);
 
 		adapter.handle(request, response, definitionMock);
-		assertXMLEqual(definition, response.getContentAsString());
+		assertThat(response.getContentAsString()).and(definition).areSimilar();
 
 		verify(definitionMock);
 	}
@@ -104,7 +104,7 @@ public class WsdlDefinitionHandlerAdapterTest {
 		Document result = documentBuilder.parse(getClass().getResourceAsStream("wsdl11-input.wsdl"));
 		adapter.transformLocations(result, request);
 		Document expectedDocument = documentBuilder.parse(getClass().getResourceAsStream("wsdl11-expected.wsdl"));
-		assertXMLEqual("Invalid result", expectedDocument, result);
+		assertThat(result).and(expectedDocument).areSimilar();
 
 		verify(definitionMock);
 	}
@@ -192,7 +192,7 @@ public class WsdlDefinitionHandlerAdapterTest {
 
 		documentBuilder = documentBuilderFactory.newDocumentBuilder();
 		Document expectedDocument = documentBuilder.parse(getClass().getResourceAsStream("echo-input.wsdl"));
-		assertXMLEqual("Invalid WSDL returned", expectedDocument, resultingDocument);
+		assertThat(resultingDocument).and(expectedDocument).areSimilar();
 	}
 
 	@Test
@@ -222,7 +222,7 @@ public class WsdlDefinitionHandlerAdapterTest {
 
 		documentBuilder = documentBuilderFactory.newDocumentBuilder();
 		Document expectedDocument = documentBuilder.parse(getClass().getResourceAsStream("echo-expected.wsdl"));
-		assertXMLEqual("Invalid WSDL returned", expectedDocument, resultingDocument);
+		assertThat(resultingDocument).and(expectedDocument).areSimilar();
 	}
 
 }

--- a/spring-ws-core/src/test/java/org/springframework/ws/transport/http/XsdSchemaHandlerAdapterTest.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/transport/http/XsdSchemaHandlerAdapterTest.java
@@ -33,7 +33,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.w3c.dom.Document;
 
-import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
+import static org.xmlunit.assertj.XmlAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 
 public class XsdSchemaHandlerAdapterTest {
@@ -69,7 +69,7 @@ public class XsdSchemaHandlerAdapterTest {
 		schema.afterPropertiesSet();
 		adapter.handle(request, response, schema);
 		String expected = new String(FileCopyUtils.copyToByteArray(single.getFile()));
-		assertXMLEqual(expected, response.getContentAsString());
+		assertThat(response.getContentAsString()).and(expected).areSimilar();
 	}
 
 	@Test
@@ -106,7 +106,7 @@ public class XsdSchemaHandlerAdapterTest {
 
 		documentBuilder = documentBuilderFactory.newDocumentBuilder();
 		Document expectedDocument = documentBuilder.parse(getClass().getResourceAsStream("importing-expected.xsd"));
-		assertXMLEqual("Invalid WSDL returned", expectedDocument, resultingDocument);
+		assertThat(resultingDocument).and(expectedDocument).areSimilar();
 	}
 
 }

--- a/spring-ws-core/src/test/java/org/springframework/ws/wsdl/wsdl11/DefaultWsdl11DefinitionTest.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/wsdl/wsdl11/DefaultWsdl11DefinitionTest.java
@@ -27,12 +27,11 @@ import org.springframework.core.io.Resource;
 import org.springframework.xml.xsd.SimpleXsdSchema;
 import org.springframework.xml.xsd.commons.CommonsXsdSchemaCollection;
 
-import org.custommonkey.xmlunit.XMLUnit;
 import org.junit.Before;
 import org.junit.Test;
 import org.w3c.dom.Document;
 
-import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
+import static org.xmlunit.assertj.XmlAssert.assertThat;
 
 public class DefaultWsdl11DefinitionTest {
 
@@ -50,7 +49,6 @@ public class DefaultWsdl11DefinitionTest {
 		DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
 		documentBuilderFactory.setNamespaceAware(true);
 		documentBuilder = documentBuilderFactory.newDocumentBuilder();
-		XMLUnit.setIgnoreWhitespace(true);
 	}
 
 	@Test
@@ -72,8 +70,7 @@ public class DefaultWsdl11DefinitionTest {
 		Document result = (Document) domResult.getNode();
 		Document expected = documentBuilder.parse(getClass().getResourceAsStream("single-inline.wsdl"));
 
-		assertXMLEqual("Invalid WSDL built", expected, result);
-
+		assertThat(result).and(expected).ignoreWhitespace().areSimilar();
 	}
 
 	@Test
@@ -94,7 +91,7 @@ public class DefaultWsdl11DefinitionTest {
 
 		Document result = (Document) domResult.getNode();
 		Document expected = documentBuilder.parse(getClass().getResourceAsStream("include-inline.wsdl"));
-		assertXMLEqual("Invalid WSDL built", expected, result);
+		assertThat(result).and(expected).ignoreWhitespace().areSimilar();
 	}
 
 	@Test
@@ -115,7 +112,7 @@ public class DefaultWsdl11DefinitionTest {
 
 		Document result = (Document) domResult.getNode();
 		Document expected = documentBuilder.parse(getClass().getResourceAsStream("import-inline.wsdl"));
-		assertXMLEqual("Invalid WSDL built", expected, result);
+		assertThat(result).and(expected).ignoreWhitespace().areSimilar();
 	}
 
 	@Test
@@ -139,9 +136,6 @@ public class DefaultWsdl11DefinitionTest {
 		Document result = (Document) domResult.getNode();
 		Document expected = documentBuilder.parse(getClass().getResourceAsStream("soap-11-12.wsdl"));
 
-		assertXMLEqual("Invalid WSDL built", expected, result);
-
+		assertThat(result).and(expected).ignoreWhitespace().areSimilar();
 	}
-
-
 }

--- a/spring-ws-core/src/test/java/org/springframework/ws/wsdl/wsdl11/Wsdl4jDefinitionTest.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/wsdl/wsdl11/Wsdl4jDefinitionTest.java
@@ -27,14 +27,13 @@ import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMResult;
 
-import org.custommonkey.xmlunit.XMLUnit;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
 
-import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
+import static org.xmlunit.assertj.XmlAssert.assertThat;
 
 public class Wsdl4jDefinitionTest {
 
@@ -44,7 +43,6 @@ public class Wsdl4jDefinitionTest {
 
 	@Before
 	public void setUp() throws Exception {
-		XMLUnit.setIgnoreWhitespace(true);
 		WSDLFactory factory = WSDLFactory.newInstance();
 		WSDLReader reader = factory.newWSDLReader();
 		InputStream is = getClass().getResourceAsStream("complete.wsdl");
@@ -68,6 +66,6 @@ public class Wsdl4jDefinitionTest {
 		documentBuilderFactory.setNamespaceAware(true);
 		DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
 		Document expected = documentBuilder.parse(getClass().getResourceAsStream("complete.wsdl"));
-		assertXMLEqual(expected, (Document) result.getNode());
+		assertThat(result.getNode()).and(expected).ignoreWhitespace().areSimilar();
 	}
 }

--- a/spring-ws-core/src/test/resources/org/springframework/ws/soap/addressing/10/response-anonymous.xml
+++ b/spring-ws-core/src/test/resources/org/springframework/ws/soap/addressing/10/response-anonymous.xml
@@ -1,9 +1,9 @@
 <env:Envelope xmlns:env="http://www.w3.org/2003/05/soap-envelope" xmlns:wsa="http://www.w3.org/2005/08/addressing">
     <env:Header>
-        <wsa:MessageID>uid:1234</wsa:MessageID>
-        <wsa:RelatesTo>http://example.com/someuniquestring</wsa:RelatesTo>
         <wsa:To env:mustUnderstand="true">http://www.w3.org/2005/08/addressing/anonymous</wsa:To>
         <wsa:Action>urn:replyAction</wsa:Action>
+        <wsa:MessageID>uid:1234</wsa:MessageID>
+        <wsa:RelatesTo>http://example.com/someuniquestring</wsa:RelatesTo>
     </env:Header>
     <env:Body/>
 </env:Envelope>

--- a/spring-ws-core/src/test/resources/org/springframework/ws/soap/addressing/10/response-fault-to.xml
+++ b/spring-ws-core/src/test/resources/org/springframework/ws/soap/addressing/10/response-fault-to.xml
@@ -1,9 +1,9 @@
 <env:Envelope xmlns:env="http://www.w3.org/2003/05/soap-envelope" xmlns:wsa="http://www.w3.org/2005/08/addressing">
     <env:Header>
-        <wsa:MessageID>uid:1234</wsa:MessageID>
-        <wsa:RelatesTo>http://example.com/someuniquestring</wsa:RelatesTo>
         <wsa:To env:mustUnderstand="true">http://www.w3.org/2005/08/addressing/anonymous</wsa:To>
         <wsa:Action>urn:faultAction</wsa:Action>
+        <wsa:MessageID>uid:1234</wsa:MessageID>
+        <wsa:RelatesTo>http://example.com/someuniquestring</wsa:RelatesTo>
     </env:Header>
     <env:Body>
         <env:Fault>

--- a/spring-ws-core/src/test/resources/org/springframework/ws/soap/addressing/10/valid.xml
+++ b/spring-ws-core/src/test/resources/org/springframework/ws/soap/addressing/10/valid.xml
@@ -1,11 +1,11 @@
 <S:Envelope xmlns:S="http://www.w3.org/2003/05/soap-envelope" xmlns:wsa="http://www.w3.org/2005/08/addressing">
     <S:Header>
-        <wsa:MessageID>http://example.com/someuniquestring</wsa:MessageID>
+        <wsa:To S:mustUnderstand="true">mailto:fabrikam@example.com</wsa:To>
         <wsa:ReplyTo>
             <wsa:Address>http://example.com/business/client1</wsa:Address>
         </wsa:ReplyTo>
-        <wsa:To S:mustUnderstand="true">mailto:fabrikam@example.com</wsa:To>
         <wsa:Action>http://example.com/fabrikam/mail/Delete</wsa:Action>
+        <wsa:MessageID>http://example.com/someuniquestring</wsa:MessageID>
     </S:Header>
     <S:Body>
         <f:Delete xmlns:f="http://example.com/fabrikam">

--- a/spring-ws-core/src/test/resources/org/springframework/ws/soap/addressing/200408/response-anonymous.xml
+++ b/spring-ws-core/src/test/resources/org/springframework/ws/soap/addressing/200408/response-anonymous.xml
@@ -1,10 +1,10 @@
 <env:Envelope xmlns:env="http://www.w3.org/2003/05/soap-envelope"
               xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing">
     <env:Header>
-        <wsa:MessageID>uid:1234</wsa:MessageID>
-        <wsa:RelatesTo>uuid:aaaabbbb-cccc-dddd-eeee-ffffffffffff</wsa:RelatesTo>
         <wsa:To env:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</wsa:To>
         <wsa:Action>urn:replyAction</wsa:Action>
+        <wsa:MessageID>uid:1234</wsa:MessageID>
+        <wsa:RelatesTo>uuid:aaaabbbb-cccc-dddd-eeee-ffffffffffff</wsa:RelatesTo>
     </env:Header>
     <env:Body/>
 </env:Envelope>

--- a/spring-ws-core/src/test/resources/org/springframework/ws/soap/addressing/200408/response-fault-to.xml
+++ b/spring-ws-core/src/test/resources/org/springframework/ws/soap/addressing/200408/response-fault-to.xml
@@ -1,10 +1,10 @@
 <env:Envelope xmlns:env="http://www.w3.org/2003/05/soap-envelope"
               xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing">
     <env:Header>
-        <wsa:MessageID>uid:1234</wsa:MessageID>
-        <wsa:RelatesTo>uuid:aaaabbbb-cccc-dddd-eeee-ffffffffffff</wsa:RelatesTo>
         <wsa:To env:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</wsa:To>
         <wsa:Action>urn:faultAction</wsa:Action>
+        <wsa:MessageID>uid:1234</wsa:MessageID>
+        <wsa:RelatesTo>uuid:aaaabbbb-cccc-dddd-eeee-ffffffffffff</wsa:RelatesTo>
     </env:Header>
     <env:Body>
         <env:Fault>

--- a/spring-ws-core/src/test/resources/org/springframework/ws/soap/addressing/200408/valid.xml
+++ b/spring-ws-core/src/test/resources/org/springframework/ws/soap/addressing/200408/valid.xml
@@ -1,12 +1,12 @@
 <S:Envelope xmlns:S="http://www.w3.org/2003/05/soap-envelope"
             xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing">
     <S:Header>
-        <wsa:MessageID>http://example.com/someuniquestring</wsa:MessageID>
+        <wsa:To S:mustUnderstand="true">mailto:fabrikam@example.com</wsa:To>
         <wsa:ReplyTo>
             <wsa:Address>http://example.com/business/client1</wsa:Address>
         </wsa:ReplyTo>
-        <wsa:To S:mustUnderstand="true">mailto:fabrikam@example.com</wsa:To>
         <wsa:Action>http://example.com/fabrikam/mail/Delete</wsa:Action>
+        <wsa:MessageID>http://example.com/someuniquestring</wsa:MessageID>
     </S:Header>
     <S:Body>
         <f:Delete xmlns:f="http://example.com/fabrikam">

--- a/spring-ws-support/src/test/java/org/springframework/ws/transport/jms/JmsIntegrationTest.java
+++ b/spring-ws-support/src/test/java/org/springframework/ws/transport/jms/JmsIntegrationTest.java
@@ -23,7 +23,7 @@ import org.springframework.ws.client.core.WebServiceTemplate;
 import org.springframework.xml.transform.StringResult;
 import org.springframework.xml.transform.StringSource;
 
-import org.custommonkey.xmlunit.XMLAssert;
+import static org.xmlunit.assertj.XmlAssert.assertThat;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -44,7 +44,7 @@ public class JmsIntegrationTest {
 		String content = "<root xmlns='http://springframework.org/spring-ws'><child/></root>";
 		StringResult result = new StringResult();
 		webServiceTemplate.sendSourceAndReceiveToResult(new StringSource(content), result);
-		XMLAssert.assertXMLEqual("Invalid content received", content, result.toString());
+		assertThat(result.toString()).and(content).areSimilar();
 	}
 
 	@Test
@@ -53,6 +53,6 @@ public class JmsIntegrationTest {
 		String content = "<root xmlns='http://springframework.org/spring-ws'><child/></root>";
 		StringResult result = new StringResult();
 		webServiceTemplate.sendSourceAndReceiveToResult(url, new StringSource(content), result);
-		XMLAssert.assertXMLEqual("Invalid content received", content, result.toString());
+		assertThat(result.toString()).and(content).areSimilar();
 	}
 }

--- a/spring-ws-support/src/test/java/org/springframework/ws/transport/mail/MailIntegrationTest.java
+++ b/spring-ws-support/src/test/java/org/springframework/ws/transport/mail/MailIntegrationTest.java
@@ -24,7 +24,7 @@ import org.springframework.ws.client.core.WebServiceTemplate;
 import org.springframework.xml.transform.StringResult;
 import org.springframework.xml.transform.StringSource;
 
-import org.custommonkey.xmlunit.XMLAssert;
+import static org.xmlunit.assertj.XmlAssert.assertThat;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -56,8 +56,7 @@ public class MailIntegrationTest {
 		applicationContext.close();
 		assertEquals("Server mail message not deleted", 0, Mailbox.get("server@example.com").size());
 		assertEquals("No client mail message received", 1, Mailbox.get("client@example.com").size());
-		XMLAssert.assertXMLEqual("Invalid content received", content, result.toString());
-
+		assertThat(result.toString()).and(content).areSimilar();
 	}
 
 }

--- a/spring-ws-test/pom.xml
+++ b/spring-ws-test/pom.xml
@@ -35,8 +35,8 @@
 		</dependency>
 
 		<dependency>
-			<groupId>xmlunit</groupId>
-			<artifactId>xmlunit</artifactId>
+			<groupId>org.xmlunit</groupId>
+			<artifactId>xmlunit-core</artifactId>
 			<version>${xmlunit.version}</version>
 		</dependency>
 

--- a/spring-ws-test/src/main/java/org/springframework/ws/test/support/matcher/DiffMatcher.java
+++ b/spring-ws-test/src/main/java/org/springframework/ws/test/support/matcher/DiffMatcher.java
@@ -18,28 +18,24 @@ package org.springframework.ws.test.support.matcher;
 
 import java.io.IOException;
 
-import org.custommonkey.xmlunit.Diff;
-import org.custommonkey.xmlunit.XMLUnit;
 import static org.springframework.ws.test.support.AssertionErrors.assertTrue;
 
 import org.springframework.ws.WebServiceMessage;
+import org.xmlunit.diff.Diff;
 
 /**
  * Implementation of {@link WebServiceMessageMatcher} based on XMLUnit's {@link Diff}.
  *
  * @author Arjen Poutsma
+ * @author Leandro Quiroga
  * @since 2.0
  */
 public abstract class DiffMatcher implements WebServiceMessageMatcher {
 
-	static {
-		XMLUnit.setIgnoreWhitespace(true);
-	}
-
 	@Override
 	public final void match(WebServiceMessage message) throws IOException, AssertionError {
 		Diff diff = createDiff(message);
-		assertTrue("Messages are different, " + diff.toString(), diff.similar(), "Payload", message.getPayloadSource());
+		assertTrue("Messages are different, " + diff.toString(), !diff.hasDifferences(), "Payload", message.getPayloadSource());
 	}
 
 	/**

--- a/spring-ws-test/src/main/java/org/springframework/ws/test/support/matcher/PayloadDiffMatcher.java
+++ b/spring-ws-test/src/main/java/org/springframework/ws/test/support/matcher/PayloadDiffMatcher.java
@@ -24,8 +24,11 @@ import org.springframework.util.Assert;
 import org.springframework.ws.WebServiceMessage;
 import org.springframework.xml.transform.TransformerHelper;
 
-import org.custommonkey.xmlunit.Diff;
 import org.w3c.dom.Document;
+import org.xmlunit.builder.DiffBuilder;
+import org.xmlunit.diff.DefaultNodeMatcher;
+import org.xmlunit.diff.Diff;
+import org.xmlunit.diff.ElementSelectors;
 
 import static org.springframework.ws.test.support.AssertionErrors.fail;
 
@@ -34,6 +37,7 @@ import static org.springframework.ws.test.support.AssertionErrors.fail;
  *
  * @author Arjen Poutsma
  * @author Lukas Krecan
+ * @author Leandro Quiroga
  * @since 2.0
  */
 public class PayloadDiffMatcher extends DiffMatcher {
@@ -59,7 +63,7 @@ public class PayloadDiffMatcher extends DiffMatcher {
 	protected Diff createDiff(Source payload) {
 		Document expectedDocument = createDocumentFromSource(expected);
 		Document actualDocument = createDocumentFromSource(payload);
-		return new Diff(expectedDocument, actualDocument);
+		return DiffBuilder.compare(expectedDocument).withTest(actualDocument).withNodeMatcher(new DefaultNodeMatcher(ElementSelectors.byName)).ignoreWhitespace().checkForSimilar().build();
 	}
 
 	private Document createDocumentFromSource(Source source) {

--- a/spring-ws-test/src/test/java/org/springframework/ws/test/client/MockWebServiceServerTest.java
+++ b/spring-ws-test/src/test/java/org/springframework/ws/test/client/MockWebServiceServerTest.java
@@ -43,7 +43,7 @@ import org.springframework.xml.transform.StringSource;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
+import static org.xmlunit.assertj.XmlAssert.assertThat;
 import static org.easymock.EasyMock.*;
 import static org.junit.Assert.assertNotNull;
 import static org.springframework.ws.test.client.RequestMatchers.*;
@@ -142,7 +142,7 @@ public class MockWebServiceServerTest {
 
 		StringResult result = new StringResult();
 		template.sendSourceAndReceiveToResult(request, result);
-		assertXMLEqual(result.toString(), response.toString());
+		assertThat(response.toString()).and(result.toString()).areSimilar();
 	}
 
 	@Test(expected = AssertionError.class)
@@ -264,7 +264,7 @@ public class MockWebServiceServerTest {
 
 		StringResult result = new StringResult();
 		template.sendSourceAndReceiveToResult(request, result);
-		assertXMLEqual(result.toString(), response.toString());
+		assertThat(response.toString()).and(result.toString()).areSimilar();
 
 		server.verify();
 	}
@@ -279,7 +279,7 @@ public class MockWebServiceServerTest {
 
 		StringResult result = new StringResult();
 		template.sendSourceAndReceiveToResult(request, result);
-		assertXMLEqual(result.toString(), response.toString());
+		assertThat(response.toString()).and(result.toString()).areSimilar();
 
 		server.expect(anything()).andRespond(withPayload(response));
 	}

--- a/spring-ws-test/src/test/java/org/springframework/ws/test/client/ResponseCreatorsTest.java
+++ b/spring-ws-test/src/test/java/org/springframework/ws/test/client/ResponseCreatorsTest.java
@@ -36,7 +36,7 @@ import org.springframework.xml.transform.TransformerHelper;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
+import static org.xmlunit.assertj.XmlAssert.assertThat;
 import static org.junit.Assert.*;
 
 public class ResponseCreatorsTest {
@@ -58,8 +58,7 @@ public class ResponseCreatorsTest {
 
 		WebServiceMessage response = responseCreator.createResponse(null, null, messageFactory);
 
-		assertXMLEqual(payload, getPayloadAsString(response));
-
+		assertThat(getPayloadAsString(response)).and(payload).areSimilar();
 	}
 
 	@Test
@@ -70,7 +69,7 @@ public class ResponseCreatorsTest {
 
 		WebServiceMessage response = responseCreator.createResponse(null, null, messageFactory);
 
-		assertXMLEqual(payload, getPayloadAsString(response));
+		assertThat(getPayloadAsString(response)).and(payload).areSimilar();
 	}
 	
 	@Test
@@ -84,7 +83,7 @@ public class ResponseCreatorsTest {
 		String envelope = xmlBuilder.toString();
 		ResponseCreator responseCreator = ResponseCreators.withSoapEnvelope(new StringSource(envelope));
 		WebServiceMessage response = responseCreator.createResponse(null, null, messageFactory);
-		assertXMLEqual(envelope, getSoapEnvelopeAsString((SoapMessage)response));
+		assertThat(getSoapEnvelopeAsString((SoapMessage)response)).and(envelope).areSimilar();
 	}
 	
 	@Test
@@ -98,7 +97,7 @@ public class ResponseCreatorsTest {
 		String envelope = xmlBuilder.toString();
 		ResponseCreator responseCreator = ResponseCreators.withSoapEnvelope(new ByteArrayResource(envelope.getBytes("UTF-8")));
 		WebServiceMessage response = responseCreator.createResponse(null, null, messageFactory);
-		assertXMLEqual(envelope, getSoapEnvelopeAsString((SoapMessage)response));
+		assertThat(getSoapEnvelopeAsString((SoapMessage)response)).and(envelope).areSimilar();
 	}
 
 	@Test

--- a/spring-xml/src/test/java/org/springframework/xml/dom/DomContentHandlerTest.java
+++ b/spring-xml/src/test/java/org/springframework/xml/dom/DomContentHandlerTest.java
@@ -28,7 +28,7 @@ import org.xml.sax.InputSource;
 import org.xml.sax.XMLReader;
 import org.xml.sax.helpers.XMLReaderFactory;
 
-import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
+import static org.xmlunit.assertj.XmlAssert.assertThat;
 
 public class DomContentHandlerTest {
 
@@ -69,7 +69,7 @@ public class DomContentHandlerTest {
 		expected = documentBuilder.parse(new InputSource(new StringReader(XML_1)));
 		xmlReader.setContentHandler(handler);
 		xmlReader.parse(new InputSource(new StringReader(XML_1)));
-		assertXMLEqual("Invalid result", expected, result);
+		assertThat(result).and(expected).areSimilar();
 	}
 
 	@Test
@@ -78,7 +78,7 @@ public class DomContentHandlerTest {
 		expected = documentBuilder.parse(new InputSource(new StringReader(XML_1)));
 		xmlReader.setContentHandler(handler);
 		xmlReader.parse(new InputSource(new StringReader(XML_1)));
-		assertXMLEqual("Invalid result", expected, result);
+		assertThat(result).and(expected).areSimilar();
 	}
 
 	@Test
@@ -89,7 +89,6 @@ public class DomContentHandlerTest {
 		expected = documentBuilder.parse(new InputSource(new StringReader(XML_2_EXPECTED)));
 		xmlReader.setContentHandler(handler);
 		xmlReader.parse(new InputSource(new StringReader(XML_2_SNIPPET)));
-		assertXMLEqual("Invalid result", expected, result);
-
+		assertThat(result).and(expected).areSimilar();
 	}
 }

--- a/spring-xml/src/test/java/org/springframework/xml/transform/StringResultTest.java
+++ b/spring-xml/src/test/java/org/springframework/xml/transform/StringResultTest.java
@@ -25,7 +25,7 @@ import org.junit.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
-import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
+import static org.xmlunit.assertj.XmlAssert.assertThat;
 
 public class StringResultTest {
 
@@ -37,7 +37,7 @@ public class StringResultTest {
 		Transformer transformer = TransformerFactory.newInstance().newTransformer();
 		StringResult result = new StringResult();
 		transformer.transform(new DOMSource(document), result);
-		assertXMLEqual("Invalid result", "<prefix:localName xmlns:prefix='namespace'/>", result.toString());
+		assertThat(result.toString()).and("<prefix:localName xmlns:prefix='namespace'/>").areSimilar();
 	}
 
 }

--- a/spring-xml/src/test/java/org/springframework/xml/transform/TransformerHelperTest.java
+++ b/spring-xml/src/test/java/org/springframework/xml/transform/TransformerHelperTest.java
@@ -19,25 +19,21 @@ package org.springframework.xml.transform;
 import java.io.IOException;
 import javax.xml.transform.Result;
 import javax.xml.transform.Source;
-import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.xml.sax.SAXException;
 
-import static org.custommonkey.xmlunit.XMLAssert.*;
-import static org.easymock.EasyMock.*;
+import static org.xmlunit.assertj.XmlAssert.assertThat;
 
 public class TransformerHelperTest {
 
 	private TransformerHelper helper;
-	private Transformer transformer;
 
 	@Before
 	public void setUp() throws Exception {
 		helper = new TransformerHelper();
-		transformer = createMock(Transformer.class);
 	}
 
 	@Test
@@ -59,7 +55,7 @@ public class TransformerHelperTest {
 
 		helper.transform(source, result);
 
-		assertXMLEqual(xml, result.toString());
+		assertThat(result.toString()).and(xml).areSimilar();
 	}
 
 }

--- a/spring-xml/src/test/java/org/springframework/xml/xsd/AbstractXsdSchemaTestCase.java
+++ b/spring-xml/src/test/java/org/springframework/xml/xsd/AbstractXsdSchemaTestCase.java
@@ -27,7 +27,6 @@ import org.springframework.core.io.Resource;
 import org.springframework.xml.sax.SaxUtils;
 import org.springframework.xml.validation.XmlValidator;
 
-//import org.custommonkey.xmlunit.XMLUnit;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -49,7 +48,6 @@ public abstract class AbstractXsdSchemaTestCase {
 		documentBuilder = documentBuilderFactory.newDocumentBuilder();
 		TransformerFactory transformerFactory = TransformerFactory.newInstance();
 		transformer = transformerFactory.newTransformer();
-//		XMLUnit.setIgnoreWhitespace(true);
 	}
 
 	@Test

--- a/spring-xml/src/test/java/org/springframework/xml/xsd/AbstractXsdSchemaTestCase.java
+++ b/spring-xml/src/test/java/org/springframework/xml/xsd/AbstractXsdSchemaTestCase.java
@@ -27,13 +27,14 @@ import org.springframework.core.io.Resource;
 import org.springframework.xml.sax.SaxUtils;
 import org.springframework.xml.validation.XmlValidator;
 
-import org.custommonkey.xmlunit.XMLUnit;
+//import org.custommonkey.xmlunit.XMLUnit;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.w3c.dom.Document;
 
-import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
+import static org.xmlunit.assertj.XmlAssert.assertThat;
+
 
 public abstract class AbstractXsdSchemaTestCase {
 
@@ -48,7 +49,7 @@ public abstract class AbstractXsdSchemaTestCase {
 		documentBuilder = documentBuilderFactory.newDocumentBuilder();
 		TransformerFactory transformerFactory = TransformerFactory.newInstance();
 		transformer = transformerFactory.newTransformer();
-		XMLUnit.setIgnoreWhitespace(true);
+//		XMLUnit.setIgnoreWhitespace(true);
 	}
 
 	@Test
@@ -62,7 +63,7 @@ public abstract class AbstractXsdSchemaTestCase {
 		DOMResult domResult = new DOMResult();
 		transformer.transform(single.getSource(), domResult);
 		Document result = (Document) domResult.getNode();
-		assertXMLEqual("Invalid Source returned", expected, result);
+		assertThat(result).and(expected).ignoreWhitespace().areSimilar();
 	}
 
 	@Test
@@ -76,7 +77,7 @@ public abstract class AbstractXsdSchemaTestCase {
 		DOMResult domResult = new DOMResult();
 		transformer.transform(including.getSource(), domResult);
 		Document result = (Document) domResult.getNode();
-		assertXMLEqual("Invalid Source returned", expected, result);
+		assertThat(result).and(expected).ignoreWhitespace().areSimilar();
 	}
 
 	@Test
@@ -90,7 +91,7 @@ public abstract class AbstractXsdSchemaTestCase {
 		DOMResult domResult = new DOMResult();
 		transformer.transform(importing.getSource(), domResult);
 		Document result = (Document) domResult.getNode();
-		assertXMLEqual("Invalid Source returned", expected, result);
+		assertThat(result).and(expected).ignoreWhitespace().areSimilar();
 	}
 
 	@Test
@@ -104,7 +105,7 @@ public abstract class AbstractXsdSchemaTestCase {
 		DOMResult domResult = new DOMResult();
 		transformer.transform(importing.getSource(), domResult);
 		Document result = (Document) domResult.getNode();
-		assertXMLEqual("Invalid Source returned", expected, result);
+		assertThat(result).and(expected).ignoreWhitespace().areSimilar();
 	}
 
 	@Test

--- a/spring-xml/src/test/java/org/springframework/xml/xsd/commons/CommonsXsdSchemaCollectionTest.java
+++ b/spring-xml/src/test/java/org/springframework/xml/xsd/commons/CommonsXsdSchemaCollectionTest.java
@@ -152,6 +152,6 @@ public class CommonsXsdSchemaCollectionTest {
 		expected = documentBuilder.parse(SaxUtils.createInputSource(holiday));
 		domResult = new DOMResult();
 		transformer.transform(schemas[1].getSource(), domResult);
-		assertThat(domResult.getNode()).and(expected).ignoreWhitespace().areIdentical();
+		assertThat(domResult.getNode()).and(expected).ignoreWhitespace().areSimilar();
 	}
 }

--- a/spring-xml/src/test/java/org/springframework/xml/xsd/commons/CommonsXsdSchemaCollectionTest.java
+++ b/spring-xml/src/test/java/org/springframework/xml/xsd/commons/CommonsXsdSchemaCollectionTest.java
@@ -29,13 +29,12 @@ import org.springframework.xml.validation.XmlValidator;
 import org.springframework.xml.xsd.AbstractXsdSchemaTestCase;
 import org.springframework.xml.xsd.XsdSchema;
 
-import org.custommonkey.xmlunit.XMLUnit;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.w3c.dom.Document;
 
-import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
+import static org.xmlunit.assertj.XmlAssert.assertThat;
 
 public class CommonsXsdSchemaCollectionTest {
 
@@ -53,7 +52,6 @@ public class CommonsXsdSchemaCollectionTest {
 		DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
 		documentBuilderFactory.setNamespaceAware(true);
 		documentBuilder = documentBuilderFactory.newDocumentBuilder();
-		XMLUnit.setIgnoreWhitespace(true);
 	}
 
 	@Test
@@ -78,14 +76,14 @@ public class CommonsXsdSchemaCollectionTest {
 		Document expected = documentBuilder.parse(SaxUtils.createInputSource(abc));
 		DOMResult domResult = new DOMResult();
 		transformer.transform(schemas[0].getSource(), domResult);
-		assertXMLEqual("Invalid XSD generated", expected, (Document) domResult.getNode());
+		assertThat(domResult.getNode()).and(expected).ignoreWhitespace().areSimilar();
 
 		Assert.assertEquals("Invalid target namespace", "urn:2", schemas[1].getTargetNamespace());
 		Resource cd = new ClassPathResource("CD.xsd", AbstractXsdSchemaTestCase.class);
 		expected = documentBuilder.parse(SaxUtils.createInputSource(cd));
 		domResult = new DOMResult();
 		transformer.transform(schemas[1].getSource(), domResult);
-		assertXMLEqual("Invalid XSD generated", expected, (Document) domResult.getNode());
+		assertThat(domResult.getNode()).and(expected).ignoreWhitespace().areSimilar();
 	}
 
 	@Test
@@ -147,14 +145,13 @@ public class CommonsXsdSchemaCollectionTest {
 		Document expected = documentBuilder.parse(SaxUtils.createInputSource(hr_employee));
 		DOMResult domResult = new DOMResult();
 		transformer.transform(schemas[0].getSource(), domResult);
-		assertXMLEqual("Invalid XSD generated", expected, (Document) domResult.getNode());
+		assertThat(domResult.getNode()).and(expected).ignoreWhitespace().areSimilar();
 
 		Assert.assertEquals("Invalid target namespace", "http://mycompany.com/hr/schemas/holiday", schemas[1].getTargetNamespace());
 		Resource holiday = new ClassPathResource("holiday.xsd", getClass());
 		expected = documentBuilder.parse(SaxUtils.createInputSource(holiday));
 		domResult = new DOMResult();
 		transformer.transform(schemas[1].getSource(), domResult);
-		assertXMLEqual("Invalid XSD generated", expected, (Document) domResult.getNode());
-
+		assertThat(domResult.getNode()).and(expected).ignoreWhitespace().areIdentical();
 	}
 }


### PR DESCRIPTION
Basically I replaced the use of

`org.custommonkey.xmlunit.XMLAssert.assertXMLEqual()`

with

`org.xmlunit.assertj.XmlAssert.assertThat(x).and(y).areSimilar()`

following the example in [https://github.com/xmlunit/xmlunit#comparing-two-documents](https://github.com/xmlunit/xmlunit#comparing-two-documents) using AssertJ.

I also corrected an error at

[https://github.com/spring-projects/spring-ws/compare/master...leaqui:SWS-1035?expand=1#diff-267dffc46eb1bcd24a2daf06428aff1eL59](https://github.com/spring-projects/spring-ws/compare/master...leaqui:SWS-1035?expand=1#diff-267dffc46eb1bcd24a2daf06428aff1eL59)

there, the `assertXMLSimilar()` method, was wrong. It returns the opposite of what is needed. The error resides in the `false` argument of

`org.custommonkey.xmlunit.XMLAssert.assertXMLEqual(compareXML(expectedDocument, resultDocument), false)`

Also, I have to change the order of some tags at

[https://github.com/spring-projects/spring-ws/compare/master...leaqui:SWS-1035?expand=1#diff-66472375685665e43f5a84d2d94670e9](https://github.com/spring-projects/spring-ws/compare/master...leaqui:SWS-1035?expand=1#diff-66472375685665e43f5a84d2d94670e9)

[https://github.com/spring-projects/spring-ws/compare/master...leaqui:SWS-1035?expand=1#diff-e7691ec6d1c488508fb11504c2940815](https://github.com/spring-projects/spring-ws/compare/master...leaqui:SWS-1035?expand=1#diff-e7691ec6d1c488508fb11504c2940815)

[https://github.com/spring-projects/spring-ws/compare/master...leaqui:SWS-1035?expand=1#diff-57144daa10fc56222a5673f414b4d6bd](https://github.com/spring-projects/spring-ws/compare/master...leaqui:SWS-1035?expand=1#diff-57144daa10fc56222a5673f414b4d6bd)

[https://github.com/spring-projects/spring-ws/compare/master...leaqui:SWS-1035?expand=1#diff-74695df9f89dcef0db6c8590fde8c1e3](https://github.com/spring-projects/spring-ws/compare/master...leaqui:SWS-1035?expand=1#diff-74695df9f89dcef0db6c8590fde8c1e3)

[https://github.com/spring-projects/spring-ws/compare/master...leaqui:SWS-1035?expand=1#diff-539160ae71b2fb6cb54315dfee3c7bcc](https://github.com/spring-projects/spring-ws/compare/master...leaqui:SWS-1035?expand=1#diff-539160ae71b2fb6cb54315dfee3c7bcc)

[https://github.com/spring-projects/spring-ws/compare/master...leaqui:SWS-1035?expand=1#diff-f52c5ff62d1a2592fed7ae4b710d5a91](https://github.com/spring-projects/spring-ws/compare/master...leaqui:SWS-1035?expand=1#diff-f52c5ff62d1a2592fed7ae4b710d5a91)

because by default element order is significant in XMLUnit 2.x

Migration of spring-ws-test didn´t need for a major refactor. The biggest changes are at:

[https://github.com/spring-projects/spring-ws/compare/master...leaqui:SWS-1035?expand=1#diff-741b860aab67e4e1290d660e6bd57210](https://github.com/spring-projects/spring-ws/compare/master...leaqui:SWS-1035?expand=1#diff-741b860aab67e4e1290d660e6bd57210)

[https://github.com/spring-projects/spring-ws/compare/master...leaqui:SWS-1035?expand=1#diff-9b4789291a43675fa7cb8a7d64d622f7](https://github.com/spring-projects/spring-ws/compare/master...leaqui:SWS-1035?expand=1#diff-9b4789291a43675fa7cb8a7d64d622f7)
