### PR TITLE
URL Cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
 	repositories {
-		maven { url 'http://repo.springsource.org/plugins-release' }
+		maven { url 'https://repo.springsource.org/plugins-release' }
 	}
 	dependencies {
 		classpath 'org.springframework.build.gradle:propdeps-plugin:0.0.7'
@@ -65,12 +65,12 @@ configure(allprojects) {
 	}
 
 	ext.javadocLinks = [
-		"http://docs.oracle.com/javase/7/docs/api/",
-		"http://docs.oracle.com/javaee/6/api/",
-		"http://docs.spring.io/spring/docs/current/javadoc-api/",
+		"https://docs.oracle.com/javase/7/docs/api/",
+		"https://docs.oracle.com/javaee/6/api/",
+		"https://docs.spring.io/spring/docs/current/javadoc-api/",
 		"https://hc.apache.org/httpcomponents-core-ga/httpcore/apidocs/",
-		"http://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/",
-		"http://fasterxml.github.com/jackson-core/javadoc/2.2.0/",
+		"https://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/",
+		"https://fasterxml.github.com/jackson-core/javadoc/2.2.0/",
 	] as String[]
 
 }
@@ -339,7 +339,7 @@ configure(rootProject) {
 		baseName = 'spring-ws'
 		classifier = 'docs'
 		description = "Builds -${classifier} archive containing api and reference " +
-			"for deployment at http://static.springframework.org/spring-framework/docs."
+			"for deployment at https://docs.spring.io/spring-framework/docs."
 
 		from('src/dist') {
 			include 'changelog.txt'
@@ -359,7 +359,7 @@ configure(rootProject) {
 		baseName = 'spring-ws'
 		classifier = 'schema'
 		description = "Builds -${classifier} archive containing all " +
-			"XSDs for deployment at http://springframework.org/schema."
+			"XSDs for deployment at https://springframework.org/schema."
 
 		subprojects.each { subproject ->
 			def Properties schemas = new Properties();

--- a/publish-maven.gradle
+++ b/publish-maven.gradle
@@ -22,7 +22,7 @@ def customizePom(pom, gradleProject) {
 		generatedPom.project {
 			name = gradleProject.description
 			description = gradleProject.description
-			url = 'http://projects.spring.io/spring-ws'
+			url = 'https://projects.spring.io/spring-ws'
 			organization {
 				name = 'Spring IO'
 				url = 'https://spring.io'
@@ -30,7 +30,7 @@ def customizePom(pom, gradleProject) {
 			licenses {
 				license {
 					name 'The Apache Software License, Version 2.0'
-					url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+					url 'https://www.apache.org/licenses/LICENSE-2.0.txt'
 					distribution 'repo'
 				}
 			}


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://docs.oracle.com/javaee/6/api/ with 1 occurrences migrated to:  
  https://docs.oracle.com/javaee/6/api/ ([https](https://docs.oracle.com/javaee/6/api/) result 200).
* http://docs.oracle.com/javase/7/docs/api/ with 1 occurrences migrated to:  
  https://docs.oracle.com/javase/7/docs/api/ ([https](https://docs.oracle.com/javase/7/docs/api/) result 200).
* http://docs.spring.io/spring/docs/current/javadoc-api/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/current/javadoc-api/ ([https](https://docs.spring.io/spring/docs/current/javadoc-api/) result 200).
* http://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/ with 1 occurrences migrated to:  
  https://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/ ([https](https://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/) result 200).
* http://www.apache.org/licenses/LICENSE-2.0.txt with 1 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0.txt ([https](https://www.apache.org/licenses/LICENSE-2.0.txt) result 200).
* http://static.springframework.org/spring-framework/docs (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-framework/docs ([https](https://static.springframework.org/spring-framework/docs) result 301).
* http://fasterxml.github.com/jackson-core/javadoc/2.2.0/ with 1 occurrences migrated to:  
  https://fasterxml.github.com/jackson-core/javadoc/2.2.0/ ([https](https://fasterxml.github.com/jackson-core/javadoc/2.2.0/) result 301).
* http://projects.spring.io/spring-ws with 1 occurrences migrated to:  
  https://projects.spring.io/spring-ws ([https](https://projects.spring.io/spring-ws) result 301).
* http://repo.springsource.org/plugins-release with 1 occurrences migrated to:  
  https://repo.springsource.org/plugins-release ([https](https://repo.springsource.org/plugins-release) result 301).
* http://springframework.org/schema with 1 occurrences migrated to:  
  https://springframework.org/schema ([https](https://springframework.org/schema) result 301).