### PR TITLE
Spring ws can fail on Java 10 due to error in wss4j usage of java api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
 		<commons-io.version>2.5</commons-io.version>
 		<dom4j.version>1.6.1</dom4j.version>
 		<easymock.version>3.6</easymock.version>
-		<ehcache.version>2.10.4</ehcache.version>
+		<ehcache.version>2.10.5</ehcache.version>
 		<httpclient.version>4.5.3</httpclient.version>
 		<javax-mail.version>1.6.0</javax-mail.version>
 		<javax-servlet.version>3.1.0</javax-servlet.version>
@@ -114,10 +114,10 @@
 		<spring-security.version>5.0.8.RELEASE</spring-security.version>
 		<stax.version>1.7.8</stax.version>
 		<sun-mail.version>1.6.0</sun-mail.version>
-		<woodstox.version>4.2.0</woodstox.version>
+		<woodstox.version>5.0.3</woodstox.version>
 		<wsdl4j.version>1.6.3</wsdl4j.version>
-		<wss4j.version>2.2.0</wss4j.version>
-		<xmlsec.version>2.1.0</xmlsec.version>
+		<wss4j.version>2.2.2</wss4j.version>
+		<xmlsec.version>2.1.2</xmlsec.version>
 		<xml-schema-core.version>2.2.2</xml-schema-core.version>
 		<xmlunit.version>1.5</xmlunit.version>
 		<xws-security.version>3.0</xws-security.version>
@@ -187,8 +187,8 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.codehaus.woodstox</groupId>
-			<artifactId>woodstox-core-asl</artifactId>
+			<groupId>com.fasterxml.woodstox</groupId>
+			<artifactId>woodstox-core</artifactId>
 			<version>${woodstox.version}</version>
 			<scope>test</scope>
 		</dependency>

--- a/spring-ws-security/pom.xml
+++ b/spring-ws-security/pom.xml
@@ -115,7 +115,7 @@
 				</exclusion>
 				<exclusion>
 					<groupId>org.codehaus.woodstox</groupId>
-					<artifactId>woodstox-core-asl</artifactId>
+					<artifactId>woodstox-core</artifactId>
 				</exclusion>
 				<exclusion>
 					<groupId>org.apache.santuario</groupId>
@@ -124,6 +124,10 @@
 				<exclusion>
 					<groupId>org.slf4j</groupId>
 					<artifactId>slf4j-api</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>commons-codec</groupId>
+					<artifactId>commons-codec</artifactId>
 				</exclusion>
 			</exclusions>
 		</dependency>


### PR DESCRIPTION
ref.: https://issues.apache.org/jira/browse/WSS-627
(https://issues.apache.org/jira/browse/WSS-605)

This is solved on release 2.2.2 of wss4j.

Although wss4j:2.2.2 is a patch release, I suspect that, since for instance updates to woodstox-core-asl from org.codehaus to com.fasterxml, this can be a breaking change. 

Example stacktrace of failing runtume:
org.w3c.dom.DOMException: WRONG_DOCUMENT_ERR: A node is used in a different document than the one that created it.
at java.xml/com.sun.org.apache.xerces.internal.dom.ParentNode.internalInsertBefore(ParentNode.java:356)
at java.xml/com.sun.org.apache.xerces.internal.dom.ParentNode.insertBefore(ParentNode.java:287)
at java.xml/com.sun.org.apache.xerces.internal.dom.NodeImpl.appendChild(NodeImpl.java:237)
at org.apache.wss4j.dom.util.WSSecurityUtil.prependChildElement(WSSecurityUtil.java:314)
at org.apache.wss4j.dom.util.WSSecurityUtil.findWsseSecurityHeaderBlock(WSSecurityUtil.java:435)
at org.apache.wss4j.dom.message.WSSecHeader.insertSecurityHeader(WSSecHeader.java:165)
at org.apache.wss4j.dom.handler.WSHandler.doSenderAction(WSHandler.java:117)
at org.springframework.ws.soap.security.wss4j2.Wss4jHandler.doSenderAction(Wss4jHandler.java:63)
at org.springframework.ws.soap.security.wss4j2.Wss4jSecurityInterceptor.secureMessage(Wss4jSecurityInterceptor.java:574)
at org.springframework.ws.soap.security.AbstractWsSecurityInterceptor.handleRequest(AbstractWsSecurityInterceptor.java:210)
at org.springframework.ws.client.core.WebServiceTemplate.doSendAndReceive(WebServiceTemplate.java:597)
at org.springframework.ws.client.core.WebServiceTemplate.sendAndReceive(WebServiceTemplate.java:555)
at org.springframework.ws.client.core.WebServiceTemplate.marshalSendAndReceive(WebServiceTemplate.java:390)