### PR TITLE
add try-catch-block for XMLConstants.ACCESS_EXTERNAL_DTD

### DIFF
--- a/spring-xml/src/main/java/org/springframework/xml/transform/TransformerFactoryUtils.java
+++ b/spring-xml/src/main/java/org/springframework/xml/transform/TransformerFactoryUtils.java
@@ -19,11 +19,16 @@ import javax.xml.XMLConstants;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.TransformerFactoryConfigurationError;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
 /**
  * @author Greg Turnquist
  * @since 3.0.5
  */
 public class TransformerFactoryUtils {
+
+	private static final Log log = LogFactory.getLog(TransformerFactoryUtils.class);
 
 	/**
 	 * Build a new {@link TransformerFactory} using the default constructor.
@@ -50,7 +55,13 @@ public class TransformerFactoryUtils {
 	 * Prevent external entities from accessing.
 	 */
 	private static TransformerFactory defaultSettings(TransformerFactory factory) {
-		factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+		try {
+			factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+		} catch (IllegalArgumentException e) {
+			if (log.isWarnEnabled()) {
+				log.warn(XMLConstants.ACCESS_EXTERNAL_DTD + " property not supported by " + factory.getClass().getCanonicalName());
+			}
+		}
 		factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
 		return factory;
 	}


### PR DESCRIPTION
The XMLConstants.ACCESS_EXTERNAL_DTD property is not supported by every
XML library.

Since 3.0.6 I get this error:

```
ContextLoader.initWebApplicationContext:312 - Context initialization failed
java.lang.IllegalArgumentException: Unrecognized configuration feature: http://javax.xml.XMLConstants/property/accessExternalDTD
	at net.sf.saxon.Configuration.setConfigurationProperty(Configuration.java:4387)
	at net.sf.saxon.jaxp.SaxonTransformerFactory.setAttribute(SaxonTransformerFactory.java:311)
	at org.springframework.xml.transform.TransformerFactoryUtils.defaultSettings(TransformerFactoryUtils.java:53)
	at org.springframework.xml.transform.TransformerFactoryUtils.newInstance(TransformerFactoryUtils.java:32)
	at org.springframework.ws.server.endpoint.mapping.PayloadRootAnnotationMethodEndpointMapping.<clinit>(PayloadRootAnnotationMethodEndpointMapping.java:58)
```