### PR TITLE
Support WSS4J subject cert constraints

### DIFF
--- a/spring-ws-security/src/main/java/org/springframework/ws/soap/security/wss4j2/Wss4jSecurityInterceptor.java
+++ b/spring-ws-security/src/main/java/org/springframework/ws/soap/security/wss4j2/Wss4jSecurityInterceptor.java
@@ -184,7 +184,21 @@ public class Wss4jSecurityInterceptor extends AbstractWsSecurityInterceptor impl
 	public void setSecurementEncryptionCrypto(Crypto securementEncryptionCrypto) {
 		handler.setSecurementEncryptionCrypto(securementEncryptionCrypto);
 	}
-	
+
+	/**
+	 * Certificate constraints which will be applied to the subject DN of the certificate used for
+	 * signature validation, after trust verification of the certificate chain associated with the
+	 * certificate.
+	 *
+	 * @param patterns A comma separated String of regular expressions which will be applied to
+	 *                 the subject DN.
+	 *
+	 * @see <a href="https://ws.apache.org/wss4j/config.html">WSS4J configuration: SIG_SUBJECT_CERT_CONSTRAINTS</a>
+	 */
+	public void setSignatureValidationSubjectCertificateConstraints(String patterns) {
+	    handler.setOption(ConfigurationConstants.SIG_SUBJECT_CERT_CONSTRAINTS, patterns);
+	}
+
 	/**
 	 * Defines which key identifier type to use. The WS-Security specifications recommends to use the identifier type
 	 * {@code IssuerSerial}. For possible encryption key identifier types refer to {@link


### PR DESCRIPTION
If no Subject DN Certificate Constraint has been configured for the case described here http://koenserneels.blogspot.com/2013/09/ws-security-using-binarysecuritytoken.html WSS4J emits the following warning:
```
WARN - org.apache.wss4j.common.crypto.CryptoBase - No Subject DN Certificate Constraints were defined. This could be a security issue
```
[CryptoBase.java](https://github.com/apache/wss4j/blob/wss4j-2.2.0/ws-security-common/src/main/java/org/apache/wss4j/common/crypto/CryptoBase.java#L310-L329)

This PR is a work-in-progress for adding support for configuring Subject DN Certificate Constraint for WSS4J ([`SIG_SUBJECT_CERT_CONSTRAINTS `](https://ws.apache.org/wss4j/config.html)).

~More info in JIRA-issue: https://jira.spring.io/browse/SWS-1058~
Issue: #1124