### PR TITLE
URL Cleanup

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -42,7 +42,7 @@ added after the original pull request but before a merge.
 * A few unit tests would help a lot as well -- someone has to do it.
 * If no-one else is using your branch, please rebase it against the current master (or
   other target branch in the main project).
-* When writing a commit message please follow http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions].
+* When writing a commit message please follow https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions].
 
 === Building from source
 This project includes the Maven wrapper, meaning you don't have to install any CLI tools to compile. Simply clone it and do this:

--- a/spring-ws-core/src/main/java/org/springframework/ws/client/core/WebServiceTemplate.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/client/core/WebServiceTemplate.java
@@ -282,7 +282,7 @@ public class WebServiceTemplate extends WebServiceAccessor implements WebService
 	 * allows this template to deal with non-conforming services.
 	 *
 	 * @see #hasError(WebServiceConnection, WebServiceMessage)
-	 * @see <a href="http://www.w3.org/TR/2000/NOTE-SOAP-20000508/#_Toc478383529">SOAP 1.1 specification</a>
+	 * @see <a href="https://www.w3.org/TR/2000/NOTE-SOAP-20000508/#_Toc478383529">SOAP 1.1 specification</a>
 	 * @see <a href="http://www.ws-i.org/Profiles/BasicProfile-1.1.html#HTTP_Success_Status_Codes">WS-I Basic
 	 *		Profile</a>
 	 */
@@ -301,7 +301,7 @@ public class WebServiceTemplate extends WebServiceAccessor implements WebService
 	 * {@code false} allows this template to deal with non-conforming services.
 	 *
 	 * @see #hasFault(WebServiceConnection,WebServiceMessage)
-	 * @see <a href="http://www.w3.org/TR/2000/NOTE-SOAP-20000508/#_Toc478383529">SOAP 1.1 specification</a>
+	 * @see <a href="https://www.w3.org/TR/2000/NOTE-SOAP-20000508/#_Toc478383529">SOAP 1.1 specification</a>
 	 * @see <a href="http://www.ws-i.org/Profiles/BasicProfile-1.1.html#HTTP_Server_Error_Status_Codes">WS-I Basic
 	 *		Profile</a>
 	 */

--- a/spring-ws-core/src/main/java/org/springframework/ws/mime/MimeMessage.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/mime/MimeMessage.java
@@ -36,9 +36,9 @@ public interface MimeMessage extends WebServiceMessage {
 	/**
 	 * Indicates whether this message is a XOP package.
 	 *
-	 * @return {@code true} when the constraints specified in <a href="http://www.w3.org/TR/2005/REC-xop10-20050125/#identifying_xop_documents">Identifying
+	 * @return {@code true} when the constraints specified in <a href="https://www.w3.org/TR/2005/REC-xop10-20050125/#identifying_xop_documents">Identifying
 	 *		   XOP Documents</a> are met.
-	 * @see <a href="http://www.w3.org/TR/2005/REC-xop10-20050125/#xop_packages">XOP Packages</a>
+	 * @see <a href="https://www.w3.org/TR/2005/REC-xop10-20050125/#xop_packages">XOP Packages</a>
 	 */
 	boolean isXopPackage();
 
@@ -46,7 +46,7 @@ public interface MimeMessage extends WebServiceMessage {
 	 * Turns this message into a XOP package.
 	 *
 	 * @return {@code true} when the message is a XOP package
-	 * @see <a href="http://www.w3.org/TR/2005/REC-xop10-20050125/#xop_packages">XOP Packages</a>
+	 * @see <a href="https://www.w3.org/TR/2005/REC-xop10-20050125/#xop_packages">XOP Packages</a>
 	 */
 	boolean convertToXopPackage();
 

--- a/spring-ws-core/src/main/java/org/springframework/ws/server/endpoint/interceptor/PayloadTransformingInterceptor.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/server/endpoint/interceptor/PayloadTransformingInterceptor.java
@@ -140,7 +140,7 @@ public class PayloadTransformingInterceptor extends TransformerObjectSupport
 		}
 		TransformerFactory transformerFactory = getTransformerFactory();
 		XMLReader xmlReader = XMLReaderFactory.createXMLReader();
-		xmlReader.setFeature("http://xml.org/sax/features/namespace-prefixes", true);
+		xmlReader.setFeature("http://www.xml.org/sax/features/namespace-prefixes", true);
 		if (requestXslt != null) {
 			Assert.isTrue(requestXslt.exists(), "requestXslt \"" + requestXslt + "\" does not exit");
 			if (logger.isInfoEnabled()) {

--- a/spring-ws-core/src/main/java/org/springframework/ws/server/endpoint/mapping/UriEndpointMapping.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/server/endpoint/mapping/UriEndpointMapping.java
@@ -39,7 +39,7 @@ import org.springframework.ws.transport.context.TransportContextHolder;
  * <p>Mappings to bean names can be set via the {@code mappings} property, in a form accepted by the {@code
  * java.util.Properties} class, like as follows:
  * <pre>
- * http://example.com:8080/services/bookFlight=bookFlightEndpoint
+ * https://example.com:8080/services/bookFlight=bookFlightEndpoint
  * jms://exampleQueue=getFlightsEndpoint
  * </pre>
  * or, when the {@code usePath} property is enabled:

--- a/spring-ws-core/src/main/java/org/springframework/ws/soap/SoapVersion.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/soap/SoapVersion.java
@@ -32,13 +32,13 @@ public interface SoapVersion {
 	/**
 	 * Represents version 1.1 of the SOAP specification.
 	 *
-	 * @see <a href="http://www.w3.org/TR/2000/NOTE-SOAP-20000508/">SOAP 1.1 specification</a>
+	 * @see <a href="https://www.w3.org/TR/2000/NOTE-SOAP-20000508/">SOAP 1.1 specification</a>
 	 */
 	SoapVersion SOAP_11 = new SoapVersion() {
 
 		private static final String ENVELOPE_NAMESPACE_URI = "http://schemas.xmlsoap.org/soap/envelope/";
 
-		private static final String NEXT_ROLE_URI = "http://schemas.xmlsoap.org/soap/actor/next";
+		private static final String NEXT_ROLE_URI = "http://schemas.xmlsoap.org/soap/actor/next/";
 
 		private static final String CONTENT_TYPE = "text/xml";
 
@@ -130,7 +130,7 @@ public interface SoapVersion {
 	/**
 	 * Represents version 1.2 of the SOAP specification.
 	 *
-	 * @see <a href="http://www.w3.org/TR/soap12-part0/">SOAP 1.2 specification</a>
+	 * @see <a href="https://www.w3.org/TR/soap12-part0/">SOAP 1.2 specification</a>
 	 */
 	SoapVersion SOAP_12 = new SoapVersion() {
 

--- a/spring-ws-core/src/main/java/org/springframework/ws/soap/addressing/client/ActionCallback.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/soap/addressing/client/ActionCallback.java
@@ -43,7 +43,7 @@ import org.springframework.ws.transport.context.TransportContextHolder;
  * WebServiceTemplate template = new WebServiceTemplate(messageFactory);
  * Result result = new DOMResult();
  * template.sendSourceAndReceiveToResult(
- *	   new StringSource("&lt;content xmlns=\"http://tempuri.org\"/&gt;"),
+ *	   new StringSource("&lt;content xmlns=\"https://www.bing.com/\"/&gt;"),
  *	   new ActionCallback(new URI("http://tempuri.org/Action")),
  *	   result);
  * </pre>

--- a/spring-ws-core/src/main/java/org/springframework/ws/soap/addressing/core/EndpointReference.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/soap/addressing/core/EndpointReference.java
@@ -29,7 +29,7 @@ import org.w3c.dom.Node;
  * Represents an Endpoint Reference, as defined in the WS-Addressing specification.
  *
  * @author Arjen Poutsma
- * @see <a href="http://www.w3.org/TR/ws-addr-core/#eprs">Endpoint References</a>
+ * @see <a href="https://www.w3.org/TR/ws-addr-core/#eprs">Endpoint References</a>
  * @since 1.5.0
  */
 public final class EndpointReference implements Serializable {

--- a/spring-ws-core/src/main/java/org/springframework/ws/soap/addressing/core/MessageAddressingProperties.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/soap/addressing/core/MessageAddressingProperties.java
@@ -29,7 +29,7 @@ import org.w3c.dom.Node;
  * <p>In earlier versions of the spec, these properties were called Message Information Headers.
  *
  * @author Arjen Poutsma
- * @see <a href="http://www.w3.org/TR/ws-addr-core/#msgaddrprops">Message Addressing Properties</a>
+ * @see <a href="https://www.w3.org/TR/ws-addr-core/#msgaddrprops">Message Addressing Properties</a>
  * @since 1.5.0
  */
 public final class MessageAddressingProperties implements Serializable {

--- a/spring-ws-core/src/main/java/org/springframework/ws/soap/addressing/server/AnnotationActionEndpointMapping.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/soap/addressing/server/AnnotationActionEndpointMapping.java
@@ -41,7 +41,7 @@ import org.springframework.ws.soap.addressing.server.annotation.Address;
  * &#64;Endpoint
  * &#64;Address("mailto:joe@fabrikam123.example")
  * public class MyEndpoint{
- *	  &#64;Action("http://fabrikam123.example/mail/Delete")
+ *	  &#64;Action("https://fabrikam123.example/mail/Delete")
  *	  public Source doSomethingWithRequest() {
  *		 ...
  *	  }

--- a/spring-ws-core/src/main/java/org/springframework/ws/soap/addressing/version/Addressing10.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/soap/addressing/version/Addressing10.java
@@ -29,13 +29,13 @@ import org.springframework.ws.soap.addressing.core.MessageAddressingProperties;
  * Communication Foundation (WCF), and supported by Axis 1 and 2.
  *
  * @author Arjen Poutsma
- * @see <a href="http://www.w3.org/TR/2006/REC-ws-addr-core-20060509">Web Services Addressing, August 2004</a>
+ * @see <a href="https://www.w3.org/TR/2006/REC-ws-addr-core-20060509">Web Services Addressing, August 2004</a>
  * @since 1.5.0
  */
 
 public class Addressing10 extends AbstractAddressingVersion {
 
-	private static final String NAMESPACE_URI = "http://www.w3.org/2005/08/addressing";
+	private static final String NAMESPACE_URI = "https://www.w3.org/2005/08/addressing";
 
 	@Override
 	public void addAddressingHeaders(SoapMessage message, MessageAddressingProperties map) {

--- a/spring-ws-core/src/main/java/org/springframework/ws/soap/addressing/version/Addressing200408.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/soap/addressing/version/Addressing200408.java
@@ -29,7 +29,7 @@ import org.springframework.ws.soap.addressing.core.MessageAddressingProperties;
  * Microsoft's Web Services Enhancements (WSE) 3.0, and supported by Axis 1 and 2, and XFire.
  *
  * @author Arjen Poutsma
- * @see <a href="http://www.w3.org/Submission/2004/SUBM-ws-addressing-20040810/">Web Services Addressing, August
+ * @see <a href="https://www.w3.org/Submission/2004/SUBM-ws-addressing-20040810/">Web Services Addressing, August
  *		2004</a>
  * @since 1.5.0
  */

--- a/spring-ws-core/src/main/java/org/springframework/ws/soap/addressing/version/AddressingVersion.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/soap/addressing/version/AddressingVersion.java
@@ -36,7 +36,7 @@ public interface AddressingVersion {
 	 *
 	 * @param message the message to find the map for
 	 * @return the message addressing properties
-	 * @see <a href="http://www.w3.org/TR/ws-addr-core/#msgaddrprops">Message Addressing Properties</a>
+	 * @see <a href="https://www.w3.org/TR/ws-addr-core/#msgaddrprops">Message Addressing Properties</a>
 	 */
 	MessageAddressingProperties getMessageAddressingProperties(SoapMessage message);
 
@@ -72,7 +72,7 @@ public interface AddressingVersion {
 	 * Indicates whether the given endpoint reference has a Anonymous address. This address is used to indicate that a
 	 * message should be sent in-band.
 	 *
-	 * @see <a href="http://www.w3.org/TR/ws-addr-core/#formreplymsg">Formulating a Reply Message</a>
+	 * @see <a href="https://www.w3.org/TR/ws-addr-core/#formreplymsg">Formulating a Reply Message</a>
 	 */
 	boolean hasAnonymousAddress(EndpointReference epr);
 
@@ -80,7 +80,7 @@ public interface AddressingVersion {
 	 * Indicates whether the given endpoint reference has a None address. Messages to be sent to this address will not
 	 * be sent.
 	 *
-	 * @see <a href="http://www.w3.org/TR/ws-addr-core/#sendmsgepr">Sending a Message to an EPR</a>
+	 * @see <a href="https://www.w3.org/TR/ws-addr-core/#sendmsgepr">Sending a Message to an EPR</a>
 	 */
 	boolean hasNoneAddress(EndpointReference epr);
 
@@ -91,14 +91,14 @@ public interface AddressingVersion {
 	/**
 	 * Adds a Invalid Addressing Header fault to the given message.
 	 *
-	 * @see <a href="http://www.w3.org/TR/ws-addr-soap/#invalidmapfault">Invalid Addressing Header</a>
+	 * @see <a href="https://www.w3.org/TR/ws-addr-soap/#invalidmapfault">Invalid Addressing Header</a>
 	 */
 	SoapFault addInvalidAddressingHeaderFault(SoapMessage message);
 
 	/**
 	 * Adds a Message Addressing Header Required fault to the given message.
 	 *
-	 * @see <a href="http://www.w3.org/TR/ws-addr-soap/#missingmapfault">Message Addressing Header Required</a>
+	 * @see <a href="https://www.w3.org/TR/ws-addr-soap/#missingmapfault">Message Addressing Header Required</a>
 	 */
 	SoapFault addMessageAddressingHeaderRequiredFault(SoapMessage message);
 

--- a/spring-ws-core/src/main/java/org/springframework/ws/soap/axiom/AxiomSoap11Body.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/soap/axiom/AxiomSoap11Body.java
@@ -146,7 +146,7 @@ class AxiomSoap11Body extends AxiomSoapBody implements Soap11Body {
 	}
 
 	private void addLangAttribute(Locale locale, SOAPFaultReason faultReason) {
-		OMNamespace xmlNamespace = getAxiomFactory().createOMNamespace("http://www.w3.org/XML/1998/namespace", "xml");
+		OMNamespace xmlNamespace = getAxiomFactory().createOMNamespace("https://www.w3.org/XML/1998/namespace", "xml");
 		OMAttribute langAttribute =
 				getAxiomFactory().createOMAttribute("lang", xmlNamespace, AxiomUtils.toLanguage(locale));
 		faultReason.addAttribute(langAttribute);

--- a/spring-ws-core/src/main/java/org/springframework/ws/soap/axiom/AxiomSoap11Fault.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/soap/axiom/AxiomSoap11Fault.java
@@ -55,7 +55,7 @@ class AxiomSoap11Fault extends AxiomSoapFault implements Soap11Fault {
 	public Locale getFaultStringLocale() {
 		if (getAxiomFault().getReason() != null) {
 			OMAttribute langAttribute =
-					getAxiomFault().getReason().getAttribute(new QName("http://www.w3.org/XML/1998/namespace", "lang"));
+					getAxiomFault().getReason().getAttribute(new QName("https://www.w3.org/XML/1998/namespace", "lang"));
 			if (langAttribute != null) {
 				String xmlLangString = langAttribute.getAttributeValue();
 				if (xmlLangString != null) {

--- a/spring-ws-core/src/main/java/org/springframework/ws/soap/client/core/SoapActionCallback.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/soap/client/core/SoapActionCallback.java
@@ -32,7 +32,7 @@ import org.springframework.ws.soap.SoapMessage;
  * WebServiceTemplate template = new WebServiceTemplate(messageFactory);
  * Result result = new DOMResult();
  * template.sendSourceAndReceiveToResult(
- *	   new StringSource("&lt;content xmlns=\"http://tempuri.org\"/&gt;"),
+ *	   new StringSource("&lt;content xmlns=\"https://www.bing.com/\"/&gt;"),
  *	   new SoapActionCallback("http://tempuri.org/SOAPAction"),
  *	   result);
  * </pre>

--- a/spring-ws-core/src/main/java/org/springframework/ws/soap/saaj/SaajSoapMessageFactory.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/soap/saaj/SaajSoapMessageFactory.java
@@ -252,8 +252,8 @@ public class SaajSoapMessageFactory implements SoapMessageFactory, InitializingB
 	/**
 	 * Checks for the UTF-8 Byte Order Mark, and removes it if present. The SAAJ RI cannot cope with these BOMs.
 	 *
-	 * @see <a href="http://jira.springframework.org/browse/SWS-393">SWS-393</a>
-	 * @see <a href="http://unicode.org/faq/utf_bom.html#22">UTF-8 BOMs</a>
+	 * @see <a href="https://jira.springframework.org/browse/SWS-393">SWS-393</a>
+	 * @see <a href="https://unicode.org/faq/utf_bom.html#22">UTF-8 BOMs</a>
 	 */
 	private InputStream checkForUtf8ByteOrderMark(InputStream inputStream) throws IOException {
 		PushbackInputStream pushbackInputStream = new PushbackInputStream(new BufferedInputStream(inputStream), 3);

--- a/spring-ws-core/src/main/java/org/springframework/ws/soap/saaj/support/SaajXmlReader.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/soap/saaj/support/SaajXmlReader.java
@@ -43,9 +43,9 @@ import org.springframework.xml.sax.AbstractXmlReader;
  */
 public class SaajXmlReader extends AbstractXmlReader {
 
-	private static final String NAMESPACES_FEATURE_NAME = "http://xml.org/sax/features/namespaces";
+	private static final String NAMESPACES_FEATURE_NAME = "http://www.xml.org/sax/features/namespaces";
 
-	private static final String NAMESPACE_PREFIXES_FEATURE_NAME = "http://xml.org/sax/features/namespace-prefixes";
+	private static final String NAMESPACE_PREFIXES_FEATURE_NAME = "http://www.xml.org/sax/features/namespace-prefixes";
 
 	private final Node startNode;
 

--- a/spring-ws-core/src/main/java/org/springframework/ws/soap/server/endpoint/adapter/method/SoapHeaderElementMethodArgumentResolver.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/soap/server/endpoint/adapter/method/SoapHeaderElementMethodArgumentResolver.java
@@ -38,9 +38,9 @@ import org.springframework.xml.namespace.QNameUtils;
  * supports simple {@link SoapHeaderElement} parameters and {@link List} parameters for elements that appear multiple
  * times in the same SOAP header. </p> The following snippet shows an example of supported declarations.
  * <pre><code>
- * public void soapHeaderElement(@SoapHeader("{http://springframework.org/ws}header") SoapHeaderElement element)
+ * public void soapHeaderElement(@SoapHeader("{https://springframework.org/ws}header") SoapHeaderElement element)
  *
- * public void soapHeaderElementList(@SoapHeader("{http://springframework.org/ws}header") List&lt;SoapHeaderElement&gt; elements)
+ * public void soapHeaderElementList(@SoapHeader("{https://springframework.org/ws}header") List&lt;SoapHeaderElement&gt; elements)
  * </code></pre>
  *
  * @author Tareq Abedrabbo

--- a/spring-ws-core/src/main/java/org/springframework/ws/transport/http/CommonsHttpMessageSender.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/transport/http/CommonsHttpMessageSender.java
@@ -39,7 +39,7 @@ import org.springframework.util.Assert;
 import org.springframework.ws.transport.WebServiceConnection;
 
 /**
- * {@code WebServiceMessageSender} implementation that uses <a href="http://jakarta.apache.org/commons/httpclient">Jakarta
+ * {@code WebServiceMessageSender} implementation that uses <a href="https://jakarta.apache.org/commons/httpclient">Jakarta
  * Commons HttpClient</a> to execute POST requests.
  *
  * <p>Allows to use a preconfigured HttpClient instance, potentially with authentication, HTTP connection pooling, etc.
@@ -156,7 +156,7 @@ public class CommonsHttpMessageSender extends AbstractHttpWebServiceMessageSende
 	 * per host can be set in a form accepted by the {@code java.util.Properties} class, like as follows:
 	 * <pre>
 	 * https://www.example.com=1
-	 * http://www.example.com:8080=7
+	 * https://www.example.com:8080=7
 	 * www.springframework.org=10
 	 * *=5
 	 * </pre>

--- a/spring-ws-core/src/main/java/org/springframework/ws/transport/http/HttpComponentsMessageSender.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/transport/http/HttpComponentsMessageSender.java
@@ -41,7 +41,7 @@ import org.springframework.util.Assert;
 import org.springframework.ws.transport.WebServiceConnection;
 
 /**
- * {@code WebServiceMessageSender} implementation that uses <a href="http://hc.apache.org/httpcomponents-client">Apache
+ * {@code WebServiceMessageSender} implementation that uses <a href="https://hc.apache.org/httpcomponents-client">Apache
  * HttpClient</a> to execute POST requests.
  *
  * <p>Allows to use a pre-configured HttpClient instance, potentially with authentication, HTTP connection pooling, etc.
@@ -174,8 +174,8 @@ public class HttpComponentsMessageSender extends AbstractHttpWebServiceMessageSe
 	 *
 	 * <pre>
 	 * https://www.example.com=1
-	 * http://www.example.com:8080=7
-	 * http://www.springframework.org=10
+	 * https://www.example.com:8080=7
+	 * https://www.springframework.org=10
 	 * </pre>
 	 *
 	 * <p>The host can be specified as a URI (with scheme and port).

--- a/spring-ws-core/src/main/java/org/springframework/ws/transport/http/LocationTransformerObjectSupport.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/transport/http/LocationTransformerObjectSupport.java
@@ -80,8 +80,8 @@ public abstract class LocationTransformerObjectSupport extends TransformerObject
 	 * will be changed to {@code http://example.com:80/context/services/myService}.
 	 *
 	 * <p>If the location attribute defined in the WSDL is {@code /services/myService}, and the request URI for the
-	 * WSDL is {@code http://example.com:8080/context/myService.wsdl}, the location will be changed to
-	 * {@code http://example.com:8080/context/services/myService}.
+	 * WSDL is {@code https://example.com:8080/context/myService.wsdl}, the location will be changed to
+	 * {@code https://example.com:8080/context/services/myService}.
 	 *
 	 * <p>This method is only called when the {@code transformLocations} property is true.
 	 */

--- a/spring-ws-core/src/main/java/org/springframework/ws/transport/http/WsdlDefinitionHandlerAdapter.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/transport/http/WsdlDefinitionHandlerAdapter.java
@@ -48,12 +48,12 @@ import org.springframework.xml.xpath.XPathExpressionFactory;
  * overriding the {@code transformLocation()} method.
  *
  * <p>For instance, if the location attribute defined in the WSDL is {@code http://localhost:8080/context/services/myService},
- * and the request URI for the WSDL is {@code http://example.com/context/myService.wsdl}, the location will be
- * changed to {@code http://example.com/context/services/myService}.
+ * and the request URI for the WSDL is {@code https://example.com/context/myService.wsdl}, the location will be
+ * changed to {@code https://example.com/context/services/myService}.
  *
  * <p>If the location attribute defined in the WSDL is {@code /services/myService}, and the request URI for the WSDL
- * is {@code http://example.com:8080/context/myService.wsdl}, the location will be changed to
- * {@code http://example.com:8080/context/services/myService}.
+ * is {@code https://example.com:8080/context/myService.wsdl}, the location will be changed to
+ * {@code https://example.com:8080/context/services/myService}.
  *
  * <p>When {@code transformLocations} is enabled, all {@code location} attributes found in the WSDL definition
  * are changed by default. This behavior can be customized by changing the {@code locationExpression} property,

--- a/spring-ws-core/src/main/java/org/springframework/ws/wsdl/wsdl11/SimpleWsdl11Definition.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/wsdl/wsdl11/SimpleWsdl11Definition.java
@@ -71,7 +71,7 @@ public class SimpleWsdl11Definition implements Wsdl11Definition, InitializingBea
 	public Source getSource() {
 		try {
 			XMLReader xmlReader = XMLReaderFactory.createXMLReader();
-			xmlReader.setFeature("http://xml.org/sax/features/namespace-prefixes", true);
+			xmlReader.setFeature("http://www.xml.org/sax/features/namespace-prefixes", true);
 			return new ResourceSource(xmlReader, wsdlResource);
 		}
 		catch (SAXException ex) {

--- a/spring-ws-core/src/main/java/org/springframework/ws/wsdl/wsdl11/provider/Soap11Provider.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/wsdl/wsdl11/provider/Soap11Provider.java
@@ -53,7 +53,7 @@ import org.springframework.util.Assert;
 public class Soap11Provider extends DefaultConcretePartProvider {
 
 	/** The default transport URI, which indicates an HTTP transport. */
-	public static final String DEFAULT_TRANSPORT_URI = "http://schemas.xmlsoap.org/soap/http";
+	public static final String DEFAULT_TRANSPORT_URI = "http://schemas.xmlsoap.org/soap/http/";
 
 	/** The prefix of the WSDL SOAP 1.1 namespace. */
 	public static final String SOAP_11_NAMESPACE_PREFIX = "soap";

--- a/spring-ws-core/src/main/java/org/springframework/ws/wsdl/wsdl11/provider/Soap12Provider.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/wsdl/wsdl11/provider/Soap12Provider.java
@@ -52,7 +52,7 @@ import org.springframework.util.Assert;
 public class Soap12Provider extends DefaultConcretePartProvider {
 
 	/** The default transport URI, which indicates an HTTP transport. */
-	public static final String DEFAULT_TRANSPORT_URI = "http://schemas.xmlsoap.org/soap/http";
+	public static final String DEFAULT_TRANSPORT_URI = "http://schemas.xmlsoap.org/soap/http/";
 
 	/** The prefix of the WSDL SOAP 1.2 namespace. */
 	public static final String SOAP_12_NAMESPACE_PREFIX = "soap12";

--- a/spring-ws-core/src/main/resources/org/springframework/ws/config/web-services-2.0.xsd
+++ b/spring-ws-core/src/main/resources/org/springframework/ws/config/web-services-2.0.xsd
@@ -6,8 +6,8 @@
             targetNamespace="http://www.springframework.org/schema/web-services" elementFormDefault="qualified"
             attributeFormDefault="unqualified">
 
-    <xsd:import namespace="http://www.springframework.org/schema/beans" schemaLocation="http://www.springframework.org/schema/beans/spring-beans-3.0.xsd" />
-    <xsd:import namespace="http://www.springframework.org/schema/tool" schemaLocation="http://www.springframework.org/schema/tool/spring-tool-3.0.xsd" />
+    <xsd:import namespace="http://www.springframework.org/schema/beans" schemaLocation="https://www.springframework.org/schema/beans/spring-beans-3.0.xsd" />
+    <xsd:import namespace="http://www.springframework.org/schema/tool" schemaLocation="https://www.springframework.org/schema/tool/spring-tool-3.0.xsd" />
 
     <xsd:annotation>
         <xsd:documentation>
@@ -231,7 +231,7 @@
                     </xsd:documentation>
                 </xsd:annotation>
             </xsd:attribute>
-            <xsd:attribute name="transportUri" type="xsd:anyURI" default="http://schemas.xmlsoap.org/soap/http">
+            <xsd:attribute name="transportUri" type="xsd:anyURI" default="http://schemas.xmlsoap.org/soap/http/">
                 <xsd:annotation>
                     <xsd:documentation>
                         Sets the value used for the binding transport attribute value. Defaults to HTTP.

--- a/spring-ws-core/src/test/java/org/springframework/ws/client/core/WebServiceTemplateTest.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/client/core/WebServiceTemplateTest.java
@@ -488,7 +488,7 @@ public class WebServiceTemplateTest {
 		connectionMock.send(isA(WebServiceMessage.class));
 		expect(connectionMock.hasError()).andReturn(false);
 		expect(connectionMock.receive(messageFactory)).andReturn(null);
-//		expect(connectionMock.getUri()).andReturn(new URI("http://example.com"));
+//		expect(connectionMock.getUri()).andReturn(new URI("https://example.com"));
 		connectionMock.close();
 
 		replay(connectionMock, extractorMock, providerMock);

--- a/spring-ws-core/src/test/java/org/springframework/ws/client/support/destination/Wsdl11DestinationProviderTest.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/client/support/destination/Wsdl11DestinationProviderTest.java
@@ -42,7 +42,7 @@ public class Wsdl11DestinationProviderTest {
 
 		URI result = provider.getDestination();
 
-		Assert.assertEquals("Invalid URI returned", new URI("http://example.com/myService"), result);
+		Assert.assertEquals("Invalid URI returned", new URI("https://example.com/myService"), result);
 	}
 
 	@Test
@@ -52,7 +52,7 @@ public class Wsdl11DestinationProviderTest {
 
 		URI result = provider.getDestination();
 
-		Assert.assertEquals("Invalid URI returned", new URI("http://example.com/soap11"), result);
+		Assert.assertEquals("Invalid URI returned", new URI("https://example.com/soap11"), result);
 	}
 
 	@Test
@@ -63,6 +63,6 @@ public class Wsdl11DestinationProviderTest {
 
 		URI result = provider.getDestination();
 
-		Assert.assertEquals("Invalid URI returned", new URI("http://example.com/soap12"), result);
+		Assert.assertEquals("Invalid URI returned", new URI("https://example.com/soap12"), result);
 	}
 }

--- a/spring-ws-core/src/test/java/org/springframework/ws/client/support/interceptor/PayloadValidatingInterceptorTest.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/client/support/interceptor/PayloadValidatingInterceptorTest.java
@@ -147,7 +147,7 @@ public class PayloadValidatingInterceptorTest {
 	@Test
 	public void testNamespacesInType() throws Exception {
 		// Make sure we use Xerces for this testcase: the JAXP implementation used internally by JDK 1.5 has a bug
-		// See http://opensource.atlassian.com/projects/spring/browse/SWS-35
+		// See https://opensource.atlassian.com/projects/spring/browse/SWS-35
 		String previousSchemaFactory =
 				System.getProperty("javax.xml.validation.SchemaFactory:" + XMLConstants.W3C_XML_SCHEMA_NS_URI, "");
 		System.setProperty("javax.xml.validation.SchemaFactory:" + XMLConstants.W3C_XML_SCHEMA_NS_URI,

--- a/spring-ws-core/src/test/java/org/springframework/ws/server/endpoint/AbstractEndpointTestCase.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/server/endpoint/AbstractEndpointTestCase.java
@@ -43,7 +43,7 @@ import org.springframework.xml.DocumentBuilderFactoryUtils;
 @SuppressWarnings("Since15")
 public abstract class AbstractEndpointTestCase {
 
-	protected static final String NAMESPACE_URI = "http://springframework.org/ws";
+	protected static final String NAMESPACE_URI = "https://springframework.org/ws";
 
 	protected static final String REQUEST_ELEMENT = "request";
 

--- a/spring-ws-core/src/test/java/org/springframework/ws/server/endpoint/adapter/DefaultMethodEndpointAdapterTest.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/server/endpoint/adapter/DefaultMethodEndpointAdapterTest.java
@@ -124,7 +124,7 @@ public class DefaultMethodEndpointAdapterTest {
 
 	@Test
 	public void invokeSupported() throws Exception {
-		MockWebServiceMessage request = new MockWebServiceMessage("<root xmlns='http://springframework.org'/>");
+		MockWebServiceMessage request = new MockWebServiceMessage("<root xmlns='https://springframework.org'/>");
 		MessageContext messageContext = new DefaultMessageContext(request, new MockWebServiceMessageFactory());
 
 		String value = "Foo";
@@ -151,7 +151,7 @@ public class DefaultMethodEndpointAdapterTest {
 
 	@Test
 	public void invokeNullReturnValue() throws Exception {
-		MockWebServiceMessage request = new MockWebServiceMessage("<root xmlns='http://springframework.org'/>");
+		MockWebServiceMessage request = new MockWebServiceMessage("<root xmlns='https://springframework.org'/>");
 		MessageContext messageContext = new DefaultMessageContext(request, new MockWebServiceMessageFactory());
 
 		String value = "Foo";
@@ -172,7 +172,7 @@ public class DefaultMethodEndpointAdapterTest {
 
 	@Test
 	public void invokeException() throws Exception {
-		MockWebServiceMessage request = new MockWebServiceMessage("<root xmlns='http://springframework.org'/>");
+		MockWebServiceMessage request = new MockWebServiceMessage("<root xmlns='https://springframework.org'/>");
 		MessageContext messageContext = new DefaultMessageContext(request, new MockWebServiceMessageFactory());
 
 		String value = "Foo";

--- a/spring-ws-core/src/test/java/org/springframework/ws/server/endpoint/adapter/XPathParamAnnotationMethodEndpointAdapterTest.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/server/endpoint/adapter/XPathParamAnnotationMethodEndpointAdapterTest.java
@@ -145,10 +145,10 @@ public class XPathParamAnnotationMethodEndpointAdapterTest {
 		DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactoryUtils.newInstance();
 		DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
 		Document document = documentBuilder.newDocument();
-		String rootNamespace = "http://rootnamespace";
+		String rootNamespace = "https://rootnamespace";
 		Element rootElement = document.createElementNS(rootNamespace, "root");
 		document.appendChild(rootElement);
-		String childNamespace = "http://childnamespace";
+		String childNamespace = "https://childnamespace";
 		Element first = document.createElementNS(childNamespace, "child");
 		rootElement.appendChild(first);
 		Text text = document.createTextNode("value");

--- a/spring-ws-core/src/test/java/org/springframework/ws/server/endpoint/adapter/method/AbstractMethodArgumentResolverTestCase.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/server/endpoint/adapter/method/AbstractMethodArgumentResolverTestCase.java
@@ -34,7 +34,7 @@ import org.apache.axiom.soap.SOAPFactory;
 
 public class AbstractMethodArgumentResolverTestCase extends TransformerObjectSupport {
 
-	protected static final String NAMESPACE_URI = "http://springframework.org/ws";
+	protected static final String NAMESPACE_URI = "https://springframework.org/ws";
 
 	protected static final String LOCAL_NAME = "request";
 

--- a/spring-ws-core/src/test/java/org/springframework/ws/server/endpoint/adapter/method/jaxb/JaxbElementPayloadMethodProcessorTest.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/server/endpoint/adapter/method/jaxb/JaxbElementPayloadMethodProcessorTest.java
@@ -77,7 +77,7 @@ public class JaxbElementPayloadMethodProcessorTest {
 
 	@Test
 	public void resolveArgument() throws JAXBException {
-		WebServiceMessage request = new MockWebServiceMessage("<myType xmlns='http://springframework.org'><string>Foo</string></myType>");
+		WebServiceMessage request = new MockWebServiceMessage("<myType xmlns='https://springframework.org'><string>Foo</string></myType>");
 		MessageContext messageContext = new DefaultMessageContext(request, new MockWebServiceMessageFactory());
 
 		JAXBElement<?> result = processor.resolveArgument(messageContext, supportedParameter);
@@ -92,11 +92,11 @@ public class JaxbElementPayloadMethodProcessorTest {
 
 		MyType type = new MyType();
 		type.setString("Foo");
-		JAXBElement<MyType> element = new JAXBElement<MyType>(new QName("http://springframework.org", "type"), MyType.class, type);
+		JAXBElement<MyType> element = new JAXBElement<MyType>(new QName("https://springframework.org", "type"), MyType.class, type);
 		processor.handleReturnValue(messageContext, supportedReturnType, element);
 		assertTrue("context has no response", messageContext.hasResponse());
 		MockWebServiceMessage response = (MockWebServiceMessage) messageContext.getResponse();
-		assertXMLEqual("<type xmlns='http://springframework.org'><string>Foo</string></type>", response.getPayloadAsString());
+		assertXMLEqual("<type xmlns='https://springframework.org'><string>Foo</string></type>", response.getPayloadAsString());
 	}
 
 	@Test
@@ -104,11 +104,11 @@ public class JaxbElementPayloadMethodProcessorTest {
 		MessageContext messageContext = new DefaultMessageContext(new MockWebServiceMessageFactory());
 
 		String s = "Foo";
-		JAXBElement<String> element = new JAXBElement<String>(new QName("http://springframework.org", "string"), String.class, s);
+		JAXBElement<String> element = new JAXBElement<String>(new QName("https://springframework.org", "string"), String.class, s);
 		processor.handleReturnValue(messageContext, stringReturnType, element);
 		assertTrue("context has no response", messageContext.hasResponse());
 		MockWebServiceMessage response = (MockWebServiceMessage) messageContext.getResponse();
-		assertXMLEqual("<string xmlns='http://springframework.org'>Foo</string>", response.getPayloadAsString());
+		assertXMLEqual("<string xmlns='https://springframework.org'>Foo</string>", response.getPayloadAsString());
 	}
 
 	@Test
@@ -127,7 +127,7 @@ public class JaxbElementPayloadMethodProcessorTest {
 
 		MyType type = new MyType();
 		type.setString("Foo");
-		JAXBElement<MyType> element = new JAXBElement<MyType>(new QName("http://springframework.org", "type"), MyType.class, type);
+		JAXBElement<MyType> element = new JAXBElement<MyType>(new QName("https://springframework.org", "type"), MyType.class, type);
 
 		processor.handleReturnValue(messageContext, supportedReturnType, element);
 		assertTrue("context has no response", messageContext.hasResponse());
@@ -137,7 +137,7 @@ public class JaxbElementPayloadMethodProcessorTest {
 		StringResult payloadResult = new StringResult();
 		transformer.transform(response.getPayloadSource(), payloadResult);
 
-		assertXMLEqual("<type xmlns='http://springframework.org'><string>Foo</string></type>",
+		assertXMLEqual("<type xmlns='https://springframework.org'><string>Foo</string></type>",
 				payloadResult.toString());
 
 		ByteArrayOutputStream bos = new ByteArrayOutputStream();
@@ -145,7 +145,7 @@ public class JaxbElementPayloadMethodProcessorTest {
 		String messageResult = bos.toString("UTF-8");
 
 		assertXMLEqual("<soapenv:Envelope xmlns:soapenv='http://schemas.xmlsoap.org/soap/envelope/'><soapenv:Header/><soapenv:Body>" +
-				"<type xmlns='http://springframework.org'><string>Foo</string></type>" +
+				"<type xmlns='https://springframework.org'><string>Foo</string></type>" +
 				"</soapenv:Body></soapenv:Envelope>", messageResult);
 
 	}
@@ -161,12 +161,12 @@ public class JaxbElementPayloadMethodProcessorTest {
 		return new JAXBElement<String>(new QName("string"), String.class, "Foo");
 	}
 
-	@XmlType(name="myType", namespace = "http://springframework.org")
+	@XmlType(name="myType", namespace = "https://springframework.org")
 	public static class MyType {
 
 		private String string;
 
-		@XmlElement(name = "string", namespace = "http://springframework.org")
+		@XmlElement(name = "string", namespace = "https://springframework.org")
 		public String getString() {
 			return string;
 		}

--- a/spring-ws-core/src/test/java/org/springframework/ws/server/endpoint/adapter/method/jaxb/XmlRootElementPayloadMethodProcessorTest.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/server/endpoint/adapter/method/jaxb/XmlRootElementPayloadMethodProcessorTest.java
@@ -89,7 +89,7 @@ public class XmlRootElementPayloadMethodProcessorTest {
 
 	@Test
 	public void resolveArgumentRootElement() throws JAXBException {
-		WebServiceMessage request = new MockWebServiceMessage("<root xmlns='http://springframework.org'><string>Foo</string></root>");
+		WebServiceMessage request = new MockWebServiceMessage("<root xmlns='https://springframework.org'><string>Foo</string></root>");
 		MessageContext messageContext = new DefaultMessageContext(request, new MockWebServiceMessageFactory());
 
 		Object result = processor.resolveArgument(messageContext, rootElementParameter);
@@ -100,7 +100,7 @@ public class XmlRootElementPayloadMethodProcessorTest {
 
 	@Test
 	public void resolveArgumentType() throws JAXBException {
-		WebServiceMessage request = new MockWebServiceMessage("<type xmlns='http://springframework.org'><string>Foo</string></type>");
+		WebServiceMessage request = new MockWebServiceMessage("<type xmlns='https://springframework.org'><string>Foo</string></type>");
 		MessageContext messageContext = new DefaultMessageContext(request, new MockWebServiceMessageFactory());
 
 		Object result = processor.resolveArgument(messageContext, typeParameter);
@@ -125,14 +125,14 @@ public class XmlRootElementPayloadMethodProcessorTest {
 			
 			private void parse() throws SAXException {
 				ContentHandler handler = getContentHandler();
-				// <root xmlns='http://springframework.org'><string>Foo</string></root>
+				// <root xmlns='https://springframework.org'><string>Foo</string></root>
 				handler.startDocument();
-				handler.startPrefixMapping("", "http://springframework.org");
-				handler.startElement("http://springframework.org", "root", "root", new AttributesImpl());
-				handler.startElement("http://springframework.org", "string", "string", new AttributesImpl());
+				handler.startPrefixMapping("", "https://springframework.org");
+				handler.startElement("https://springframework.org", "root", "root", new AttributesImpl());
+				handler.startElement("https://springframework.org", "string", "string", new AttributesImpl());
 				handler.characters("Foo".toCharArray(), 0, 3);
-				handler.endElement("http://springframework.org", "string", "string");
-				handler.endElement("http://springframework.org", "root", "root");
+				handler.endElement("https://springframework.org", "string", "string");
+				handler.endElement("https://springframework.org", "root", "root");
 				handler.endPrefixMapping("");
 				handler.endDocument();
 			}
@@ -175,7 +175,7 @@ public class XmlRootElementPayloadMethodProcessorTest {
 		processor.handleReturnValue(messageContext, rootElementReturnType, rootElement);
 		assertTrue("context has no response", messageContext.hasResponse());
 		MockWebServiceMessage response = (MockWebServiceMessage) messageContext.getResponse();
-		assertXMLEqual("<root xmlns='http://springframework.org'><string>Foo</string></root>", response.getPayloadAsString());
+		assertXMLEqual("<root xmlns='https://springframework.org'><string>Foo</string></root>", response.getPayloadAsString());
 	}
 
 	@Test
@@ -203,7 +203,7 @@ public class XmlRootElementPayloadMethodProcessorTest {
 		StringResult payloadResult = new StringResult();
 		transformer.transform(response.getPayloadSource(), payloadResult);
 
-		assertXMLEqual("<root xmlns='http://springframework.org'><string>Foo</string></root>",
+		assertXMLEqual("<root xmlns='https://springframework.org'><string>Foo</string></root>",
 				payloadResult.toString());
 
 		ByteArrayOutputStream bos = new ByteArrayOutputStream();
@@ -211,7 +211,7 @@ public class XmlRootElementPayloadMethodProcessorTest {
 		String messageResult = bos.toString("UTF-8");
 		
 		assertXMLEqual("<soapenv:Envelope xmlns:soapenv='http://schemas.xmlsoap.org/soap/envelope/'><soapenv:Header/><soapenv:Body>" +
-				"<root xmlns='http://springframework.org'><string>Foo</string></root>" +
+				"<root xmlns='https://springframework.org'><string>Foo</string></root>" +
 				"</soapenv:Body></soapenv:Envelope>", messageResult);
 
 	}
@@ -234,7 +234,7 @@ public class XmlRootElementPayloadMethodProcessorTest {
 		String messageResult = bos.toString("UTF-8");
 
 		assertXMLEqual("<soapenv:Envelope xmlns:soapenv='http://schemas.xmlsoap.org/soap/envelope/'><soapenv:Header/><soapenv:Body>" +
-				"<root xmlns='http://springframework.org'><string>Foo</string></root>" +
+				"<root xmlns='https://springframework.org'><string>Foo</string></root>" +
 				"</soapenv:Body></soapenv:Envelope>", messageResult);
 
 	}
@@ -247,12 +247,12 @@ public class XmlRootElementPayloadMethodProcessorTest {
 	public void type(@RequestPayload MyType type) {
 	}
 
-	@XmlRootElement(name = "root", namespace = "http://springframework.org")
+	@XmlRootElement(name = "root", namespace = "https://springframework.org")
 	public static class MyRootElement {
 
 		private String string;
 
-		@XmlElement(name = "string", namespace = "http://springframework.org")
+		@XmlElement(name = "string", namespace = "https://springframework.org")
 		public String getString() {
 			return string;
 		}
@@ -262,12 +262,12 @@ public class XmlRootElementPayloadMethodProcessorTest {
 		}
 	}
 
-	@XmlType(name = "root", namespace = "http://springframework.org")
+	@XmlType(name = "root", namespace = "https://springframework.org")
 	public static class MyType {
 
 		private String string;
 
-		@XmlElement(name = "string", namespace = "http://springframework.org")
+		@XmlElement(name = "string", namespace = "https://springframework.org")
 		public String getString() {
 			return string;
 		}

--- a/spring-ws-core/src/test/java/org/springframework/ws/server/endpoint/mapping/UriEndpointMappingTest.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/server/endpoint/mapping/UriEndpointMappingTest.java
@@ -71,7 +71,7 @@ public class UriEndpointMappingTest {
 		WebServiceConnection connectionMock = createMock(WebServiceConnection.class);
 		TransportContextHolder.setTransportContext(new DefaultTransportContext(connectionMock));
 
-		URI uri = new URI("http://example.com/foo/bar");
+		URI uri = new URI("https://example.com/foo/bar");
 		expect(connectionMock.getUri()).andReturn(uri);
 
 		replay(connectionMock);
@@ -83,7 +83,7 @@ public class UriEndpointMappingTest {
 
 	@Test
 	public void testValidateLookupKey() throws Exception {
-		Assert.assertTrue("URI not valid", mapping.validateLookupKey("http://example.com/services"));
+		Assert.assertTrue("URI not valid", mapping.validateLookupKey("https://example.com/services"));
 		Assert.assertFalse("URI not valid", mapping.validateLookupKey("some string"));
 	}
 }

--- a/spring-ws-core/src/test/java/org/springframework/ws/soap/AbstractSoapBodyTestCase.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/soap/AbstractSoapBodyTestCase.java
@@ -44,14 +44,14 @@ public abstract class AbstractSoapBodyTestCase extends AbstractSoapElementTestCa
 
 	@Test
 	public void testPayload() throws Exception {
-		String payload = "<payload xmlns='http://www.springframework.org' />";
+		String payload = "<payload xmlns='https://www.springframework.org' />";
 		transformer.transform(new StringSource(payload), soapBody.getPayloadResult());
 		assertPayloadEqual(payload);
 	}
 
 	@Test
 	public void testGetPayloadResultTwice() throws Exception {
-		String payload = "<payload xmlns='http://www.springframework.org' />";
+		String payload = "<payload xmlns='https://www.springframework.org' />";
 		transformer.transform(new StringSource(payload), soapBody.getPayloadResult());
 		transformer.transform(new StringSource(payload), soapBody.getPayloadResult());
 		DOMResult domResult = new DOMResult();
@@ -68,7 +68,7 @@ public abstract class AbstractSoapBodyTestCase extends AbstractSoapElementTestCa
 
 	@Test
 	public void testAddFaultWithExistingPayload() throws Exception {
-		StringSource contents = new StringSource("<payload xmlns='http://www.springframework.org' />");
+		StringSource contents = new StringSource("<payload xmlns='https://www.springframework.org' />");
 		transformer.transform(contents, soapBody.getPayloadResult());
 		soapBody.addMustUnderstandFault("faultString", Locale.ENGLISH);
 		assertTrue("Body has no fault", soapBody.hasFault());

--- a/spring-ws-core/src/test/java/org/springframework/ws/soap/AbstractSoapHeaderTestCase.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/soap/AbstractSoapHeaderTestCase.java
@@ -31,7 +31,7 @@ public abstract class AbstractSoapHeaderTestCase extends AbstractSoapElementTest
 
 	protected SoapHeader soapHeader;
 
-	protected static final String NAMESPACE = "http://www.springframework.org";
+	protected static final String NAMESPACE = "https://www.springframework.org";
 
 	protected static final String PREFIX = "spring";
 
@@ -51,10 +51,10 @@ public abstract class AbstractSoapHeaderTestCase extends AbstractSoapElementTest
 		assertEquals("Invalid qName for element", qName, headerElement.getName());
 		Iterator<SoapHeaderElement> iterator = soapHeader.examineAllHeaderElements();
 		assertTrue("SoapHeader has no elements", iterator.hasNext());
-		String payload = "<content xmlns='http://www.springframework.org'/>";
+		String payload = "<content xmlns='https://www.springframework.org'/>";
 		transformer.transform(new StringSource(payload), headerElement.getResult());
 		assertHeaderElementEqual(headerElement,
-				"<spring:localName xmlns:spring='http://www.springframework.org'><spring:content/></spring:localName>");
+				"<spring:localName xmlns:spring='https://www.springframework.org'><spring:content/></spring:localName>");
 	}
 
 	@Test
@@ -73,7 +73,7 @@ public abstract class AbstractSoapHeaderTestCase extends AbstractSoapElementTest
 		SoapHeaderElement headerElement = soapHeader.addHeaderElement(qName);
 		assertEquals("Invalid qName for element", qName, headerElement.getName());
 		assertNotNull("No SoapHeaderElement returned", headerElement);
-		String payload = "<content xmlns='http://www.springframework.org'/>";
+		String payload = "<content xmlns='https://www.springframework.org'/>";
 		transformer.transform(new StringSource(payload), headerElement.getResult());
 		Iterator<SoapHeaderElement> iterator = soapHeader.examineAllHeaderElements();
 		assertNotNull("header element iterator is null", iterator);
@@ -83,7 +83,7 @@ public abstract class AbstractSoapHeaderTestCase extends AbstractSoapElementTest
 		StringResult result = new StringResult();
 		transformer.transform(headerElement.getSource(), result);
 		assertXMLEqual("Invalid contents of header element",
-				"<spring:localName xmlns:spring='http://www.springframework.org'><spring:content/></spring:localName>",
+				"<spring:localName xmlns:spring='https://www.springframework.org'><spring:content/></spring:localName>",
 				result.toString());
 		assertFalse("header element iterator has too many elements", iterator.hasNext());
 	}
@@ -125,7 +125,7 @@ public abstract class AbstractSoapHeaderTestCase extends AbstractSoapElementTest
 	@Test
 	public void testGetResult() throws Exception {
 		String content =
-				"<spring:localName xmlns:spring='http://www.springframework.org'><spring:content/></spring:localName>";
+				"<spring:localName xmlns:spring='https://www.springframework.org'><spring:content/></spring:localName>";
 		transformer.transform(new StringSource(content), soapHeader.getResult());
 		Iterator<SoapHeaderElement> iterator = soapHeader.examineAllHeaderElements();
 		assertTrue("Header has no children", iterator.hasNext());

--- a/spring-ws-core/src/test/java/org/springframework/ws/soap/AbstractSoapMessageTestCase.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/soap/AbstractSoapMessageTestCase.java
@@ -102,7 +102,7 @@ public abstract class AbstractSoapMessageTestCase extends AbstractMimeMessageTes
 		}
 		StreamingWebServiceMessage streamingMessage = (StreamingWebServiceMessage) soapMessage;
 
-		final QName name = new QName("http://springframework.org", "root", "");
+		final QName name = new QName("https://springframework.org", "root", "");
 		streamingMessage.setStreamingPayload(new StreamingPayload() {
 			public QName getName() {
 				return name;
@@ -122,7 +122,7 @@ public abstract class AbstractSoapMessageTestCase extends AbstractMimeMessageTes
 		StringResult result = new StringResult();
 		transformer.transform(streamingMessage.getPayloadSource(), result);
 
-		String expected = "<root xmlns='http://springframework.org'><child>Foo</child></root>";
+		String expected = "<root xmlns='https://springframework.org'><child>Foo</child></root>";
 		assertXMLEqual(expected, result.toString());
 
 		soapMessage.writeTo(new ByteArrayOutputStream());

--- a/spring-ws-core/src/test/java/org/springframework/ws/soap/addressing/client/AbstractActionCallbackTestCase.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/soap/addressing/client/AbstractActionCallbackTestCase.java
@@ -70,8 +70,8 @@ public abstract class AbstractActionCallbackTestCase extends AbstractWsAddressin
 		callback = new ActionCallback(action, getVersion(), to);
 		callback.setMessageIdStrategy(strategyMock);
 		SaajSoapMessage message = createDeleteMessage();
-		expect(strategyMock.newMessageId(message)).andReturn(new URI("http://example.com/someuniquestring"));
-		callback.setReplyTo(new EndpointReference(new URI("http://example.com/business/client1")));
+		expect(strategyMock.newMessageId(message)).andReturn(new URI("https://example.com/someuniquestring"));
+		callback.setReplyTo(new EndpointReference(new URI("https://example.com/business/client1")));
 
 		replay(strategyMock, connectionMock);
 
@@ -92,8 +92,8 @@ public abstract class AbstractActionCallbackTestCase extends AbstractWsAddressin
 		expect(connectionMock.getUri()).andReturn(connectionUri);
 
 		SaajSoapMessage message = createDeleteMessage();
-		expect(strategyMock.newMessageId(message)).andReturn(new URI("http://example.com/someuniquestring"));
-		callback.setReplyTo(new EndpointReference(new URI("http://example.com/business/client1")));
+		expect(strategyMock.newMessageId(message)).andReturn(new URI("https://example.com/someuniquestring"));
+		callback.setReplyTo(new EndpointReference(new URI("https://example.com/business/client1")));
 
 		replay(strategyMock, connectionMock);
 

--- a/spring-ws-core/src/test/java/org/springframework/ws/soap/addressing/server/AbstractAddressingInterceptorTestCase.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/soap/addressing/server/AbstractAddressingInterceptorTestCase.java
@@ -186,7 +186,7 @@ public abstract class AbstractAddressingInterceptorTestCase extends AbstractWsAd
 		URI messageId = new URI("uid:1234");
 		expect(strategyMock.newMessageId((SoapMessage) context.getResponse())).andReturn(messageId);
 
-		URI uri = new URI("http://example.com/business/client1");
+		URI uri = new URI("https://example.com/business/client1");
 		expect(senderMock.supports(uri)).andReturn(true);
 		expect(senderMock.createConnection(uri)).andReturn(connectionMock);
 		connectionMock.send(response);

--- a/spring-ws-core/src/test/java/org/springframework/ws/soap/addressing/server/AnnotationActionMethodEndpointMappingTest.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/soap/addressing/server/AnnotationActionMethodEndpointMappingTest.java
@@ -97,7 +97,7 @@ public class AnnotationActionMethodEndpointMappingTest {
 	@Address("mailto:joe@fabrikam123.example")
 	private static class MyEndpoint {
 
-		@Action("http://fabrikam123.example/mail/Delete")
+		@Action("https://fabrikam123.example/mail/Delete")
 		public void doIt() {
 
 		}

--- a/spring-ws-core/src/test/java/org/springframework/ws/soap/axiom/AxiomSoap11BodyTest.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/soap/axiom/AxiomSoap11BodyTest.java
@@ -43,7 +43,7 @@ public class AxiomSoap11BodyTest extends AbstractSoap11BodyTestCase {
 		AxiomSoapMessage axiomSoapMessage = messageFactory.createWebServiceMessage();
 		soapBody = axiomSoapMessage.getSoapBody();
 
-		String payload = "<payload xmlns='http://www.springframework.org' />";
+		String payload = "<payload xmlns='https://www.springframework.org' />";
 		transformer.transform(new StringSource(payload), soapBody.getPayloadResult());
 		assertPayloadEqual(payload);
 	}

--- a/spring-ws-core/src/test/java/org/springframework/ws/soap/axiom/AxiomSoap11MessageFactoryTest.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/soap/axiom/AxiomSoap11MessageFactoryTest.java
@@ -105,7 +105,7 @@ public class AxiomSoap11MessageFactoryTest extends AbstractSoap11MessageFactoryT
 	}
 
 	/**
-	 * See http://jira.springframework.org/browse/SWS-502
+	 * See https://jira.springframework.org/browse/SWS-502
 	 */
 	@Test
 	public void testSWS502() throws Exception {

--- a/spring-ws-core/src/test/java/org/springframework/ws/soap/axiom/AxiomSoap12BodyTest.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/soap/axiom/AxiomSoap12BodyTest.java
@@ -43,7 +43,7 @@ public class AxiomSoap12BodyTest extends AbstractSoap12BodyTestCase {
 		AxiomSoapMessage axiomSoapMessage = messageFactory.createWebServiceMessage();
 		soapBody = axiomSoapMessage.getSoapBody();
 
-		String payload = "<payload xmlns='http://www.springframework.org' />";
+		String payload = "<payload xmlns='https://www.springframework.org' />";
 		transformer.transform(new StringSource(payload), soapBody.getPayloadResult());
 		assertPayloadEqual(payload);
 	}

--- a/spring-ws-core/src/test/java/org/springframework/ws/soap/axiom/support/AxiomUtilsTest.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/soap/axiom/support/AxiomUtilsTest.java
@@ -51,7 +51,7 @@ public class AxiomUtilsTest {
 	@Before
 	public void setUp() throws Exception {
 		OMFactory factory = OMAbstractFactory.getOMFactory();
-		OMNamespace namespace = factory.createOMNamespace("http://www.springframework.org", "prefix");
+		OMNamespace namespace = factory.createOMNamespace("https://www.springframework.org", "prefix");
 		element = factory.createOMElement("element", namespace);
 		XMLUnit.setIgnoreWhitespace(true);
 	}
@@ -66,7 +66,7 @@ public class AxiomUtilsTest {
 
 	@Test
 	public void testToNamespaceUndeclared() throws Exception {
-		QName qName = new QName("http://www.example.com", "localPart");
+		QName qName = new QName("https://www.example.com", "localPart");
 		OMNamespace namespace = AxiomUtils.toNamespace(qName, element);
 		Assert.assertNotNull("Invalid namespace", namespace);
 		Assert.assertEquals("Invalid namespace", qName.getNamespaceURI(), namespace.getNamespaceURI());
@@ -84,7 +84,7 @@ public class AxiomUtilsTest {
 
 	@Test
 	public void testToNamespacePrefixUndeclared() throws Exception {
-		QName qName = new QName("http://www.example.com", "localPart", "otherPrefix");
+		QName qName = new QName("https://www.example.com", "localPart", "otherPrefix");
 		OMNamespace namespace = AxiomUtils.toNamespace(qName, element);
 		Assert.assertNotNull("Invalid namespace", namespace);
 		Assert.assertEquals("Invalid namespace", qName.getNamespaceURI(), namespace.getNamespaceURI());

--- a/spring-ws-core/src/test/java/org/springframework/ws/soap/saaj/support/SaajXmlReaderTest.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/soap/saaj/support/SaajXmlReaderTest.java
@@ -53,8 +53,8 @@ public class SaajXmlReaderTest {
 
 	@Test
 	public void testNamespacesPrefixes() throws Exception {
-		saajReader.setFeature("http://xml.org/sax/features/namespaces", true);
-		saajReader.setFeature("http://xml.org/sax/features/namespace-prefixes", true);
+		saajReader.setFeature("http://www.xml.org/sax/features/namespaces", true);
+		saajReader.setFeature("http://www.xml.org/sax/features/namespace-prefixes", true);
 		DOMResult result = new DOMResult();
 		Source source = new SAXSource(saajReader, new InputSource());
 		transformer.transform(source, result);
@@ -65,8 +65,8 @@ public class SaajXmlReaderTest {
 
 	@Test
 	public void testNamespacesNoPrefixes() throws Exception {
-		saajReader.setFeature("http://xml.org/sax/features/namespaces", true);
-		saajReader.setFeature("http://xml.org/sax/features/namespace-prefixes", false);
+		saajReader.setFeature("http://www.xml.org/sax/features/namespaces", true);
+		saajReader.setFeature("http://www.xml.org/sax/features/namespace-prefixes", false);
 		DOMResult result = new DOMResult();
 		Source source = new SAXSource(saajReader, new InputSource());
 		transformer.transform(source, result);

--- a/spring-ws-core/src/test/java/org/springframework/ws/soap/server/SoapMessageDispatcherTest.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/soap/server/SoapMessageDispatcherTest.java
@@ -59,7 +59,7 @@ public class SoapMessageDispatcherTest {
 		MessageFactory messageFactory = MessageFactory.newInstance(SOAPConstants.SOAP_1_1_PROTOCOL);
 		SOAPMessage request = messageFactory.createMessage();
 		SOAPHeaderElement header =
-				request.getSOAPHeader().addHeaderElement(new QName("http://www.springframework.org", "Header"));
+				request.getSOAPHeader().addHeaderElement(new QName("https://www.springframework.org", "Header"));
 		header.setActor(SOAPConstants.URI_SOAP_ACTOR_NEXT);
 		header.setMustUnderstand(true);
 		SoapMessageFactory factory = new SaajSoapMessageFactory(messageFactory);
@@ -82,7 +82,7 @@ public class SoapMessageDispatcherTest {
 		MessageFactory messageFactory = MessageFactory.newInstance(SOAPConstants.SOAP_1_2_PROTOCOL);
 		SOAPMessage request = messageFactory.createMessage();
 		SOAPHeaderElement header =
-				request.getSOAPHeader().addHeaderElement(new QName("http://www.springframework.org", "Header"));
+				request.getSOAPHeader().addHeaderElement(new QName("https://www.springframework.org", "Header"));
 		header.setMustUnderstand(true);
 		header.setRole(SOAPConstants.URI_SOAP_1_2_ROLE_NEXT);
 		SoapMessageFactory factory = new SaajSoapMessageFactory(messageFactory);
@@ -105,7 +105,7 @@ public class SoapMessageDispatcherTest {
 		MessageFactory messageFactory = MessageFactory.newInstance(SOAPConstants.SOAP_1_1_PROTOCOL);
 		SOAPMessage request = messageFactory.createMessage();
 		SOAPHeaderElement header = request.getSOAPHeader()
-				.addHeaderElement(new QName("http://www.springframework.org", "Header", "spring-ws"));
+				.addHeaderElement(new QName("https://www.springframework.org", "Header", "spring-ws"));
 		header.setActor(SOAPConstants.URI_SOAP_ACTOR_NEXT);
 		header.setMustUnderstand(true);
 		SoapMessageFactory factory = new SaajSoapMessageFactory(messageFactory);
@@ -137,7 +137,7 @@ public class SoapMessageDispatcherTest {
 		MessageFactory messageFactory = MessageFactory.newInstance(SOAPConstants.SOAP_1_2_PROTOCOL);
 		SOAPMessage request = messageFactory.createMessage();
 		SOAPHeaderElement header = request.getSOAPHeader()
-				.addHeaderElement(new QName("http://www.springframework.org", "Header", "spring-ws"));
+				.addHeaderElement(new QName("https://www.springframework.org", "Header", "spring-ws"));
 		header.setMustUnderstand(true);
 		header.setRole(SOAPConstants.URI_SOAP_1_2_ROLE_NEXT);
 		SoapMessageFactory factory = new SaajSoapMessageFactory(messageFactory);
@@ -175,8 +175,8 @@ public class SoapMessageDispatcherTest {
 		MessageFactory messageFactory = MessageFactory.newInstance(SOAPConstants.SOAP_1_1_PROTOCOL);
 		SOAPMessage request = messageFactory.createMessage();
 		SOAPHeaderElement header = request.getSOAPHeader()
-				.addHeaderElement(new QName("http://www.springframework.org", "Header", "spring-ws"));
-		String headerActor = "http://www/springframework.org/role";
+				.addHeaderElement(new QName("https://www.springframework.org", "Header", "spring-ws"));
+		String headerActor = "https://www/springframework.org/role";
 		header.setActor(headerActor);
 		header.setMustUnderstand(true);
 		SoapMessageFactory factory = new SaajSoapMessageFactory(messageFactory);
@@ -199,8 +199,8 @@ public class SoapMessageDispatcherTest {
 		MessageFactory messageFactory = MessageFactory.newInstance(SOAPConstants.SOAP_1_2_PROTOCOL);
 		SOAPMessage request = messageFactory.createMessage();
 		SOAPHeaderElement header = request.getSOAPHeader()
-				.addHeaderElement(new QName("http://www.springframework.org", "Header", "spring-ws"));
-		String headerRole = "http://www/springframework.org/role";
+				.addHeaderElement(new QName("https://www.springframework.org", "Header", "spring-ws"));
+		String headerRole = "https://www/springframework.org/role";
 		header.setRole(headerRole);
 		header.setMustUnderstand(true);
 		SoapMessageFactory factory = new SaajSoapMessageFactory(messageFactory);
@@ -240,7 +240,7 @@ public class SoapMessageDispatcherTest {
 		MessageFactory messageFactory = MessageFactory.newInstance(SOAPConstants.SOAP_1_1_PROTOCOL);
 		SOAPMessage request = messageFactory.createMessage();
 		SOAPHeaderElement header =
-				request.getSOAPHeader().addHeaderElement(new QName("http://www.springframework.org", "Header"));
+				request.getSOAPHeader().addHeaderElement(new QName("https://www.springframework.org", "Header"));
 		header.setActor(SOAPConstants.URI_SOAP_ACTOR_NEXT);
 		header.setMustUnderstand(true);
 		SoapMessageFactory factory = new SaajSoapMessageFactory(messageFactory);

--- a/spring-ws-core/src/test/java/org/springframework/ws/soap/server/endpoint/adapter/method/SoapHeaderElementMethodArgumentResolverTest.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/soap/server/endpoint/adapter/method/SoapHeaderElementMethodArgumentResolverTest.java
@@ -133,18 +133,18 @@ public class SoapHeaderElementMethodArgumentResolverTest extends AbstractMethodA
 	public void soapHeaderWithEmptyValue(@SoapHeader("") SoapHeaderElement element) {
 	}
 
-	public void soapHeaderElement(@SoapHeader("{http://springframework.org/ws}header") SoapHeaderElement element) {
+	public void soapHeaderElement(@SoapHeader("{https://springframework.org/ws}header") SoapHeaderElement element) {
 	}
 
 	public void soapHeaderElementList(@SoapHeader(
-			"{http://springframework.org/ws}header") List<SoapHeaderElement> elements) {
+			"{https://springframework.org/ws}header") List<SoapHeaderElement> elements) {
 	}
 
-	public void soapHeaderMismatch(@SoapHeader("{http://springframework.org/ws}xxx") SoapHeaderElement element) {
+	public void soapHeaderMismatch(@SoapHeader("{https://springframework.org/ws}xxx") SoapHeaderElement element) {
 	}
 
 	public void soapHeaderMismatchList(@SoapHeader(
-			"{http://springframework.org/ws}xxx") List<SoapHeaderElement> elements) {
+			"{https://springframework.org/ws}xxx") List<SoapHeaderElement> elements) {
 	}
 
 

--- a/spring-ws-core/src/test/java/org/springframework/ws/soap/server/endpoint/interceptor/PayloadRootSmartSoapEndpointInterceptorTest.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/soap/server/endpoint/interceptor/PayloadRootSmartSoapEndpointInterceptorTest.java
@@ -67,7 +67,7 @@ public class PayloadRootSmartSoapEndpointInterceptorTest {
 	@Test
 	public void shouldInterceptFullNonMatch() throws Exception {
 		PayloadRootSmartSoapEndpointInterceptor interceptor =
-				new PayloadRootSmartSoapEndpointInterceptor(delegate, "http://springframework.org/other", localPart);
+				new PayloadRootSmartSoapEndpointInterceptor(delegate, "https://springframework.org/other", localPart);
 
 		boolean result = interceptor.shouldIntercept(messageContext, null);
 		assertFalse("Interceptor should not apply", result);
@@ -85,7 +85,7 @@ public class PayloadRootSmartSoapEndpointInterceptorTest {
 	@Test
 	public void shouldInterceptNamespaceUriNonMatch() throws Exception {
 		PayloadRootSmartSoapEndpointInterceptor interceptor =
-				new PayloadRootSmartSoapEndpointInterceptor(delegate, "http://springframework.org/other", null);
+				new PayloadRootSmartSoapEndpointInterceptor(delegate, "https://springframework.org/other", null);
 
 		boolean result = interceptor.shouldIntercept(messageContext, null);
 		assertFalse("Interceptor should not apply", result);

--- a/spring-ws-core/src/test/java/org/springframework/ws/soap/server/endpoint/interceptor/PayloadValidatingInterceptorTest.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/soap/server/endpoint/interceptor/PayloadValidatingInterceptorTest.java
@@ -204,7 +204,7 @@ public class PayloadValidatingInterceptorTest {
 	@Test
 	public void testNamespacesInType() throws Exception {
 		// Make sure we use Xerces for this testcase: the JAXP implementation used internally by JDK 1.5 has a bug
-		// See http://opensource.atlassian.com/projects/spring/browse/SWS-35
+		// See https://opensource.atlassian.com/projects/spring/browse/SWS-35
 		String previousSchemaFactory =
 				System.getProperty("javax.xml.validation.SchemaFactory:" + XMLConstants.W3C_XML_SCHEMA_NS_URI, "");
 		System.setProperty("javax.xml.validation.SchemaFactory:" + XMLConstants.W3C_XML_SCHEMA_NS_URI,

--- a/spring-ws-core/src/test/java/org/springframework/ws/soap/server/endpoint/interceptor/SoapActionSmartEndpointInterceptorTest.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/soap/server/endpoint/interceptor/SoapActionSmartEndpointInterceptorTest.java
@@ -66,7 +66,7 @@ public class SoapActionSmartEndpointInterceptorTest {
 	@Test
 	public void shouldInterceptNonMatch() throws Exception {
 		SoapActionSmartEndpointInterceptor interceptor =
-				new SoapActionSmartEndpointInterceptor(delegate, "http://springframework.org/other");
+				new SoapActionSmartEndpointInterceptor(delegate, "https://springframework.org/other");
 
 		boolean result = interceptor.shouldIntercept(messageContext, null);
 		assertFalse("Interceptor should apply", result);

--- a/spring-ws-core/src/test/java/org/springframework/ws/soap/soap11/AbstractSoap11BodyTestCase.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/soap/soap11/AbstractSoap11BodyTestCase.java
@@ -84,7 +84,7 @@ public abstract class AbstractSoap11BodyTestCase extends AbstractSoapBodyTestCas
 
 	@Test
 	public void testAddFault() throws Exception {
-		QName faultCode = new QName("http://www.springframework.org", "fault", "spring");
+		QName faultCode = new QName("https://www.springframework.org", "fault", "spring");
 		String faultString = "faultString";
 		Soap11Fault fault = ((Soap11Body) soapBody).addFault(faultCode, faultString, Locale.ENGLISH);
 		assertNotNull("Null returned", fault);
@@ -93,18 +93,18 @@ public abstract class AbstractSoap11BodyTestCase extends AbstractSoapBodyTestCas
 		assertEquals("Invalid fault code", faultCode, fault.getFaultCode());
 		assertEquals("Invalid fault string", faultString, fault.getFaultStringOrReason());
 		assertEquals("Invalid fault string locale", Locale.ENGLISH, fault.getFaultStringLocale());
-		String actor = "http://www.springframework.org/actor";
+		String actor = "https://www.springframework.org/actor";
 		fault.setFaultActorOrRole(actor);
 		assertEquals("Invalid fault actor", actor, fault.getFaultActorOrRole());
 		assertPayloadEqual("<SOAP-ENV:Fault xmlns:SOAP-ENV='http://schemas.xmlsoap.org/soap/envelope/' " +
-				"xmlns:spring='http://www.springframework.org'>" + "<faultcode>spring:fault</faultcode>" +
+				"xmlns:spring='https://www.springframework.org'>" + "<faultcode>spring:fault</faultcode>" +
 				"<faultstring xml:lang='en'>" + faultString + "</faultstring>" + "<faultactor>" + actor +
 				"</faultactor>" + "</SOAP-ENV:Fault>");
 	}
 
 	@Test
 	public void testAddFaultNoPrefix() throws Exception {
-		QName faultCode = new QName("http://www.springframework.org", "fault");
+		QName faultCode = new QName("https://www.springframework.org", "fault");
 		String faultString = "faultString";
 		Soap11Fault fault = ((Soap11Body) soapBody).addFault(faultCode, faultString, Locale.ENGLISH);
 		assertNotNull("Null returned", fault);
@@ -113,18 +113,18 @@ public abstract class AbstractSoap11BodyTestCase extends AbstractSoapBodyTestCas
 		assertEquals("Invalid fault code", faultCode, fault.getFaultCode());
 		assertEquals("Invalid fault string", faultString, fault.getFaultStringOrReason());
 		assertEquals("Invalid fault string locale", Locale.ENGLISH, fault.getFaultStringLocale());
-		String actor = "http://www.springframework.org/actor";
+		String actor = "https://www.springframework.org/actor";
 		fault.setFaultActorOrRole(actor);
 		assertEquals("Invalid fault actor", actor, fault.getFaultActorOrRole());
 	}
 
 	@Test
 	public void testAddFaultWithDetail() throws Exception {
-		QName faultCode = new QName("http://www.springframework.org", "fault", "spring");
+		QName faultCode = new QName("https://www.springframework.org", "fault", "spring");
 		String faultString = "faultString";
 		SoapFault fault = ((Soap11Body) soapBody).addFault(faultCode, faultString, null);
 		SoapFaultDetail detail = fault.addFaultDetail();
-		QName detailName = new QName("http://www.springframework.org", "detailEntry", "spring");
+		QName detailName = new QName("https://www.springframework.org", "detailEntry", "spring");
 		SoapFaultDetailElement detailElement1 = detail.addFaultDetailElement(detailName);
 		StringSource detailContents = new StringSource("<detailContents xmlns='namespace'/>");
 		transformer.transform(detailContents, detailElement1.getResult());
@@ -132,11 +132,11 @@ public abstract class AbstractSoap11BodyTestCase extends AbstractSoapBodyTestCas
 		detailContents = new StringSource("<detailContents xmlns='namespace'/>");
 		transformer.transform(detailContents, detailElement2.getResult());
 		assertPayloadEqual(
-				"<SOAP-ENV:Fault xmlns:SOAP-ENV='http://schemas.xmlsoap.org/soap/envelope/' xmlns:spring='http://www.springframework.org'>" +
+				"<SOAP-ENV:Fault xmlns:SOAP-ENV='http://schemas.xmlsoap.org/soap/envelope/' xmlns:spring='https://www.springframework.org'>" +
 						"<faultcode>spring:fault</faultcode>" + "<faultstring>" + faultString + "</faultstring>" +
 						"<detail>" +
-						"<spring:detailEntry xmlns:spring='http://www.springframework.org'><detailContents xmlns='namespace'/></spring:detailEntry>" +
-						"<spring:detailEntry xmlns:spring='http://www.springframework.org'><detailContents xmlns='namespace'/></spring:detailEntry>" +
+						"<spring:detailEntry xmlns:spring='https://www.springframework.org'><detailContents xmlns='namespace'/></spring:detailEntry>" +
+						"<spring:detailEntry xmlns:spring='https://www.springframework.org'><detailContents xmlns='namespace'/></spring:detailEntry>" +
 						"</detail>" + "</SOAP-ENV:Fault>");
 
 	}

--- a/spring-ws-core/src/test/java/org/springframework/ws/soap/soap11/AbstractSoap11MessageTestCase.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/soap/soap11/AbstractSoap11MessageTestCase.java
@@ -58,7 +58,7 @@ public abstract class AbstractSoap11MessageTestCase extends AbstractSoapMessageT
 	@Override
 	public void testWriteToTransportOutputStream() throws Exception {
 		SoapBody body = soapMessage.getSoapBody();
-		String payload = "<payload xmlns='http://www.springframework.org' />";
+		String payload = "<payload xmlns='https://www.springframework.org' />";
 		transformer.transform(new StringSource(payload), body.getPayloadResult());
 
 		ByteArrayOutputStream bos = new ByteArrayOutputStream();
@@ -68,7 +68,7 @@ public abstract class AbstractSoap11MessageTestCase extends AbstractSoapMessageT
 		soapMessage.writeTo(tos);
 		String result = bos.toString("UTF-8");
 		assertXMLEqual(
-				"<" + getNS() + ":Envelope xmlns:" + getNS() + "='http://schemas.xmlsoap.org/soap/envelope/'>" + getHeader() + "<" + getNS() + ":Body><payload xmlns='http://www.springframework.org' /></" + getNS() + ":Body></" + getNS() + ":Envelope>",
+				"<" + getNS() + ":Envelope xmlns:" + getNS() + "='http://schemas.xmlsoap.org/soap/envelope/'>" + getHeader() + "<" + getNS() + ":Body><payload xmlns='https://www.springframework.org' /></" + getNS() + ":Body></" + getNS() + ":Envelope>",
 				result);
 		String contentType = tos.getHeaders().get("Content-Type");
 		assertTrue("Invalid Content-Type set", contentType.indexOf(SoapVersion.SOAP_11.getContentType()) != -1);
@@ -94,7 +94,7 @@ public abstract class AbstractSoap11MessageTestCase extends AbstractSoapMessageT
 
 	@Override
 	public void testToDocument() throws Exception {
-		transformer.transform(new StringSource("<payload xmlns='http://www.springframework.org' />"),
+		transformer.transform(new StringSource("<payload xmlns='https://www.springframework.org' />"),
 				soapMessage.getSoapBody().getPayloadResult());
 
 		DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactoryUtils.newInstance();
@@ -111,7 +111,7 @@ public abstract class AbstractSoap11MessageTestCase extends AbstractSoapMessageT
 
 		Element body = expected.createElementNS("http://schemas.xmlsoap.org/soap/envelope/", "Body");
 		envelope.appendChild(body);
-		Element payload = expected.createElementNS("http://www.springframework.org", "payload");
+		Element payload = expected.createElementNS("https://www.springframework.org", "payload");
 		body.appendChild(payload);
 
 		Document result = soapMessage.getDocument();
@@ -121,7 +121,7 @@ public abstract class AbstractSoap11MessageTestCase extends AbstractSoapMessageT
 
 	@Override
 	public void testSetLiveDocument() throws Exception {
-		transformer.transform(new StringSource("<payload xmlns='http://www.springframework.org' />"),
+		transformer.transform(new StringSource("<payload xmlns='https://www.springframework.org' />"),
 				soapMessage.getSoapBody().getPayloadResult());
 
 		Document document = soapMessage.getDocument();
@@ -133,13 +133,13 @@ public abstract class AbstractSoap11MessageTestCase extends AbstractSoapMessageT
 
 		String result = bos.toString("UTF-8");
 		assertXMLEqual(
-				"<" + getNS() + ":Envelope xmlns:" + getNS() + "='http://schemas.xmlsoap.org/soap/envelope/'>" + getHeader() + "<" + getNS() + ":Body><payload xmlns='http://www.springframework.org' /></" + getNS() + ":Body></" + getNS() + ":Envelope>",
+				"<" + getNS() + ":Envelope xmlns:" + getNS() + "='http://schemas.xmlsoap.org/soap/envelope/'>" + getHeader() + "<" + getNS() + ":Body><payload xmlns='https://www.springframework.org' /></" + getNS() + ":Body></" + getNS() + ":Envelope>",
 				result);
 	}
 
 	@Override
 	public void testSetOtherDocument() throws Exception {
-		transformer.transform(new StringSource("<payload xmlns='http://www.springframework.org' />"),
+		transformer.transform(new StringSource("<payload xmlns='https://www.springframework.org' />"),
 				soapMessage.getSoapBody().getPayloadResult());
 
 		ByteArrayOutputStream bos = new ByteArrayOutputStream();
@@ -158,7 +158,7 @@ public abstract class AbstractSoap11MessageTestCase extends AbstractSoapMessageT
 
 		String result = bos.toString("UTF-8");
 		assertXMLEqual(
-				"<" + getNS() + ":Envelope xmlns:" + getNS() + "='http://schemas.xmlsoap.org/soap/envelope/'>" + getHeader() + "<" + getNS() + ":Body><payload xmlns='http://www.springframework.org' /></" + getNS() + ":Body></" + getNS() + ":Envelope>",
+				"<" + getNS() + ":Envelope xmlns:" + getNS() + "='http://schemas.xmlsoap.org/soap/envelope/'>" + getHeader() + "<" + getNS() + ":Body><payload xmlns='https://www.springframework.org' /></" + getNS() + ":Body></" + getNS() + ":Envelope>",
 				result);
 	}
 

--- a/spring-ws-core/src/test/java/org/springframework/ws/soap/soap12/AbstractSoap12BodyTestCase.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/soap/soap12/AbstractSoap12BodyTestCase.java
@@ -138,9 +138,9 @@ public abstract class AbstractSoap12BodyTestCase extends AbstractSoapBodyTestCas
 	@Test
 	public void testAddFaultWithSubcode() throws Exception {
 		Soap12Fault fault = (Soap12Fault) soapBody.addServerOrReceiverFault("faultString", Locale.ENGLISH);
-		QName subcode1 = new QName("http://www.springframework.org", "Subcode1", "spring-ws");
+		QName subcode1 = new QName("https://www.springframework.org", "Subcode1", "spring-ws");
 		fault.addFaultSubcode(subcode1);
-		QName subcode2 = new QName("http://www.springframework.org", "Subcode2", "spring-ws");
+		QName subcode2 = new QName("https://www.springframework.org", "Subcode2", "spring-ws");
 		fault.addFaultSubcode(subcode2);
 		Iterator<QName> iterator = fault.getFaultSubcodes();
 		assertTrue("No subcode found", iterator.hasNext());
@@ -153,8 +153,8 @@ public abstract class AbstractSoap12BodyTestCase extends AbstractSoapBodyTestCas
 		assertXMLEqual("Invalid source for body",
 				"<soapenv:Fault xmlns:soapenv='http://www.w3.org/2003/05/soap-envelope'>" +
 						"<soapenv:Code><soapenv:Value>" + soapBody.getName().getPrefix() + ":Receiver</soapenv:Value>" +
-						"<soapenv:Subcode><soapenv:Value xmlns:spring-ws='http://www.springframework.org'>spring-ws:Subcode1</soapenv:Value>" +
-						"<soapenv:Subcode><soapenv:Value xmlns:spring-ws='http://www.springframework.org'>spring-ws:Subcode2</soapenv:Value>" +
+						"<soapenv:Subcode><soapenv:Value xmlns:spring-ws='https://www.springframework.org'>spring-ws:Subcode1</soapenv:Value>" +
+						"<soapenv:Subcode><soapenv:Value xmlns:spring-ws='https://www.springframework.org'>spring-ws:Subcode2</soapenv:Value>" +
 						"</soapenv:Subcode></soapenv:Subcode></soapenv:Code>" +
 						"<soapenv:Reason><soapenv:Text xml:lang='en'>faultString</soapenv:Text></soapenv:Reason>" +
 						"</soapenv:Fault>", result.toString());

--- a/spring-ws-core/src/test/java/org/springframework/ws/soap/soap12/AbstractSoap12HeaderTestCase.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/soap/soap12/AbstractSoap12HeaderTestCase.java
@@ -52,12 +52,12 @@ public abstract class AbstractSoap12HeaderTestCase extends AbstractSoapHeaderTes
 	@Test
 	public void testAddNotUnderstood() throws Exception {
 		Soap12Header soap12Header = (Soap12Header) soapHeader;
-		QName headerName = new QName("http://www.springframework.org", "NotUnderstood", "spring-ws");
+		QName headerName = new QName("https://www.springframework.org", "NotUnderstood", "spring-ws");
 		soap12Header.addNotUnderstoodHeaderElement(headerName);
 		StringResult result = new StringResult();
 		transformer.transform(soapHeader.getSource(), result);
 		assertXMLEqual("Invalid contents of header", "<Header xmlns='http://www.w3.org/2003/05/soap-envelope' >" +
-				"<NotUnderstood qname='spring-ws:NotUnderstood' xmlns:spring-ws='http://www.springframework.org' />" +
+				"<NotUnderstood qname='spring-ws:NotUnderstood' xmlns:spring-ws='https://www.springframework.org' />" +
 				"</Header>", result.toString());
 	}
 

--- a/spring-ws-core/src/test/java/org/springframework/ws/soap/soap12/AbstractSoap12MessageTestCase.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/soap/soap12/AbstractSoap12MessageTestCase.java
@@ -60,7 +60,7 @@ public abstract class AbstractSoap12MessageTestCase extends AbstractSoapMessageT
 	@Override
 	public void testWriteToTransportOutputStream() throws Exception {
 		SoapBody body = soapMessage.getSoapBody();
-		String payload = "<payload xmlns='http://www.springframework.org' />";
+		String payload = "<payload xmlns='https://www.springframework.org' />";
 		transformer.transform(new StringSource(payload), body.getPayloadResult());
 
 		final ByteArrayOutputStream bos = new ByteArrayOutputStream();
@@ -70,7 +70,7 @@ public abstract class AbstractSoap12MessageTestCase extends AbstractSoapMessageT
 		soapMessage.writeTo(tos);
 		String result = bos.toString("UTF-8");
 		assertXMLEqual(
-				"<" + getNS() + ":Envelope xmlns:" + getNS() + "='http://www.w3.org/2003/05/soap-envelope'>" + getHeader() + "<" + getNS() + ":Body><payload xmlns='http://www.springframework.org' /></" + getNS() + ":Body></" + getNS() + ":Envelope>",
+				"<" + getNS() + ":Envelope xmlns:" + getNS() + "='http://www.w3.org/2003/05/soap-envelope'>" + getHeader() + "<" + getNS() + ":Body><payload xmlns='https://www.springframework.org' /></" + getNS() + ":Body></" + getNS() + ":Envelope>",
 				result);
 		String contentType = tos.getHeaders().get(TransportConstants.HEADER_CONTENT_TYPE);
 		assertTrue("Invalid Content-Type set",
@@ -98,7 +98,7 @@ public abstract class AbstractSoap12MessageTestCase extends AbstractSoapMessageT
 
 	@Override
 	public void testToDocument() throws Exception {
-		transformer.transform(new StringSource("<payload xmlns='http://www.springframework.org' />"),
+		transformer.transform(new StringSource("<payload xmlns='https://www.springframework.org' />"),
 				soapMessage.getSoapBody().getPayloadResult());
 
 		DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactoryUtils.newInstance();
@@ -115,7 +115,7 @@ public abstract class AbstractSoap12MessageTestCase extends AbstractSoapMessageT
 
 		Element body = expected.createElementNS("http://www.w3.org/2003/05/soap-envelope", "Body");
 		envelope.appendChild(body);
-		Element payload = expected.createElementNS("http://www.springframework.org", "payload");
+		Element payload = expected.createElementNS("https://www.springframework.org", "payload");
 		body.appendChild(payload);
 
 		Document result = soapMessage.getDocument();
@@ -125,7 +125,7 @@ public abstract class AbstractSoap12MessageTestCase extends AbstractSoapMessageT
 
 	@Override
 	public void testSetLiveDocument() throws Exception {
-		transformer.transform(new StringSource("<payload xmlns='http://www.springframework.org' />"),
+		transformer.transform(new StringSource("<payload xmlns='https://www.springframework.org' />"),
 				soapMessage.getSoapBody().getPayloadResult());
 
 		Document document = soapMessage.getDocument();
@@ -137,13 +137,13 @@ public abstract class AbstractSoap12MessageTestCase extends AbstractSoapMessageT
 
 		String result = bos.toString("UTF-8");
 		assertXMLEqual(
-				"<" + getNS() + ":Envelope xmlns:" + getNS() + "='http://www.w3.org/2003/05/soap-envelope'>" + getHeader() + "<" + getNS() + ":Body><payload xmlns='http://www.springframework.org' /></" + getNS() + ":Body></" + getNS() + ":Envelope>",
+				"<" + getNS() + ":Envelope xmlns:" + getNS() + "='http://www.w3.org/2003/05/soap-envelope'>" + getHeader() + "<" + getNS() + ":Body><payload xmlns='https://www.springframework.org' /></" + getNS() + ":Body></" + getNS() + ":Envelope>",
 				result);
 	}
 
 	@Override
 	public void testSetOtherDocument() throws Exception {
-		transformer.transform(new StringSource("<payload xmlns='http://www.springframework.org' />"),
+		transformer.transform(new StringSource("<payload xmlns='https://www.springframework.org' />"),
 				soapMessage.getSoapBody().getPayloadResult());
 
 		ByteArrayOutputStream bos = new ByteArrayOutputStream();
@@ -162,7 +162,7 @@ public abstract class AbstractSoap12MessageTestCase extends AbstractSoapMessageT
 
 		String result = bos.toString("UTF-8");
 		assertXMLEqual(
-				"<" + getNS() + ":Envelope xmlns:" + getNS() + "='http://www.w3.org/2003/05/soap-envelope'>" + getHeader() + "<" + getNS() + ":Body><payload xmlns='http://www.springframework.org' /></" + getNS() + ":Body></" + getNS() + ":Envelope>",
+				"<" + getNS() + ":Envelope xmlns:" + getNS() + "='http://www.w3.org/2003/05/soap-envelope'>" + getHeader() + "<" + getNS() + ":Body><payload xmlns='https://www.springframework.org' /></" + getNS() + ":Body></" + getNS() + ":Envelope>",
 				result);
 	}
 

--- a/spring-ws-core/src/test/java/org/springframework/ws/transport/http/CommonsHttpMessageSenderIntegrationTest.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/transport/http/CommonsHttpMessageSenderIntegrationTest.java
@@ -54,7 +54,7 @@ public class CommonsHttpMessageSenderIntegrationTest
 		messageSender.setMaxTotalConnections(2);
 		Map<String, String> maxConnectionsPerHost = new HashMap<String, String>();
 		maxConnectionsPerHost.put("https://www.example.com", "1");
-		maxConnectionsPerHost.put("http://www.example.com:8080", "7");
+		maxConnectionsPerHost.put("https://www.example.com:8080", "7");
 		maxConnectionsPerHost.put("www.springframework.org", "10");
 		maxConnectionsPerHost.put("*", "5");
 		messageSender.setMaxConnectionsPerHost(maxConnectionsPerHost);

--- a/spring-ws-core/src/test/java/org/springframework/ws/transport/http/HttpComponentsMessageSenderIntegrationTest.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/transport/http/HttpComponentsMessageSenderIntegrationTest.java
@@ -65,7 +65,7 @@ public class HttpComponentsMessageSenderIntegrationTest
 		assertThat(route1.getTargetHost().getHostName(), equalTo("www.example.com"));
 		assertTrue((route1.getTargetHost().getPort() == -1) || (route1.getTargetHost().getPort() == 443));
 
-		final String url2 = "http://www.example.com:8080";
+		final String url2 = "https://www.example.com:8080";
 		URI uri2 = new URI(url2);
 		HttpHost host2 = new HttpHost(uri2.getHost(), uri2.getPort(), uri2.getScheme());
 		HttpRoute route2 = new HttpRoute(host2);
@@ -73,7 +73,7 @@ public class HttpComponentsMessageSenderIntegrationTest
 		assertThat(route2.getTargetHost().getHostName(), equalTo("www.example.com"));
 		assertThat(route2.getTargetHost().getPort(), equalTo(8080));
 
-		final String url3 = "http://www.springframework.org";
+		final String url3 = "https://www.springframework.org";
 		URI uri3 = new URI(url3);
 		HttpHost host3 = new HttpHost(uri3.getHost(), uri3.getPort(), uri3.getScheme());
 		HttpRoute route3 = new HttpRoute(host3);

--- a/spring-ws-core/src/test/java/org/springframework/ws/transport/http/WsdlDefinitionHandlerAdapterTest.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/transport/http/WsdlDefinitionHandlerAdapterTest.java
@@ -122,7 +122,7 @@ public class WsdlDefinitionHandlerAdapterTest {
 
 		String result = adapter.transformLocation(oldLocation, request);
 		Assert.assertNotNull("No result", result);
-		Assert.assertEquals("Invalid result", new URI("http://example.com:8080/context/service"), new URI(result));
+		Assert.assertEquals("Invalid result", new URI("https://example.com:8080/context/service"), new URI(result));
 	}
 
 	@Test
@@ -136,7 +136,7 @@ public class WsdlDefinitionHandlerAdapterTest {
 
 		String result = adapter.transformLocation(oldLocation, request);
 		Assert.assertNotNull("No result", result);
-		Assert.assertEquals("Invalid result", new URI("http://example.com:8080/service"), new URI(result));
+		Assert.assertEquals("Invalid result", new URI("https://example.com:8080/service"), new URI(result));
 	}
 
 	@Test
@@ -151,7 +151,7 @@ public class WsdlDefinitionHandlerAdapterTest {
 
 		String result = adapter.transformLocation(oldLocation, request);
 		Assert.assertNotNull("No result", result);
-		Assert.assertEquals("Invalid result", new URI("http://example.com:8080/context/service"), new URI(result));
+		Assert.assertEquals("Invalid result", new URI("https://example.com:8080/context/service"), new URI(result));
 	}
 
 	@Test
@@ -165,7 +165,7 @@ public class WsdlDefinitionHandlerAdapterTest {
 
 		String result = adapter.transformLocation(oldLocation, request);
 		Assert.assertNotNull("No result", result);
-		Assert.assertEquals("Invalid result", new URI("http://example.com:8080/service"), new URI(result));
+		Assert.assertEquals("Invalid result", new URI("https://example.com:8080/service"), new URI(result));
 	}
 
 	@Test

--- a/spring-ws-core/src/test/java/org/springframework/ws/transport/support/EchoPayloadEndpoint.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/transport/support/EchoPayloadEndpoint.java
@@ -26,7 +26,7 @@ import org.springframework.ws.server.endpoint.annotation.ResponsePayload;
 @Endpoint
 public class EchoPayloadEndpoint {
 
-	public static final String NAMESPACE = "http://springframework.org";
+	public static final String NAMESPACE = "https://springframework.org";
 
 	public static final String LOCAL_PART = "root";
 

--- a/spring-ws-core/src/test/resources/org/springframework/ws/client/support/destination/complex.wsdl
+++ b/spring-ws-core/src/test/resources/org/springframework/ws/client/support/destination/complex.wsdl
@@ -54,7 +54,7 @@
         </wsdl:operation>
     </wsdl:portType>
     <wsdl:binding name="OrderSoap12" type="tns:Order">
-        <soap12:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <soap12:binding style="document" transport="http://schemas.xmlsoap.org/soap/http/"/>
         <wsdl:operation name="GetOrder">
             <soap12:operation soapAction=""/>
             <wsdl:input name="GetOrderRequest">
@@ -69,7 +69,7 @@
         </wsdl:operation>
     </wsdl:binding>
     <wsdl:binding name="OrderSoap11" type="tns:Order">
-        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http/"/>
         <wsdl:operation name="GetOrder">
             <soap:operation soapAction=""/>
             <wsdl:input name="GetOrderRequest">
@@ -85,10 +85,10 @@
     </wsdl:binding>
     <wsdl:service name="OrderService">
         <wsdl:port binding="tns:OrderSoap11" name="OrderSoap11">
-            <soap:address location="http://example.com/soap11"/>
+            <soap:address location="https://example.com/soap11"/>
         </wsdl:port>
         <wsdl:port binding="tns:OrderSoap12" name="OrderSoap12">
-            <soap12:address location="http://example.com/soap12"/>
+            <soap12:address location="https://example.com/soap12"/>
         </wsdl:port>
     </wsdl:service>
 </wsdl:definitions>

--- a/spring-ws-core/src/test/resources/org/springframework/ws/client/support/destination/simple.wsdl
+++ b/spring-ws-core/src/test/resources/org/springframework/ws/client/support/destination/simple.wsdl
@@ -53,7 +53,7 @@
         </wsdl:operation>
     </wsdl:portType>
     <wsdl:binding name="OrderSoap11" type="tns:Order">
-        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http/"/>
         <wsdl:operation name="GetOrder">
             <soap:operation soapAction=""/>
             <wsdl:input name="GetOrderRequest">
@@ -69,7 +69,7 @@
     </wsdl:binding>
     <wsdl:service name="OrderService">
         <wsdl:port binding="tns:OrderSoap11" name="OrderSoap11">
-            <soap:address location="http://example.com/myService"/>
+            <soap:address location="https://example.com/myService"/>
         </wsdl:port>
     </wsdl:service>
 </wsdl:definitions>

--- a/spring-ws-core/src/test/resources/org/springframework/ws/client/support/interceptor/schema2.xsd
+++ b/spring-ws-core/src/test/resources/org/springframework/ws/client/support/interceptor/schema2.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema xmlns="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="qualified"
-        targetNamespace="http://springws.cas.de" xmlns:tns="http://springws.cas.de">
+        targetNamespace="https://springws.cas.de" xmlns:tns="https://springws.cas.de">
 
     <complexType name="CasDataType">
         <sequence>

--- a/spring-ws-core/src/test/resources/org/springframework/ws/soap/server/endpoint/interceptor/schema2.xsd
+++ b/spring-ws-core/src/test/resources/org/springframework/ws/soap/server/endpoint/interceptor/schema2.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema xmlns="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="qualified"
-        targetNamespace="http://springws.cas.de" xmlns:tns="http://springws.cas.de">
+        targetNamespace="https://springws.cas.de" xmlns:tns="https://springws.cas.de">
 
     <complexType name="CasDataType">
         <sequence>

--- a/spring-ws-core/src/test/resources/org/springframework/ws/soap/soap11/soap11.xsd
+++ b/spring-ws-core/src/test/resources/org/springframework/ws/soap/soap11/soap11.xsd
@@ -6,19 +6,19 @@ Portions © 2001 DevelopMentor.
 © 2001 W3C (Massachusetts Institute of Technology, Institut National de Recherche en Informatique et en Automatique, Keio University). All Rights Reserved.
 
 This document is governed by the W3C Software License [1] as described in the FAQ [2].
-[1] http://www.w3.org/Consortium/Legal/copyright-software-19980720
-[2] http://www.w3.org/Consortium/Legal/IPR-FAQ-20000620.html#DTD
+[1] https://www.w3.org/Consortium/Legal/copyright-software-19980720
+[2] https://www.w3.org/Consortium/Legal/IPR-FAQ-20000620.html#DTD
 By obtaining, using and/or copying this work, you (the licensee) agree that you have read, understood, and will comply with the following terms and conditions:
 
 Permission to use, copy, modify, and distribute this software and its documentation, with or without modification,  for any purpose and without fee or royalty is hereby granted, provided that you include the following on ALL copies of the software and documentation or portions thereof, including modifications, that you make:
 
 1.  The full text of this NOTICE in a location viewable to users of the redistributed or derivative work.
 
-2.  Any pre-existing intellectual property disclaimers, notices, or terms and conditions. If none exist, a short notice of the following form (hypertext is preferred, text is permitted) should be used within the body of any redistributed or derivative code: "Copyright © 2001 World Wide Web Consortium, (Massachusetts Institute of Technology, Institut National de Recherche en Informatique et en Automatique, Keio University). All Rights Reserved. http://www.w3.org/Consortium/Legal/"
+2.  Any pre-existing intellectual property disclaimers, notices, or terms and conditions. If none exist, a short notice of the following form (hypertext is preferred, text is permitted) should be used within the body of any redistributed or derivative code: "Copyright © 2001 World Wide Web Consortium, (Massachusetts Institute of Technology, Institut National de Recherche en Informatique et en Automatique, Keio University). All Rights Reserved. https://www.w3.org/Consortium/Legal/"
 
 3.  Notice of any changes or modifications to the W3C files, including the date changes were made. (We recommend you provide URIs to the location from which the code is derived.)
 
-Original W3C files; http://www.w3.org/2001/06/soap-envelope
+Original W3C files; https://www.w3.org/2001/06/soap-envelope
 Changes made:
      - reverted namespace to http://schemas.xmlsoap.org/soap/envelope/
      - reverted mustUnderstand to only allow 0 and 1 as lexical values

--- a/spring-ws-core/src/test/resources/org/springframework/ws/soap/soap12/soap12.xsd
+++ b/spring-ws-core/src/test/resources/org/springframework/ws/soap/soap12/soap12.xsd
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?><!-- Schema defined in the SOAP Version 1.2 Part 1 specification
      Proposed Recommendation:
-     http://www.w3.org/TR/2003/PR-soap12-part1-20030507/
+     https://www.w3.org/TR/2003/PR-soap12-part1-20030507/
      $Id: soap-envelope.xsd,v 1.1 2003/04/17 14:23:23 ylafon Exp $
 
      Copyright (C)2003 W3C(R) (MIT, ERCIM, Keio), All Rights Reserved.
      W3C viability, trademark, document use and software licensing rules
      apply.
-     http://www.w3.org/Consortium/Legal/
+     https://www.w3.org/Consortium/Legal/
 
      This document is governed by the W3C Software License [1] as
      described in the FAQ [2].
 
-     [1] http://www.w3.org/Consortium/Legal/copyright-software-19980720
-     [2] http://www.w3.org/Consortium/Legal/IPR-FAQ-20000620.html#DTD
+     [1] https://www.w3.org/Consortium/Legal/copyright-software-19980720
+     [2] https://www.w3.org/Consortium/Legal/IPR-FAQ-20000620.html#DTD
 -->
 
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://www.w3.org/2003/05/soap-envelope"
            targetNamespace="http://www.w3.org/2003/05/soap-envelope" elementFormDefault="qualified">
 
-    <xs:import namespace="http://www.w3.org/XML/1998/namespace"/>
+    <xs:import namespace="https://www.w3.org/XML/1998/namespace"/>
 
     <!-- Envelope, header and body -->
     <xs:element name="Envelope" type="tns:Envelope"/>
@@ -60,7 +60,7 @@
 
     <!-- 'encodingStyle' indicates any canonicalization conventions
    followed in the contents of the containing element.  For example, the
-   value 'http://www.w3.org/2003/05/soap-encoding' indicates the pattern
+   value 'https://www.w3.org/2003/05/soap-encoding' indicates the pattern
    described in the last call working draft of SOAP Version 1.2 Part 2:
    Adjuncts -->
 

--- a/spring-ws-core/src/test/resources/org/springframework/ws/soap/soap12/xml.xsd
+++ b/spring-ws-core/src/test/resources/org/springframework/ws/soap/soap12/xml.xsd
@@ -1,10 +1,10 @@
 <?xml version='1.0'?>
-<xs:schema targetNamespace="http://www.w3.org/XML/1998/namespace" xmlns:xs="http://www.w3.org/2001/XMLSchema"
+<xs:schema targetNamespace="https://www.w3.org/XML/1998/namespace" xmlns:xs="http://www.w3.org/2001/XMLSchema"
            xml:lang="en">
 
     <xs:annotation>
         <xs:documentation>
-            See http://www.w3.org/XML/1998/namespace.html and http://www.w3.org/TR/REC-xml for information about this
+            See https://www.w3.org/XML/1998/namespace.html and https://www.w3.org/TR/REC-xml for information about this
             namespace.
 
             This schema document describes the XML namespace, in a form suitable for import by other schema documents.
@@ -42,8 +42,8 @@
             allow xml:base, xml:lang, xml:space or xml:id attributes on elements they define.
 
             To enable this, such a schema must import this schema for the XML namespace, e.g. as follows: &lt;schema . .
-            .> . . . &lt;import namespace="http://www.w3.org/XML/1998/namespace"
-            schemaLocation="http://www.w3.org/2001/xml.xsd"/>
+            .> . . . &lt;import namespace="https://www.w3.org/XML/1998/namespace"
+            schemaLocation="https://www.w3.org/2001/xml.xsd"/>
 
             Subsequently, qualified reference to any of the attributes or the group defined below will have the desired
             effect, e.g.
@@ -56,11 +56,11 @@
 
     <xs:annotation>
         <xs:documentation>In keeping with the XML Schema WG's standard versioning policy, this schema document will
-            persist at http://www.w3.org/2005/08/xml.xsd. At the date of issue it can also be found at
-            http://www.w3.org/2001/xml.xsd. The schema document at that URI may however change in the future, in order
+            persist at https://www.w3.org/2005/08/xml.xsd. At the date of issue it can also be found at
+            https://www.w3.org/2001/xml.xsd. The schema document at that URI may however change in the future, in order
             to remain compatible with the latest version of XML Schema itself, or with the XML namespace itself. In
             other words, if the XML Schema or XML namespaces change, the version of this document at
-            http://www.w3.org/2001/xml.xsd will change accordingly; the version at http://www.w3.org/2005/08/xml.xsd
+            https://www.w3.org/2001/xml.xsd will change accordingly; the version at https://www.w3.org/2005/08/xml.xsd
             will not change.</xs:documentation>
     </xs:annotation>
 
@@ -68,8 +68,8 @@
         <xs:annotation>
             <xs:documentation>Attempting to install the relevant ISO 2- and 3-letter codes as the enumerated possible
                 values is probably never going to be a realistic possibility. See RFC 3066 at
-                http://www.ietf.org/rfc/rfc3066.txt and the IANA registry at
-                http://www.iana.org/assignments/lang-tag-apps.htm for further information.
+                https://www.ietf.org/rfc/rfc3066.txt and the IANA registry at
+                https://www.iana.org/assignments/lang-tag-apps.htm for further information.
 
                 The union allows for the 'un-declaration' of xml:lang with the empty string.</xs:documentation>
         </xs:annotation>
@@ -95,13 +95,13 @@
 
     <xs:attribute name="base" type="xs:anyURI">
         <xs:annotation>
-            <xs:documentation>See http://www.w3.org/TR/xmlbase/ for information about this attribute.</xs:documentation>
+            <xs:documentation>See https://www.w3.org/TR/xmlbase/ for information about this attribute.</xs:documentation>
         </xs:annotation>
     </xs:attribute>
 
     <xs:attribute name="id" type="xs:ID">
         <xs:annotation>
-            <xs:documentation>See http://www.w3.org/TR/xml-id/ for information about this attribute.</xs:documentation>
+            <xs:documentation>See https://www.w3.org/TR/xml-id/ for information about this attribute.</xs:documentation>
         </xs:annotation>
     </xs:attribute>
 

--- a/spring-ws-core/src/test/resources/org/springframework/ws/transport/http/echo-expected.wsdl
+++ b/spring-ws-core/src/test/resources/org/springframework/ws/transport/http/echo-expected.wsdl
@@ -32,7 +32,7 @@
         </wsdl:operation>
     </wsdl:portType>
     <wsdl:binding name="EchoBinding" type="schema:Echo">
-        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http/"/>
         <wsdl:operation name="echo">
             <soap:operation soapAction="test"/>
             <wsdl:input name="echoRequest">

--- a/spring-ws-core/src/test/resources/org/springframework/ws/transport/http/echo-input.wsdl
+++ b/spring-ws-core/src/test/resources/org/springframework/ws/transport/http/echo-input.wsdl
@@ -32,7 +32,7 @@
         </wsdl:operation>
     </wsdl:portType>
     <wsdl:binding name="EchoBinding" type="schema:Echo">
-        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http/"/>
         <wsdl:operation name="echo">
             <soap:operation soapAction="test"/>
             <wsdl:input name="echoRequest">

--- a/spring-ws-core/src/test/resources/org/springframework/ws/transport/http/wsdl11-expected.wsdl
+++ b/spring-ws-core/src/test/resources/org/springframework/ws/transport/http/wsdl11-expected.wsdl
@@ -27,7 +27,7 @@
     </wsdl:portType>
 
     <wsdl:binding name="binding" type="tns:portType">
-        <wsdlsoap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdlsoap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http/"/>
         <wsdl:operation name="operation">
             <wsdlsoap:operation soapAction=""/>
             <wsdl:input name="request">
@@ -41,7 +41,7 @@
 
     <wsdl:service name="service">
         <wsdl:port binding="tns:binding" name="port">
-            <wsdlsoap:address location="http://example.com:8080/context/service"/>
+            <wsdlsoap:address location="https://example.com:8080/context/service"/>
         </wsdl:port>
     </wsdl:service>
 </wsdl:definitions>

--- a/spring-ws-core/src/test/resources/org/springframework/ws/transport/http/wsdl11-input.wsdl
+++ b/spring-ws-core/src/test/resources/org/springframework/ws/transport/http/wsdl11-input.wsdl
@@ -27,7 +27,7 @@
     </wsdl:portType>
 
     <wsdl:binding name="binding" type="tns:portType">
-        <wsdlsoap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdlsoap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http/"/>
         <wsdl:operation name="operation">
             <wsdlsoap:operation soapAction=""/>
             <wsdl:input name="request">

--- a/spring-ws-core/src/test/resources/org/springframework/ws/wsdl/wsdl11/complete.wsdl
+++ b/spring-ws-core/src/test/resources/org/springframework/ws/wsdl/wsdl11/complete.wsdl
@@ -28,7 +28,7 @@
     </wsdl:portType>
 
     <wsdl:binding name="binding" type="tns:portType">
-        <wsdlsoap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdlsoap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http/"/>
         <wsdl:operation name="operation">
             <wsdlsoap:operation soapAction=""/>
             <wsdl:input name="request">

--- a/spring-ws-core/src/test/resources/org/springframework/ws/wsdl/wsdl11/concrete.wsdl
+++ b/spring-ws-core/src/test/resources/org/springframework/ws/wsdl/wsdl11/concrete.wsdl
@@ -8,7 +8,7 @@
 
 
     <binding name="binding" type="defs:portType">
-        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http/"/>
         <operation name="operation">
             <soap:operation soapAction=""/>
             <input name="request">

--- a/spring-ws-core/src/test/resources/org/springframework/ws/wsdl/wsdl11/import-inline.wsdl
+++ b/spring-ws-core/src/test/resources/org/springframework/ws/wsdl/wsdl11/import-inline.wsdl
@@ -46,7 +46,7 @@
         </wsdl:operation>
     </wsdl:portType>
     <wsdl:binding name="OrderSoap11" type="tns:Order">
-        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http/"/>
         <wsdl:operation name="GetOrder">
             <soap:operation soapAction=""/>
             <wsdl:input name="GetOrderRequest">

--- a/spring-ws-core/src/test/resources/org/springframework/ws/wsdl/wsdl11/include-inline.wsdl
+++ b/spring-ws-core/src/test/resources/org/springframework/ws/wsdl/wsdl11/include-inline.wsdl
@@ -11,7 +11,7 @@
                     xmlns="http://www.springframework.org/spring-ws/include/schema" elementFormDefault="qualified"
                     attributeFormDefault="unqualified">
 
-            <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
+            <xsd:import namespace="https://www.w3.org/XML/1998/namespace"/>
 
             <xsd:element name="GetOrderRequest">
                 <xsd:complexType>
@@ -46,7 +46,7 @@
         </wsdl:operation>
     </wsdl:portType>
     <wsdl:binding name="OrderSoap11" type="tns:Order">
-        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http/"/>
         <wsdl:operation name="GetOrder">
             <soap:operation soapAction=""/>
             <wsdl:input name="GetOrderRequest">

--- a/spring-ws-core/src/test/resources/org/springframework/ws/wsdl/wsdl11/including.xsd
+++ b/spring-ws-core/src/test/resources/org/springframework/ws/wsdl/wsdl11/including.xsd
@@ -5,7 +5,7 @@
             attributeFormDefault="unqualified">
 
     <xsd:include schemaLocation="included.xsd"/>
-    <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
+    <xsd:import namespace="https://www.w3.org/XML/1998/namespace"/>
 
     <xsd:element name="GetOrderRequest">
         <xsd:complexType>

--- a/spring-ws-core/src/test/resources/org/springframework/ws/wsdl/wsdl11/provider/B.xsd
+++ b/spring-ws-core/src/test/resources/org/springframework/ws/wsdl/wsdl11/provider/B.xsd
@@ -3,7 +3,7 @@
             targetNamespace="urn:1"
             xmlns="urn:1"
             xmlns:imported="urn:2" elementFormDefault="qualified">
-    <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
+    <xsd:import namespace="https://www.w3.org/XML/1998/namespace"/>
     <xsd:include schemaLocation="C.xsd"/>
     <xsd:import schemaLocation="D.xsd" namespace="urn:2"/>
     <xsd:complexType name="B">

--- a/spring-ws-core/src/test/resources/org/springframework/ws/wsdl/wsdl11/single-inline.wsdl
+++ b/spring-ws-core/src/test/resources/org/springframework/ws/wsdl/wsdl11/single-inline.wsdl
@@ -54,7 +54,7 @@
         </wsdl:operation>
     </wsdl:portType>
     <wsdl:binding name="OrderSoap11" type="tns:Order">
-        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http/"/>
         <wsdl:operation name="GetOrder">
             <soap:operation soapAction=""/>
             <wsdl:input name="GetOrderRequest">

--- a/spring-ws-core/src/test/resources/org/springframework/ws/wsdl/wsdl11/soap-11-12.wsdl
+++ b/spring-ws-core/src/test/resources/org/springframework/ws/wsdl/wsdl11/soap-11-12.wsdl
@@ -55,7 +55,7 @@
         </wsdl:operation>
     </wsdl:portType>
     <wsdl:binding name="OrderSoap11" type="tns:Order">
-        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http/"/>
         <wsdl:operation name="GetOrder">
             <soap:operation soapAction=""/>
             <wsdl:input name="GetOrderRequest">
@@ -70,7 +70,7 @@
         </wsdl:operation>
     </wsdl:binding>
     <wsdl:binding name="OrderSoap12" type="tns:Order">
-        <soap12:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <soap12:binding style="document" transport="http://schemas.xmlsoap.org/soap/http/"/>
         <wsdl:operation name="GetOrder">
             <soap12:operation soapAction=""/>
             <wsdl:input name="GetOrderRequest">

--- a/spring-ws-security/src/main/java/org/springframework/ws/soap/security/AbstractWsSecurityInterceptor.java
+++ b/spring-ws-security/src/main/java/org/springframework/ws/soap/security/AbstractWsSecurityInterceptor.java
@@ -54,7 +54,7 @@ public abstract class AbstractWsSecurityInterceptor implements SoapEndpointInter
 	protected final Log logger = LogFactory.getLog(getClass());
 
 	protected static final QName WS_SECURITY_NAME =
-			new QName("http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd", "Security");
+			new QName("https://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd", "Security");
 
 	private boolean secureResponse = true;
 

--- a/spring-ws-security/src/main/java/org/springframework/ws/soap/security/support/KeyStoreUtils.java
+++ b/spring-ws-security/src/main/java/org/springframework/ws/soap/security/support/KeyStoreUtils.java
@@ -43,7 +43,7 @@ public abstract class KeyStoreUtils {
 	 *
 	 * <p>This behavior corresponds to the standard J2SDK behavior for SSL key stores.
 	 *
-	 * @see <a href="http://java.sun.com/j2se/1.4.2/docs/guide/security/jsse/JSSERefGuide.html#X509KeyManager">The
+	 * @see <a href="https://java.sun.com/j2se/1.4.2/docs/guide/security/jsse/JSSERefGuide.html#X509KeyManager">The
 	 *		standard J2SDK SSL key store mechanism</a>
 	 */
 	public static KeyStore loadDefaultKeyStore() throws GeneralSecurityException, IOException {
@@ -85,7 +85,7 @@ public abstract class KeyStoreUtils {
 	 *
 	 * <p>This behavior corresponds to the standard J2SDK behavior for SSL trust stores.
 	 *
-	 * @see <a href="http://java.sun.com/j2se/1.4.2/docs/guide/security/jsse/JSSERefGuide.html#X509TrustManager">The
+	 * @see <a href="https://java.sun.com/j2se/1.4.2/docs/guide/security/jsse/JSSERefGuide.html#X509TrustManager">The
 	 *		standard J2SDK SSL trust store mechanism</a>
 	 */
 	public static KeyStore loadDefaultTrustStore() throws GeneralSecurityException, IOException {

--- a/spring-ws-security/src/main/java/org/springframework/ws/soap/security/wss4j2/Wss4jSecurityInterceptor.java
+++ b/spring-ws-security/src/main/java/org/springframework/ws/soap/security/wss4j2/Wss4jSecurityInterceptor.java
@@ -98,7 +98,7 @@ import org.springframework.ws.soap.security.wss4j2.callback.UsernameTokenPrincip
  * @author Arjen Poutsma
  * @author Greg Turnquist
  * @author Jamin Hitchcock
- * @see <a href="http://ws.apache.org/wss4j/">Apache WSS4J 2.0</a>
+ * @see <a href="https://ws.apache.org/wss4j/">Apache WSS4J 2.0</a>
  * @since 2.3.0
  */
 public class Wss4jSecurityInterceptor extends AbstractWsSecurityInterceptor implements InitializingBean {
@@ -216,11 +216,11 @@ public class Wss4jSecurityInterceptor extends AbstractWsSecurityInterceptor impl
 	 * defaults to {@code Content} if it is omitted. Example of a list:
 	 * <pre>
 	 * &lt;property name="securementEncryptionParts"
-	 *	 value="{Content}{http://example.org/paymentv2}CreditCard;
+	 *	 value="{Content}{https://example.org/paymentv2}CreditCard;
 	 *			   {Element}{}UserName" />
 	 * </pre>
 	 * The first entry of the list identifies the element {@code CreditCard} in the namespace
-	 * {@code http://example.org/paymentv2}, and will encrypt its content. Be aware that the element name, the
+	 * {@code https://example.org/paymentv2}, and will encrypt its content. Be aware that the element name, the
 	 * namespace identifier, and the encryption modifier are case sensitive.
 	 *
 	 * <p>The encryption modifier and the namespace identifier can be omitted. In this case the encryption mode defaults to

--- a/spring-ws-security/src/main/java/org/springframework/ws/soap/security/wss4j2/package.html
+++ b/spring-ws-security/src/main/java/org/springframework/ws/soap/security/wss4j2/package.html
@@ -1,6 +1,6 @@
 <html>
 <body>
-Contains classes for using the <a href="http://ws.apache.org/wss4j/">Apache WSS4J 2.0</a> WS-Security implementation within
+Contains classes for using the <a href="https://ws.apache.org/wss4j/">Apache WSS4J 2.0</a> WS-Security implementation within
 Spring-WS.
 </body>
 </html>

--- a/spring-ws-security/src/main/java/org/springframework/ws/soap/security/x509/cache/EhCacheBasedX509UserCache.java
+++ b/spring-ws-security/src/main/java/org/springframework/ws/soap/security/x509/cache/EhCacheBasedX509UserCache.java
@@ -32,7 +32,7 @@ import org.springframework.util.Assert;
 
 /**
  * Caches {@code User} objects using a Spring IoC defined <a
- * href="http://ehcache.sourceforge.net">EHCACHE</a>.
+ * href="https://www.ehcache.org/">EHCACHE</a>.
  * <p>Migrated from Spring Security 2 since it has been removed in Spring Security 3.</p>
  *
  * @author Luke Taylor

--- a/spring-ws-security/src/main/java/org/springframework/ws/soap/security/xwss/XwsSecurityInterceptor.java
+++ b/spring-ws-security/src/main/java/org/springframework/ws/soap/security/xwss/XwsSecurityInterceptor.java
@@ -49,7 +49,7 @@ import org.springframework.ws.soap.security.xwss.callback.XwssCallbackHandlerCha
  * {@code Callback}s fired by XWSS. You can also set multiple handlers, each of which will be used in turn.
  *
  * <p>Additionally, you must define a XWSS policy file by setting {@code policyConfiguration} property. The format of
- * the policy file is documented in the <a href="http://java.sun.com/webservices/docs/1.6/tutorial/doc/XWS-SecurityIntro4.html#wp529900">Java
+ * the policy file is documented in the <a href="https://java.sun.com/webservices/docs/1.6/tutorial/doc/XWS-SecurityIntro4.html#wp529900">Java
  * Web Services Tutorial</a>.
  *
  * <p><b>Note</b> that this interceptor depends on SAAJ, and thus requires {@code SaajSoapMessage}s to operate. This

--- a/spring-ws-security/src/main/java/org/springframework/ws/soap/security/xwss/callback/KeyStoreCallbackHandler.java
+++ b/spring-ws-security/src/main/java/org/springframework/ws/soap/security/xwss/callback/KeyStoreCallbackHandler.java
@@ -102,7 +102,7 @@ import org.springframework.ws.soap.security.support.KeyStoreUtils;
  * @see EncryptionKeyCallback
  * @see SignatureKeyCallback
  * @see SignatureVerificationKeyCallback
- * @see <a href="http://java.sun.com/j2se/1.4.2/docs/guide/security/jsse/JSSERefGuide.html#X509TrustManager">The
+ * @see <a href="https://java.sun.com/j2se/1.4.2/docs/guide/security/jsse/JSSERefGuide.html#X509TrustManager">The
  *		standard Java trust store mechanism</a>
  * @since 1.0.0
  */

--- a/spring-ws-security/src/main/java/org/springframework/ws/soap/security/xwss/callback/jaas/package.html
+++ b/spring-ws-security/src/main/java/org/springframework/ws/soap/security/xwss/callback/jaas/package.html
@@ -1,6 +1,6 @@
 <html>
 <body>
 Contains <code>CallbackHandler</code> implementations for XWSS that use the <a
-        href="http://java.sun.com/products/jaas/">Java Authentication and Authorization Service (JAAS)</a>.
+        href="https://java.sun.com/products/jaas/">Java Authentication and Authorization Service (JAAS)</a>.
 </body>
 </html>

--- a/spring-ws-security/src/main/java/org/springframework/ws/soap/security/xwss/package.html
+++ b/spring-ws-security/src/main/java/org/springframework/ws/soap/security/xwss/package.html
@@ -1,6 +1,6 @@
 <html>
 <body>
-Contains classes for using the <a href="http://xwss.java.net/">XML and WebServices Security</a> WS-Security
+Contains classes for using the <a href="https://xwss.java.net/">XML and WebServices Security</a> WS-Security
 implementation within Spring-WS.
 </body>
 </html>

--- a/spring-ws-security/src/test/java/org/springframework/ws/soap/security/wss4j2/SaajWss4jMessageInterceptorSignTest.java
+++ b/spring-ws-security/src/test/java/org/springframework/ws/soap/security/wss4j2/SaajWss4jMessageInterceptorSignTest.java
@@ -60,10 +60,10 @@ public class SaajWss4jMessageInterceptorSignTest extends Wss4jMessageInterceptor
 
 		SOAPHeader header = ((SaajSoapMessage) message).getSaajMessage().getSOAPHeader();
 		Iterator<?> iterator = header.getChildElements(new QName(
-				"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd", "Security"));
+				"https://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd", "Security"));
 		assertTrue("No security header", iterator.hasNext());
 		SOAPHeaderElement securityHeader = (SOAPHeaderElement) iterator.next();
-		iterator = securityHeader.getChildElements(new QName("http://www.w3.org/2000/09/xmldsig#", "Signature"));
+		iterator = securityHeader.getChildElements(new QName("https://www.w3.org/2000/09/xmldsig#", "Signature"));
 		assertTrue("No signature header", iterator.hasNext());
 
 		ByteArrayOutputStream bos = new ByteArrayOutputStream();

--- a/spring-ws-security/src/test/java/org/springframework/ws/soap/security/wss4j2/Wss4jMessageInterceptorHeaderTestCase.java
+++ b/spring-ws-security/src/test/java/org/springframework/ws/soap/security/wss4j2/Wss4jMessageInterceptorHeaderTestCase.java
@@ -76,7 +76,7 @@ public abstract class Wss4jMessageInterceptorHeaderTestCase extends Wss4jTestCas
 			SoapHeaderElement element = i.next();
 			QName name = element.getName();
 			if (name.getNamespaceURI()
-					.equals("http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd")) {
+					.equals("https://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd")) {
 				fail("Security Header not removed");
 			}
 
@@ -102,7 +102,7 @@ public abstract class Wss4jMessageInterceptorHeaderTestCase extends Wss4jTestCas
 			SoapHeaderElement element = i.next();
 			QName name = element.getName();
 			if (name.getNamespaceURI()
-					.equals("http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd")) {
+					.equals("https://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd")) {
 				foundSecurityHeader = true;
 			}
 

--- a/spring-ws-security/src/test/java/org/springframework/ws/soap/security/wss4j2/Wss4jMessageInterceptorUsernameTokenSignatureTestCase.java
+++ b/spring-ws-security/src/test/java/org/springframework/ws/soap/security/wss4j2/Wss4jMessageInterceptorUsernameTokenSignatureTestCase.java
@@ -39,7 +39,7 @@ public abstract class Wss4jMessageInterceptorUsernameTokenSignatureTestCase exte
 		assertXpathEvaluatesTo("Invalid Username", "Bert",
 				"/SOAP-ENV:Envelope/SOAP-ENV:Header/wsse:Security/wsse:UsernameToken/wsse:Username/text()", doc);
 		assertXpathExists("Invalid Password",
-				"/SOAP-ENV:Envelope/SOAP-ENV:Header/wsse:Security/wsse:UsernameToken/wsse:Password[@Type='http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordDigest']/text()",
+				"/SOAP-ENV:Envelope/SOAP-ENV:Header/wsse:Security/wsse:UsernameToken/wsse:Password[@Type='https://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordDigest']/text()",
 				doc);
 	}
 }

--- a/spring-ws-security/src/test/java/org/springframework/ws/soap/security/wss4j2/Wss4jMessageInterceptorUsernameTokenTestCase.java
+++ b/spring-ws-security/src/test/java/org/springframework/ws/soap/security/wss4j2/Wss4jMessageInterceptorUsernameTokenTestCase.java
@@ -111,7 +111,7 @@ public abstract class Wss4jMessageInterceptorUsernameTokenTestCase extends Wss4j
 		assertXpathEvaluatesTo("Invalid Username", "Bert",
 				"/SOAP-ENV:Envelope/SOAP-ENV:Header/wsse:Security/wsse:UsernameToken/wsse:Username/text()", doc);
 		assertXpathEvaluatesTo("Invalid Password", "Ernie",
-				"/SOAP-ENV:Envelope/SOAP-ENV:Header/wsse:Security/wsse:UsernameToken/wsse:Password[@Type='http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText']/text()",
+				"/SOAP-ENV:Envelope/SOAP-ENV:Header/wsse:Security/wsse:UsernameToken/wsse:Password[@Type='https://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText']/text()",
 				doc);
 	}
 
@@ -122,7 +122,7 @@ public abstract class Wss4jMessageInterceptorUsernameTokenTestCase extends Wss4j
 		assertXpathEvaluatesTo("Invalid Username", "Bert",
 				"/SOAP-ENV:Envelope/SOAP-ENV:Header/wsse:Security/wsse:UsernameToken/wsse:Username/text()", doc);
 		assertXpathExists("Password does not exist",
-				"/SOAP-ENV:Envelope/SOAP-ENV:Header/wsse:Security/wsse:UsernameToken/wsse:Password[@Type='http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordDigest']",
+				"/SOAP-ENV:Envelope/SOAP-ENV:Header/wsse:Security/wsse:UsernameToken/wsse:Password[@Type='https://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordDigest']",
 				doc);
 
 	}

--- a/spring-ws-security/src/test/java/org/springframework/ws/soap/security/wss4j2/Wss4jTestCase.java
+++ b/spring-ws-security/src/test/java/org/springframework/ws/soap/security/wss4j2/Wss4jTestCase.java
@@ -72,13 +72,13 @@ public abstract class Wss4jTestCase {
 		Map<String, String> namespaces = new HashMap<String, String>();
 		namespaces.put("SOAP-ENV", "http://schemas.xmlsoap.org/soap/envelope/");
 		namespaces.put("wsse",
-				"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd");
-		namespaces.put("ds", "http://www.w3.org/2000/09/xmldsig#");
-		namespaces.put("xenc", "http://www.w3.org/2001/04/xmlenc#");
-		namespaces.put("wsse11", "http://docs.oasis-open.org/wss/oasis-wss-wssecurity-secext-1.1.xsd");
+				"https://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd");
+		namespaces.put("ds", "https://www.w3.org/2000/09/xmldsig#");
+		namespaces.put("xenc", "https://www.w3.org/2001/04/xmlenc#");
+		namespaces.put("wsse11", "https://docs.oasis-open.org/wss/oasis-wss-wssecurity-secext-1.1.xsd");
 		namespaces.put("echo", "http://www.springframework.org/spring-ws/samples/echo");
 		namespaces.put("wsu",
-				"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd");
+				"https://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd");
 		namespaces.put("saml", "urn:oasis:names:tc:SAML:2.0:assertion");
 		namespaces.put("test", "http://test");
 		xpathTemplate.setNamespaces(namespaces);

--- a/spring-ws-security/src/test/java/org/springframework/ws/soap/security/xwss/AbstractXwssMessageInterceptorTestCase.java
+++ b/spring-ws-security/src/test/java/org/springframework/ws/soap/security/xwss/AbstractXwssMessageInterceptorTestCase.java
@@ -52,10 +52,10 @@ public abstract class AbstractXwssMessageInterceptorTestCase {
 		messageFactory = MessageFactory.newInstance();
 		namespaces = new HashMap<String, String>(4);
 		namespaces.put("SOAP-ENV", "http://schemas.xmlsoap.org/soap/envelope/");
-		namespaces.put("wsse", "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd");
-		namespaces.put("wsu", "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd");
-		namespaces.put("ds", "http://www.w3.org/2000/09/xmldsig#");
-		namespaces.put("xenc", "http://www.w3.org/2001/04/xmlenc#");
+		namespaces.put("wsse", "https://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd");
+		namespaces.put("wsu", "https://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd");
+		namespaces.put("ds", "https://www.w3.org/2000/09/xmldsig#");
+		namespaces.put("xenc", "https://www.w3.org/2001/04/xmlenc#");
 		onSetup();
 	}
 

--- a/spring-ws-security/src/test/java/org/springframework/ws/soap/security/xwss/XwssMessageInterceptorUsernameTokenTest.java
+++ b/spring-ws-security/src/test/java/org/springframework/ws/soap/security/xwss/XwssMessageInterceptorUsernameTokenTest.java
@@ -64,7 +64,7 @@ public class XwssMessageInterceptorUsernameTokenTest extends AbstractXwssMessage
 				"/SOAP-ENV:Envelope/SOAP-ENV:Header/wsse:Security/wsse:UsernameToken/wsse:Username/text()",
 				result);
 		assertXpathExists("Password does not exist",
-				"/SOAP-ENV:Envelope/SOAP-ENV:Header/wsse:Security/wsse:UsernameToken/wsse:Password[@Type='http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordDigest']",
+				"/SOAP-ENV:Envelope/SOAP-ENV:Header/wsse:Security/wsse:UsernameToken/wsse:Password[@Type='https://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordDigest']",
 				result);
 		assertXpathExists("Nonce does not exist",
 				"/SOAP-ENV:Envelope/SOAP-ENV:Header/wsse:Security/wsse:UsernameToken/wsse:Nonce",
@@ -102,7 +102,7 @@ public class XwssMessageInterceptorUsernameTokenTest extends AbstractXwssMessage
 		assertXpathEvaluatesTo("Invalid Username", "Bert",
 				"/SOAP-ENV:Envelope/SOAP-ENV:Header/wsse:Security/wsse:UsernameToken/wsse:Username/text()", result);
 		assertXpathEvaluatesTo("Invalid Password", "Ernie",
-				"/SOAP-ENV:Envelope/SOAP-ENV:Header/wsse:Security/wsse:UsernameToken/wsse:Password[@Type='http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText']/text()",
+				"/SOAP-ENV:Envelope/SOAP-ENV:Header/wsse:Security/wsse:UsernameToken/wsse:Password[@Type='https://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText']/text()",
 				result);
 	}
 
@@ -137,7 +137,7 @@ public class XwssMessageInterceptorUsernameTokenTest extends AbstractXwssMessage
 				"/SOAP-ENV:Envelope/SOAP-ENV:Header/wsse:Security/wsse:UsernameToken/wsse:Username/text()",
 				result);
 		assertXpathEvaluatesTo("Invalid Password", "Ernie",
-				"/SOAP-ENV:Envelope/SOAP-ENV:Header/wsse:Security/wsse:UsernameToken/wsse:Password[@Type='http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText']/text()",
+				"/SOAP-ENV:Envelope/SOAP-ENV:Header/wsse:Security/wsse:UsernameToken/wsse:Password[@Type='https://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText']/text()",
 				result);
 		assertXpathExists("Nonce does not exist",
 				"/SOAP-ENV:Envelope/SOAP-ENV:Header/wsse:Security/wsse:UsernameToken/wsse:Nonce",

--- a/spring-ws-support/src/main/java/org/springframework/ws/transport/jms/JmsMessageSender.java
+++ b/spring-ws-support/src/main/java/org/springframework/ws/transport/jms/JmsMessageSender.java
@@ -91,7 +91,7 @@ import org.springframework.ws.transport.jms.support.JmsTransportUtils;
  * <tt>jms:RequestQueue?replyToName=ResponseQueueName</tt><br> <tt>jms:Queue?messageType=TEXT_MESSAGE</blockquote>
  *
  * @author Arjen Poutsma
- * @see <a href="http://tools.ietf.org/id/draft-merrick-jms-iri-00.txt">IRI Scheme for Java(tm) Message Service 1.0</a>
+ * @see <a href="https://tools.ietf.org/id/draft-merrick-jms-iri-00.txt">IRI Scheme for Java(tm) Message Service 1.0</a>
  * @since 1.5.0
  */
 public class JmsMessageSender extends JmsDestinationAccessor implements WebServiceMessageSender {

--- a/spring-ws-support/src/main/java/org/springframework/ws/transport/mail/MailMessageSender.java
+++ b/spring-ws-support/src/main/java/org/springframework/ws/transport/mail/MailMessageSender.java
@@ -56,7 +56,7 @@ import org.springframework.ws.transport.mail.support.MailTransportUtils;
  * <blockquote><tt>mailto:john@example.com</tt><br> <tt>mailto:john@example.com@?subject=SOAP%20Test</tt><br></blockquote>
  *
  * @author Arjen Poutsma
- * @see <a href="http://www.ietf.org/rfc/rfc2368.txt">The mailto URL scheme</a>
+ * @see <a href="https://www.ietf.org/rfc/rfc2368.txt">The mailto URL scheme</a>
  * @since 1.5.0
  */
 public class MailMessageSender implements WebServiceMessageSender, InitializingBean {

--- a/spring-ws-support/src/test/java/org/springframework/ws/transport/jms/JmsMessageSenderIntegrationTest.java
+++ b/spring-ws-support/src/test/java/org/springframework/ws/transport/jms/JmsMessageSenderIntegrationTest.java
@@ -56,7 +56,7 @@ public class JmsMessageSenderIntegrationTest {
 
 	private MessageFactory messageFactory;
 
-	private static final String SOAP_ACTION = "\"http://springframework.org/DoIt\"";
+	private static final String SOAP_ACTION = "\"https://springframework.org/DoIt\"";
 
 	@Before
 	public void createMessageFactory() throws Exception {

--- a/spring-ws-support/src/test/java/org/springframework/ws/transport/mail/MailMessageSenderIntegrationTest.java
+++ b/spring-ws-support/src/test/java/org/springframework/ws/transport/mail/MailMessageSenderIntegrationTest.java
@@ -38,7 +38,7 @@ public class MailMessageSenderIntegrationTest {
 
 	private MessageFactory messageFactory;
 
-	private static final String SOAP_ACTION = "http://springframework.org/DoIt";
+	private static final String SOAP_ACTION = "https://springframework.org/DoIt";
 
 	@Before
 	public void setUp() throws Exception {
@@ -62,7 +62,7 @@ public class MailMessageSenderIntegrationTest {
 			URI mailTo = new URI("mailto:server@example.com?subject=SOAP%20Test");
 			connection = messageSender.createConnection(mailTo);
 			SOAPMessage saajMessage = messageFactory.createMessage();
-			saajMessage.getSOAPBody().addBodyElement(new QName("http://springframework.org", "test"));
+			saajMessage.getSOAPBody().addBodyElement(new QName("https://springframework.org", "test"));
 			SoapMessage soapRequest = new SaajSoapMessage(saajMessage);
 			soapRequest.setSoapAction(SOAP_ACTION);
 			connection.send(soapRequest);

--- a/spring-ws-test/src/test/java/org/springframework/ws/test/client/MockWebServiceServerTest.java
+++ b/spring-ws-test/src/test/java/org/springframework/ws/test/client/MockWebServiceServerTest.java
@@ -59,7 +59,7 @@ public class MockWebServiceServerTest {
 	@Before
 	public void setUp() throws Exception {
 		template = new WebServiceTemplate();
-		template.setDefaultUri("http://example.com");
+		template.setDefaultUri("https://example.com");
 
 		server = MockWebServiceServer.createServer(template);
 	}
@@ -111,7 +111,7 @@ public class MockWebServiceServerTest {
 
 	@Test
 	public void mocks() throws Exception {
-		URI uri = URI.create("http://example.com");
+		URI uri = URI.create("https://example.com");
 
 		RequestMatcher requestMatcher1 = createStrictMock("requestMatcher1", RequestMatcher.class);
 		RequestMatcher requestMatcher2 = createStrictMock("requestMatcher2", RequestMatcher.class);
@@ -127,7 +127,7 @@ public class MockWebServiceServerTest {
 		replay(requestMatcher1, requestMatcher2, responseCreator);
 
 		server.expect(requestMatcher1).andExpect(requestMatcher2).andRespond(responseCreator);
-		template.sendSourceAndReceiveToResult(uri.toString(), new StringSource("<request xmlns='http://example.com'/>"),
+		template.sendSourceAndReceiveToResult(uri.toString(), new StringSource("<request xmlns='https://example.com'/>"),
 				new StringResult());
 
 		verify(requestMatcher1, requestMatcher2, responseCreator);
@@ -135,8 +135,8 @@ public class MockWebServiceServerTest {
 
 	@Test
 	public void payloadMatch() throws Exception {
-		Source request = new StringSource("<request xmlns='http://example.com'/>");
-		Source response = new StringSource("<response xmlns='http://example.com'/>");
+		Source request = new StringSource("<request xmlns='https://example.com'/>");
+		Source response = new StringSource("<response xmlns='https://example.com'/>");
 
 		server.expect(payload(request)).andRespond(withPayload(response));
 
@@ -147,7 +147,7 @@ public class MockWebServiceServerTest {
 
 	@Test(expected = AssertionError.class)
 	public void payloadNonMatch() throws Exception {
-		Source expected = new StringSource("<request xmlns='http://example.com'/>");
+		Source expected = new StringSource("<request xmlns='https://example.com'/>");
 
 		server.expect(payload(expected));
 
@@ -158,11 +158,11 @@ public class MockWebServiceServerTest {
 
 	@Test
 	public void soapHeaderMatch() throws Exception {
-		final QName soapHeaderName = new QName("http://example.com", "mySoapHeader");
+		final QName soapHeaderName = new QName("https://example.com", "mySoapHeader");
 
 		server.expect(soapHeader(soapHeaderName));
 
-		template.sendSourceAndReceiveToResult(new StringSource("<request xmlns='http://example.com'/>"),
+		template.sendSourceAndReceiveToResult(new StringSource("<request xmlns='https://example.com'/>"),
 				new WebServiceMessageCallback() {
 					public void doWithMessage(WebServiceMessage message) throws IOException, TransformerException {
 						SoapMessage soapMessage = (SoapMessage) message;
@@ -173,20 +173,20 @@ public class MockWebServiceServerTest {
 
 	@Test(expected = AssertionError.class)
 	public void soapHeaderNonMatch() throws Exception {
-		QName soapHeaderName = new QName("http://example.com", "mySoapHeader");
+		QName soapHeaderName = new QName("https://example.com", "mySoapHeader");
 
 		server.expect(soapHeader(soapHeaderName));
 
-		template.sendSourceAndReceiveToResult(new StringSource("<request xmlns='http://example.com'/>"),
+		template.sendSourceAndReceiveToResult(new StringSource("<request xmlns='https://example.com'/>"),
 				new StringResult());
 	}
 
 	@Test
 	public void connectionMatch() throws Exception {
-		String uri = "http://example.com";
+		String uri = "https://example.com";
 		server.expect(connectionTo(uri));
 
-		template.sendSourceAndReceiveToResult(uri, new StringSource("<request xmlns='http://example.com'/>"),
+		template.sendSourceAndReceiveToResult(uri, new StringSource("<request xmlns='https://example.com'/>"),
 				new StringResult());
 	}
 
@@ -195,15 +195,15 @@ public class MockWebServiceServerTest {
 		String expected = "http://expected.com";
 		server.expect(connectionTo(expected));
 
-		String actual = "http://actual.com";
-		template.sendSourceAndReceiveToResult(actual, new StringSource("<request xmlns='http://example.com'/>"),
+		String actual = "https://www.dynamo.com/assets.htm";
+		template.sendSourceAndReceiveToResult(actual, new StringSource("<request xmlns='https://example.com'/>"),
 				new StringResult());
 	}
 
 	@Test(expected = AssertionError.class)
 	public void unexpectedConnection() throws Exception {
-		Source request = new StringSource("<request xmlns='http://example.com'/>");
-		Source response = new StringSource("<response xmlns='http://example.com'/>");
+		Source request = new StringSource("<request xmlns='https://example.com'/>");
+		Source response = new StringSource("<response xmlns='https://example.com'/>");
 
 		server.expect(payload(request)).andRespond(withPayload(response));
 
@@ -214,51 +214,51 @@ public class MockWebServiceServerTest {
 	@Test
 	public void xsdMatch() throws Exception {
 		Resource schema = new ByteArrayResource(
-				"<schema xmlns=\"http://www.w3.org/2001/XMLSchema\" targetNamespace=\"http://example.com\" elementFormDefault=\"qualified\"><element name=\"request\"/></schema>".getBytes());
+				"<schema xmlns=\"http://www.w3.org/2001/XMLSchema\" targetNamespace=\"https://example.com\" elementFormDefault=\"qualified\"><element name=\"request\"/></schema>".getBytes());
 
 		server.expect(validPayload(schema));
 
 		StringResult result = new StringResult();
-		String actual = "<request xmlns='http://example.com'/>";
+		String actual = "<request xmlns='https://example.com'/>";
 		template.sendSourceAndReceiveToResult(new StringSource(actual), result);
 	}
 
 	@Test(expected = AssertionError.class)
 	public void xsdNonMatch() throws Exception {
 		Resource schema = new ByteArrayResource(
-				"<schema xmlns=\"http://www.w3.org/2001/XMLSchema\" targetNamespace=\"http://example.com\" elementFormDefault=\"qualified\"><element name=\"request\"/></schema>".getBytes());
+				"<schema xmlns=\"http://www.w3.org/2001/XMLSchema\" targetNamespace=\"https://example.com\" elementFormDefault=\"qualified\"><element name=\"request\"/></schema>".getBytes());
 
 		server.expect(validPayload(schema));
 
 		StringResult result = new StringResult();
-		String actual = "<request2 xmlns='http://example.com'/>";
+		String actual = "<request2 xmlns='https://example.com'/>";
 		template.sendSourceAndReceiveToResult(new StringSource(actual), result);
 	}
 
 	@Test
 	public void xpathExistsMatch() throws Exception {
-		final Map<String, String> ns = Collections.singletonMap("ns", "http://example.com");
+		final Map<String, String> ns = Collections.singletonMap("ns", "https://example.com");
 
 		server.expect(xpath("/ns:request", ns).exists());
 
-		template.sendSourceAndReceiveToResult(new StringSource("<request xmlns='http://example.com'/>"),
+		template.sendSourceAndReceiveToResult(new StringSource("<request xmlns='https://example.com'/>"),
 				new StringResult());
 	}
 
 	@Test(expected = AssertionError.class)
 	public void xpathExistsNonMatch() throws Exception {
-		final Map<String, String> ns = Collections.singletonMap("ns", "http://example.com");
+		final Map<String, String> ns = Collections.singletonMap("ns", "https://example.com");
 
 		server.expect(xpath("/ns:foo", ns).exists());
 
-		template.sendSourceAndReceiveToResult(new StringSource("<request xmlns='http://example.com'/>"),
+		template.sendSourceAndReceiveToResult(new StringSource("<request xmlns='https://example.com'/>"),
 				new StringResult());
 	}
 
 	@Test
 	public void anythingMatch() throws Exception {
-		Source request = new StringSource("<request xmlns='http://example.com'/>");
-		Source response = new StringSource("<response xmlns='http://example.com'/>");
+		Source request = new StringSource("<request xmlns='https://example.com'/>");
+		Source response = new StringSource("<response xmlns='https://example.com'/>");
 
 		server.expect(anything()).andRespond(withPayload(response));
 
@@ -271,8 +271,8 @@ public class MockWebServiceServerTest {
 
 	@Test(expected = IllegalStateException.class)
 	public void recordWhenReplay() throws Exception {
-		Source request = new StringSource("<request xmlns='http://example.com'/>");
-		Source response = new StringSource("<response xmlns='http://example.com'/>");
+		Source request = new StringSource("<request xmlns='https://example.com'/>");
+		Source response = new StringSource("<response xmlns='https://example.com'/>");
 
 		server.expect(anything()).andRespond(withPayload(response));
 		server.expect(anything()).andRespond(withPayload(response));
@@ -297,7 +297,7 @@ public class MockWebServiceServerTest {
 
 	@Test(expected = SoapFaultClientException.class)
 	public void fault() throws Exception {
-		Source request = new StringSource("<request xmlns='http://example.com'/>");
+		Source request = new StringSource("<request xmlns='https://example.com'/>");
 
 		server.expect(anything()).andRespond(withClientOrSenderFault("reason", Locale.ENGLISH));
 

--- a/spring-ws-test/src/test/java/org/springframework/ws/test/client/ResponseCreatorsTest.java
+++ b/spring-ws-test/src/test/java/org/springframework/ws/test/client/ResponseCreatorsTest.java
@@ -53,7 +53,7 @@ public class ResponseCreatorsTest {
 
 	@Test
 	public void withPayloadSource() throws Exception {
-		String payload = "<payload xmlns='http://springframework.org'/>";
+		String payload = "<payload xmlns='https://springframework.org'/>";
 		ResponseCreator responseCreator = ResponseCreators.withPayload(new StringSource(payload));
 
 		WebServiceMessage response = responseCreator.createResponse(null, null, messageFactory);
@@ -64,7 +64,7 @@ public class ResponseCreatorsTest {
 
 	@Test
 	public void withPayloadResource() throws Exception {
-		String payload = "<payload xmlns='http://springframework.org'/>";
+		String payload = "<payload xmlns='https://springframework.org'/>";
 		ResponseCreator responseCreator =
 				ResponseCreators.withPayload(new ByteArrayResource(payload.getBytes("UTF-8")));
 
@@ -78,8 +78,8 @@ public class ResponseCreatorsTest {
 		StringBuilder xmlBuilder = new StringBuilder();
 		xmlBuilder.append("<?xml version='1.0'?>");
 		xmlBuilder.append("<soap:Envelope xmlns:soap='http://www.w3.org/2003/05/soap-envelope'>");
-		xmlBuilder.append("<soap:Header><header xmlns='http://springframework.org'/></soap:Header>");
-		xmlBuilder.append("<soap:Body><payload xmlns='http://springframework.org'/></soap:Body>");
+		xmlBuilder.append("<soap:Header><header xmlns='https://springframework.org'/></soap:Header>");
+		xmlBuilder.append("<soap:Body><payload xmlns='https://springframework.org'/></soap:Body>");
 		xmlBuilder.append("</soap:Envelope>");
 		String envelope = xmlBuilder.toString();
 		ResponseCreator responseCreator = ResponseCreators.withSoapEnvelope(new StringSource(envelope));
@@ -92,8 +92,8 @@ public class ResponseCreatorsTest {
 		StringBuilder xmlBuilder = new StringBuilder();
 		xmlBuilder.append("<?xml version='1.0'?>");
 		xmlBuilder.append("<soap:Envelope xmlns:soap='http://www.w3.org/2003/05/soap-envelope'>");
-		xmlBuilder.append("<soap:Header><header xmlns='http://springframework.org'/></soap:Header>");
-		xmlBuilder.append("<soap:Body><payload xmlns='http://springframework.org'/></soap:Body>");
+		xmlBuilder.append("<soap:Header><header xmlns='https://springframework.org'/></soap:Header>");
+		xmlBuilder.append("<soap:Body><payload xmlns='https://springframework.org'/></soap:Body>");
 		xmlBuilder.append("</soap:Envelope>");
 		String envelope = xmlBuilder.toString();
 		ResponseCreator responseCreator = ResponseCreators.withSoapEnvelope(new ByteArrayResource(envelope.getBytes("UTF-8")));

--- a/spring-ws-test/src/test/java/org/springframework/ws/test/client/UriMatcherTest.java
+++ b/spring-ws-test/src/test/java/org/springframework/ws/test/client/UriMatcherTest.java
@@ -43,6 +43,6 @@ public class UriMatcherTest {
 		expect(message.getPayloadSource()).andReturn(null);
 		replay(message);
 		UriMatcher matcher = new UriMatcher(GOOD_URI);
-		matcher.match(URI.create("http://www.example.org"), message);
+		matcher.match(URI.create("https://www.example.org"), message);
 	}
 }

--- a/spring-ws-test/src/test/java/org/springframework/ws/test/support/matcher/PayloadDiffMatcherTest.java
+++ b/spring-ws-test/src/test/java/org/springframework/ws/test/support/matcher/PayloadDiffMatcherTest.java
@@ -31,7 +31,7 @@ public class PayloadDiffMatcherTest {
 
 	@Test
 	public void match() throws Exception {
-		String xml = "<element xmlns='http://example.com'/>";
+		String xml = "<element xmlns='https://example.com'/>";
 		WebServiceMessage message = createMock(WebServiceMessage.class);
 		expect(message.getPayloadSource()).andReturn(new StringSource(xml)).times(2);
 		replay(message);
@@ -44,12 +44,12 @@ public class PayloadDiffMatcherTest {
 
 	@Test(expected = AssertionError.class)
 	public void nonMatch() throws Exception {
-		String actual = "<element1 xmlns='http://example.com'/>";
+		String actual = "<element1 xmlns='https://example.com'/>";
 		WebServiceMessage message = createMock(WebServiceMessage.class);
 		expect(message.getPayloadSource()).andReturn(new StringSource(actual)).times(2);
 		replay(message);
 
-		String expected = "<element2 xmlns='http://example.com'/>";
+		String expected = "<element2 xmlns='https://example.com'/>";
 		PayloadDiffMatcher matcher = new PayloadDiffMatcher(new StringSource(expected));
 		matcher.match(message);
 	}

--- a/spring-ws-test/src/test/java/org/springframework/ws/test/support/matcher/SchemaValidatingMatcherTest.java
+++ b/spring-ws-test/src/test/java/org/springframework/ws/test/support/matcher/SchemaValidatingMatcherTest.java
@@ -49,7 +49,7 @@ public class SchemaValidatingMatcherTest {
 	@Test
 	public void singleSchemaMatch() throws IOException, AssertionError {
 		expect(message.getPayloadSource()).andReturn(new StringSource(
-				"<test xmlns=\"http://www.example.org/schema\"><number>0</number><text>text</text></test>"));
+				"<test xmlns=\"https://www.example.org/schema\"><number>0</number><text>text</text></test>"));
 
 		SchemaValidatingMatcher matcher = new SchemaValidatingMatcher(schema);
 
@@ -63,7 +63,7 @@ public class SchemaValidatingMatcherTest {
 	@Test(expected = AssertionError.class)
 	public void singleSchemaNonMatch() throws IOException, AssertionError {
 		expect(message.getPayloadSource()).andReturn(new StringSource(
-				"<test xmlns=\"http://www.example.org/schema\"><number>a</number><text>text</text></test>")).times(2);
+				"<test xmlns=\"https://www.example.org/schema\"><number>a</number><text>text</text></test>")).times(2);
 
 		SchemaValidatingMatcher matcher = new SchemaValidatingMatcher(schema);
 
@@ -77,7 +77,7 @@ public class SchemaValidatingMatcherTest {
 	@Test
 	public void multipleSchemaMatch() throws IOException, AssertionError {
 		expect(message.getPayloadSource()).andReturn(new StringSource(
-				"<test xmlns=\"http://www.example.org/schema\"><number>0</number><text>text</text></test>"));
+				"<test xmlns=\"https://www.example.org/schema\"><number>0</number><text>text</text></test>"));
 
 		SchemaValidatingMatcher matcher = new SchemaValidatingMatcher(schema1, schema2);
 
@@ -91,7 +91,7 @@ public class SchemaValidatingMatcherTest {
 	@Test(expected = AssertionError.class)
 	public void multipleSchemaNotOk() throws IOException, AssertionError {
 		expect(message.getPayloadSource()).andReturn(new StringSource(
-				"<test xmlns=\"http://www.example.org/schema\"><number>a</number><text>text</text></test>")).times(2);
+				"<test xmlns=\"https://www.example.org/schema\"><number>a</number><text>text</text></test>")).times(2);
 
 		SchemaValidatingMatcher matcher = new SchemaValidatingMatcher(schema1, schema2);
 
@@ -105,7 +105,7 @@ public class SchemaValidatingMatcherTest {
 	@Test(expected = AssertionError.class)
 	public void multipleSchemaDifferentOrderNotOk() throws IOException, AssertionError {
 		expect(message.getPayloadSource()).andReturn(new StringSource(
-				"<test xmlns=\"http://www.example.org/schema\"><number>a</number><text>text</text></test>")).times(2);
+				"<test xmlns=\"https://www.example.org/schema\"><number>a</number><text>text</text></test>")).times(2);
 
 		SchemaValidatingMatcher matcher = new SchemaValidatingMatcher(schema1, schema2);
 
@@ -119,7 +119,7 @@ public class SchemaValidatingMatcherTest {
 	@Test(expected = AssertionError.class)
 	public void xmlValidatorNotOk() throws IOException, AssertionError {
 		expect(message.getPayloadSource()).andReturn(new StringSource(
-				"<test xmlns=\"http://www.example.org/schema\"><number>a</number><text>text</text></test>")).times(2);
+				"<test xmlns=\"https://www.example.org/schema\"><number>a</number><text>text</text></test>")).times(2);
 
 		SchemaValidatingMatcher matcher = new SchemaValidatingMatcher(schema);
 

--- a/spring-ws-test/src/test/java/org/springframework/ws/test/support/matcher/SoapEnvelopeDiffMatcherTest.java
+++ b/spring-ws-test/src/test/java/org/springframework/ws/test/support/matcher/SoapEnvelopeDiffMatcherTest.java
@@ -34,8 +34,8 @@ public class SoapEnvelopeDiffMatcherTest {
 		StringBuilder xmlBuilder = new StringBuilder();
 		xmlBuilder.append("<?xml version='1.0'?>");
 		xmlBuilder.append("<soap:Envelope xmlns:soap='http://www.w3.org/2003/05/soap-envelope'>");
-		xmlBuilder.append("<soap:Header><header xmlns='http://example.com'/></soap:Header>");
-		xmlBuilder.append("<soap:Body><payload xmlns='http://example.com'/></soap:Body>");
+		xmlBuilder.append("<soap:Header><header xmlns='https://example.com'/></soap:Header>");
+		xmlBuilder.append("<soap:Body><payload xmlns='https://example.com'/></soap:Body>");
 		xmlBuilder.append("</soap:Envelope>");
 		String xml = xmlBuilder.toString();
 		DOMResult result = new DOMResult();
@@ -56,8 +56,8 @@ public class SoapEnvelopeDiffMatcherTest {
 		StringBuilder xmlBuilder = new StringBuilder();
 		xmlBuilder.append("<?xml version='1.0'?>");
 		xmlBuilder.append("<soap:Envelope xmlns:soap='http://www.w3.org/2003/05/soap-envelope'>");
-		xmlBuilder.append("<soap:Header><header xmlns='http://example.com'/></soap:Header>");
-		xmlBuilder.append("<soap:Body><payload%s xmlns='http://example.com'/></soap:Body>");
+		xmlBuilder.append("<soap:Header><header xmlns='https://example.com'/></soap:Header>");
+		xmlBuilder.append("<soap:Body><payload%s xmlns='https://example.com'/></soap:Body>");
 		xmlBuilder.append("</soap:Envelope>");
 		String xml = xmlBuilder.toString();
 		String actual = String.format(xml, "1");

--- a/spring-ws-test/src/test/java/org/springframework/ws/test/support/matcher/SoapHeaderMatcherTest.java
+++ b/spring-ws-test/src/test/java/org/springframework/ws/test/support/matcher/SoapHeaderMatcherTest.java
@@ -37,7 +37,7 @@ public class SoapHeaderMatcherTest {
 
 	@Before
 	public void setUp() throws Exception {
-		expectedHeaderName = new QName("http://example.com", "header");
+		expectedHeaderName = new QName("https://example.com", "header");
 		matcher = new SoapHeaderMatcher(expectedHeaderName);
 	}
 

--- a/spring-ws-test/src/test/java/org/springframework/ws/test/support/matcher/XPathExpectationsHelperTest.java
+++ b/spring-ws-test/src/test/java/org/springframework/ws/test/support/matcher/XPathExpectationsHelperTest.java
@@ -182,14 +182,14 @@ public class XPathExpectationsHelperTest {
 
 	@Test
 	public void existsWithNamespacesMatch() throws IOException, AssertionError {
-		Map<String, String> ns = Collections.singletonMap("x", "http://example.org");
+		Map<String, String> ns = Collections.singletonMap("x", "https://example.org");
 		XPathExpectationsHelper helper = new XPathExpectationsHelper("//x:b", ns);
 		WebServiceMessageMatcher matcher = helper.exists();
 		assertNotNull(matcher);
 
 		WebServiceMessage message = createMock(WebServiceMessage.class);
 		expect(message.getPayloadSource())
-				.andReturn(new StringSource("<a:a xmlns:a=\"http://example.org\"><a:b/></a:a>"));
+				.andReturn(new StringSource("<a:a xmlns:a=\"https://example.org\"><a:b/></a:a>"));
 
 		replay(message);
 
@@ -200,14 +200,14 @@ public class XPathExpectationsHelperTest {
 
 	@Test(expected = AssertionError.class)
 	public void existsWithNamespacesNonMatch() throws IOException, AssertionError {
-		Map<String, String> ns = Collections.singletonMap("x", "http://example.org");
+		Map<String, String> ns = Collections.singletonMap("x", "https://example.org");
 		XPathExpectationsHelper helper = new XPathExpectationsHelper("//b", ns);
 		WebServiceMessageMatcher matcher = helper.exists();
 		assertNotNull(matcher);
 
 		WebServiceMessage message = createMock(WebServiceMessage.class);
 		expect(message.getPayloadSource())
-				.andReturn(new StringSource("<a:a xmlns:a=\"http://example.org\"><a:b/></a:a>")).times(2);
+				.andReturn(new StringSource("<a:a xmlns:a=\"https://example.org\"><a:b/></a:a>")).times(2);
 
 		replay(message);
 

--- a/spring-ws-test/src/test/resources/org/springframework/ws/test/client/schemaValidatingRequestMatcherTest.xsd
+++ b/spring-ws-test/src/test/resources/org/springframework/ws/test/client/schemaValidatingRequestMatcherTest.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.example.org/schema" xmlns:tns="http://www.example.org/schema" elementFormDefault="qualified">
+<schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="https://www.example.org/schema" xmlns:tns="https://www.example.org/schema" elementFormDefault="qualified">
 
     <element name="test" type="tns:testMessage"/>
     

--- a/spring-ws-test/src/test/resources/org/springframework/ws/test/support/matcher/schemaValidatingMatcherTest-1.xsd
+++ b/spring-ws-test/src/test/resources/org/springframework/ws/test/support/matcher/schemaValidatingMatcherTest-1.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.example.org/schema" xmlns:tns="http://www.example.org/schema" elementFormDefault="qualified">
+<schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="https://www.example.org/schema" xmlns:tns="https://www.example.org/schema" elementFormDefault="qualified">
 
     <element name="test" type="tns:testMessage"/>
 

--- a/spring-ws-test/src/test/resources/org/springframework/ws/test/support/matcher/schemaValidatingMatcherTest-2.xsd
+++ b/spring-ws-test/src/test/resources/org/springframework/ws/test/support/matcher/schemaValidatingMatcherTest-2.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.example.org/schema" xmlns:tns="http://www.example.org/schema" elementFormDefault="qualified">
+<schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="https://www.example.org/schema" xmlns:tns="https://www.example.org/schema" elementFormDefault="qualified">
 
 
 </schema>

--- a/spring-ws-test/src/test/resources/org/springframework/ws/test/support/matcher/schemaValidatingMatcherTest.xsd
+++ b/spring-ws-test/src/test/resources/org/springframework/ws/test/support/matcher/schemaValidatingMatcherTest.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.example.org/schema" xmlns:tns="http://www.example.org/schema" elementFormDefault="qualified">
+<schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="https://www.example.org/schema" xmlns:tns="https://www.example.org/schema" elementFormDefault="qualified">
 
     <element name="test" type="tns:testMessage"/>
     

--- a/spring-ws-test/src/test/resources/org/springframework/ws/test/support/schemaValidatingMatcherTest.xsd
+++ b/spring-ws-test/src/test/resources/org/springframework/ws/test/support/schemaValidatingMatcherTest.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.example.org/schema" xmlns:tns="http://www.example.org/schema" elementFormDefault="qualified">
+<schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="https://www.example.org/schema" xmlns:tns="https://www.example.org/schema" elementFormDefault="qualified">
 
     <element name="test" type="tns:testMessage"/>
     

--- a/spring-xml/src/main/java/org/springframework/xml/DocumentBuilderFactoryUtils.java
+++ b/spring-xml/src/main/java/org/springframework/xml/DocumentBuilderFactoryUtils.java
@@ -55,34 +55,34 @@ public class DocumentBuilderFactoryUtils {
 		}
 
 		try {
-			factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+			factory.setFeature("https://apache.org/xml/features/disallow-doctype-decl", true);
 		} catch (ParserConfigurationException e) {
 			if (log.isWarnEnabled()) {
-				log.warn("FEATURE 'http://apache.org/xml/features/disallow-doctype-decl' is probably not supported by " + factory.getClass().getCanonicalName());
+				log.warn("FEATURE 'https://apache.org/xml/features/disallow-doctype-decl' is probably not supported by " + factory.getClass().getCanonicalName());
 			}
 		}
 
 		try {
-			factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+			factory.setFeature("http://www.xml.org/sax/features/external-general-entities", false);
 		} catch (ParserConfigurationException e) {
 			if (log.isWarnEnabled()) {
-				log.warn("FEATURE 'http://xml.org/sax/features/external-general-entities' is probably not supported by " + factory.getClass().getCanonicalName());
+				log.warn("FEATURE 'http://www.xml.org/sax/features/external-general-entities' is probably not supported by " + factory.getClass().getCanonicalName());
 			}
 		}
 
 		try {
-			factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+			factory.setFeature("http://www.xml.org/sax/features/external-parameter-entities", false);
 		} catch (ParserConfigurationException e) {
 			if (log.isWarnEnabled()) {
-				log.warn("FEATURE 'http://xml.org/sax/features/external-parameter-entities' is probably not supported by " + factory.getClass().getCanonicalName());
+				log.warn("FEATURE 'http://www.xml.org/sax/features/external-parameter-entities' is probably not supported by " + factory.getClass().getCanonicalName());
 			}
 		}
 
 		try {
-			factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+			factory.setFeature("https://apache.org/xml/features/nonvalidating/load-external-dtd", false);
 		} catch (ParserConfigurationException e) {
 			if (log.isWarnEnabled()) {
-				log.warn("FEATURE 'http://apache.org/xml/features/nonvalidating/load-external-dtd' is probably not supported by " + factory.getClass().getCanonicalName());
+				log.warn("FEATURE 'https://apache.org/xml/features/nonvalidating/load-external-dtd' is probably not supported by " + factory.getClass().getCanonicalName());
 			}
 		}
 

--- a/spring-xml/src/main/java/org/springframework/xml/sax/AbstractXmlReader.java
+++ b/spring-xml/src/main/java/org/springframework/xml/sax/AbstractXmlReader.java
@@ -115,11 +115,11 @@ public abstract class AbstractXmlReader implements XMLReader {
 
 	/**
 	 * Throws a {@code SAXNotRecognizedException} exception when the given property does not signify a lexical
-	 * handler. The property name for a lexical handler is {@code http://xml.org/sax/properties/lexical-handler}.
+	 * handler. The property name for a lexical handler is {@code http://www.xml.org/sax/properties/lexical-handler}.
 	 */
 	@Override
 	public Object getProperty(String name) throws SAXNotRecognizedException, SAXNotSupportedException {
-		if ("http://xml.org/sax/properties/lexical-handler".equals(name)) {
+		if ("http://www.xml.org/sax/properties/lexical-handler".equals(name)) {
 			return lexicalHandler;
 		}
 		else {
@@ -129,11 +129,11 @@ public abstract class AbstractXmlReader implements XMLReader {
 
 	/**
 	 * Throws a {@code SAXNotRecognizedException} exception when the given property does not signify a lexical
-	 * handler. The property name for a lexical handler is {@code http://xml.org/sax/properties/lexical-handler}.
+	 * handler. The property name for a lexical handler is {@code http://www.xml.org/sax/properties/lexical-handler}.
 	 */
 	@Override
 	public void setProperty(String name, Object value) throws SAXNotRecognizedException, SAXNotSupportedException {
-		if ("http://xml.org/sax/properties/lexical-handler".equals(name)) {
+		if ("http://www.xml.org/sax/properties/lexical-handler".equals(name)) {
 			lexicalHandler = (LexicalHandler) value;
 		}
 		else {

--- a/spring-xml/src/main/java/org/springframework/xml/validation/SchemaLoaderUtils.java
+++ b/spring-xml/src/main/java/org/springframework/xml/validation/SchemaLoaderUtils.java
@@ -67,7 +67,7 @@ public abstract class SchemaLoaderUtils {
 		Assert.hasLength(schemaLanguage, "No schema language provided");
 		Source[] schemaSources = new Source[resources.length];
 		XMLReader xmlReader = XMLReaderFactoryUtils.createXMLReader();
-		xmlReader.setFeature("http://xml.org/sax/features/namespace-prefixes", true);
+		xmlReader.setFeature("http://www.xml.org/sax/features/namespace-prefixes", true);
 		for (int i = 0; i < resources.length; i++) {
 			Assert.notNull(resources[i], "Resource is null");
 			Assert.isTrue(resources[i].exists(), "Resource " + resources[i] + " does not exist");

--- a/spring-xml/src/main/java/org/springframework/xml/validation/XMLReaderFactoryUtils.java
+++ b/spring-xml/src/main/java/org/springframework/xml/validation/XMLReaderFactoryUtils.java
@@ -33,10 +33,10 @@ public class XMLReaderFactoryUtils {
 	public static XMLReader createXMLReader() throws SAXException {
 		XMLReader xmlReader = XMLReaderFactory.createXMLReader();
 
-		xmlReader.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-		xmlReader.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
-		xmlReader.setFeature("http://xml.org/sax/features/external-general-entities", false);
-		xmlReader.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+		xmlReader.setFeature("https://apache.org/xml/features/disallow-doctype-decl", true);
+		xmlReader.setFeature("https://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+		xmlReader.setFeature("http://www.xml.org/sax/features/external-general-entities", false);
+		xmlReader.setFeature("http://www.xml.org/sax/features/external-parameter-entities", false);
 
 		return xmlReader;
 	}

--- a/spring-xml/src/main/java/org/springframework/xml/validation/XmlValidatorFactory.java
+++ b/spring-xml/src/main/java/org/springframework/xml/validation/XmlValidatorFactory.java
@@ -45,7 +45,7 @@ public abstract class XmlValidatorFactory {
 	public static final String SCHEMA_W3C_XML = "http://www.w3.org/2001/XMLSchema";
 
 	/** Constant that defines a RELAX NG Schema. */
-	public static final String SCHEMA_RELAX_NG = "http://relaxng.org/ns/structure/1.0";
+	public static final String SCHEMA_RELAX_NG = "https://relaxng.org/ns/structure/1.0";
 
 	/**
 	 * Create a {@link XmlValidator} with the given schema resource and schema language type. The schema language must

--- a/spring-xml/src/main/java/org/springframework/xml/xpath/JaxenXPathTemplate.java
+++ b/spring-xml/src/main/java/org/springframework/xml/xpath/JaxenXPathTemplate.java
@@ -35,7 +35,7 @@ import org.w3c.dom.Node;
  * <p>Namespaces can be set using the {@code namespaces} property.
  *
  * @author Arjen Poutsma
- * @see <a href="http://www.jaxen.org/">Jaxen</a>
+ * @see <a href="https://www.jaxen.org/">Jaxen</a>
  * @since 1.0.0
  */
 public class JaxenXPathTemplate extends AbstractXPathTemplate {

--- a/spring-xml/src/main/java/org/springframework/xml/xpath/XPathExpression.java
+++ b/spring-xml/src/main/java/org/springframework/xml/xpath/XPathExpression.java
@@ -46,7 +46,7 @@ public interface XPathExpression {
 	 * @param node the starting point
 	 * @return the result of the evaluation
 	 * @throws XPathException in case of XPath errors
-	 * @see <a href="http://www.w3.org/TR/xpath/#function-boolean">XPath specification - boolean() function</a>
+	 * @see <a href="https://www.w3.org/TR/xpath/#function-boolean">XPath specification - boolean() function</a>
 	 */
 	boolean evaluateAsBoolean(Node node) throws XPathException;
 
@@ -57,7 +57,7 @@ public interface XPathExpression {
 	 * @param node the starting point
 	 * @return the result of the evaluation
 	 * @throws XPathException in case of XPath errors
-	 * @see <a href="http://www.w3.org/TR/xpath#node-sets">XPath specification</a>
+	 * @see <a href="https://www.w3.org/TR/xpath#node-sets">XPath specification</a>
 	 */
 	Node evaluateAsNode(Node node) throws XPathException;
 
@@ -68,7 +68,7 @@ public interface XPathExpression {
 	 * @param node the starting point
 	 * @return a list of {@code Node}s that are selected by the expression
 	 * @throws XPathException in case of XPath errors
-	 * @see <a href="http://www.w3.org/TR/xpath#node-sets">XPath specification</a>
+	 * @see <a href="https://www.w3.org/TR/xpath#node-sets">XPath specification</a>
 	 */
 	List<Node> evaluateAsNodeList(Node node) throws XPathException;
 
@@ -82,7 +82,7 @@ public interface XPathExpression {
 	 * @param node the starting point
 	 * @return the result of the evaluation
 	 * @throws XPathException in case of XPath errors
-	 * @see <a href="http://www.w3.org/TR/xpath/#function-number">XPath specification - number() function</a>
+	 * @see <a href="https://www.w3.org/TR/xpath/#function-number">XPath specification - number() function</a>
 	 */
 	double evaluateAsNumber(Node node) throws XPathException;
 
@@ -95,7 +95,7 @@ public interface XPathExpression {
 	 * @param node the starting point
 	 * @return the result of the evaluation
 	 * @throws XPathException in case of XPath errors
-	 * @see <a href="http://www.w3.org/TR/xpath/#function-string">XPath specification - string() function</a>
+	 * @see <a href="https://www.w3.org/TR/xpath/#function-string">XPath specification - string() function</a>
 	 */
 	String evaluateAsString(Node node) throws XPathException;
 
@@ -106,7 +106,7 @@ public interface XPathExpression {
 	 * @param nodeMapper object that will map one object per node
 	 * @return the single mapped object
 	 * @throws XPathException in case of XPath errors
-	 * @see <a href="http://www.w3.org/TR/xpath#node-sets">XPath specification</a>
+	 * @see <a href="https://www.w3.org/TR/xpath#node-sets">XPath specification</a>
 	 */
 	<T> T evaluateAsObject(Node node, NodeMapper<T> nodeMapper) throws XPathException;
 
@@ -118,7 +118,7 @@ public interface XPathExpression {
 	 * @param nodeMapper object that will map one object per node
 	 * @return the result list, containing mapped objects
 	 * @throws XPathException in case of XPath errors
-	 * @see <a href="http://www.w3.org/TR/xpath#node-sets">XPath specification</a>
+	 * @see <a href="https://www.w3.org/TR/xpath#node-sets">XPath specification</a>
 	 */
 	<T> List<T> evaluate(Node node, NodeMapper<T> nodeMapper) throws XPathException;
 }

--- a/spring-xml/src/main/java/org/springframework/xml/xpath/XPathOperations.java
+++ b/spring-xml/src/main/java/org/springframework/xml/xpath/XPathOperations.java
@@ -50,7 +50,7 @@ public interface XPathOperations {
 	 * @param context	 the context starting point
 	 * @return the result of the evaluation
 	 * @throws XPathException in case of XPath errors
-	 * @see <a href="http://www.w3.org/TR/xpath/#function-boolean">XPath specification - boolean() function</a>
+	 * @see <a href="https://www.w3.org/TR/xpath/#function-boolean">XPath specification - boolean() function</a>
 	 */
 	boolean evaluateAsBoolean(String expression, Source context) throws XPathException;
 
@@ -62,7 +62,7 @@ public interface XPathOperations {
 	 * @param context	 the context starting point
 	 * @return the result of the evaluation
 	 * @throws XPathException in case of XPath errors
-	 * @see <a href="http://www.w3.org/TR/xpath#node-sets">XPath specification</a>
+	 * @see <a href="https://www.w3.org/TR/xpath#node-sets">XPath specification</a>
 	 */
 	Node evaluateAsNode(String expression, Source context) throws XPathException;
 
@@ -74,7 +74,7 @@ public interface XPathOperations {
 	 * @param context	 the context starting point
 	 * @return the result of the evaluation
 	 * @throws XPathException in case of XPath errors
-	 * @see <a href="http://www.w3.org/TR/xpath#node-sets">XPath specification</a>
+	 * @see <a href="https://www.w3.org/TR/xpath#node-sets">XPath specification</a>
 	 */
 	List<Node> evaluateAsNodeList(String expression, Source context) throws XPathException;
 
@@ -89,7 +89,7 @@ public interface XPathOperations {
 	 * @param context	 the context starting point
 	 * @return the result of the evaluation
 	 * @throws XPathException in case of XPath errors
-	 * @see <a href="http://www.w3.org/TR/xpath/#function-number">XPath specification - number() function</a>
+	 * @see <a href="https://www.w3.org/TR/xpath/#function-number">XPath specification - number() function</a>
 	 */
 	double evaluateAsDouble(String expression, Source context) throws XPathException;
 
@@ -104,7 +104,7 @@ public interface XPathOperations {
 	 * @param context	 the context starting point
 	 * @return the result of the evaluation
 	 * @throws XPathException in case of XPath errors
-	 * @see <a href="http://www.w3.org/TR/xpath/#function-string">XPath specification - string() function</a>
+	 * @see <a href="https://www.w3.org/TR/xpath/#function-string">XPath specification - string() function</a>
 	 */
 	String evaluateAsString(String expression, Source context) throws XPathException;
 
@@ -116,7 +116,7 @@ public interface XPathOperations {
 	 * @param nodeMapper object that will map one object per node
 	 * @return the single mapped object
 	 * @throws XPathException in case of XPath errors
-	 * @see <a href="http://www.w3.org/TR/xpath#node-sets">XPath specification</a>
+	 * @see <a href="https://www.w3.org/TR/xpath#node-sets">XPath specification</a>
 	 */
 	<T> T evaluateAsObject(String expression, Source context, NodeMapper<T> nodeMapper) throws XPathException;
 
@@ -129,7 +129,7 @@ public interface XPathOperations {
 	 * @param nodeMapper object that will map one object per node
 	 * @return the result list, containing mapped objects
 	 * @throws XPathException in case of XPath errors
-	 * @see <a href="http://www.w3.org/TR/xpath#node-sets">XPath specification</a>
+	 * @see <a href="https://www.w3.org/TR/xpath#node-sets">XPath specification</a>
 	 */
 	<T> List<T> evaluate(String expression, Source context, NodeMapper<T> nodeMapper) throws XPathException;
 
@@ -141,7 +141,7 @@ public interface XPathOperations {
 	 * @param context		  the context starting point
 	 * @param callbackHandler object that will extract results, one row at a time
 	 * @throws XPathException in case of XPath errors
-	 * @see <a href="http://www.w3.org/TR/xpath#node-sets">XPath specification</a>
+	 * @see <a href="https://www.w3.org/TR/xpath#node-sets">XPath specification</a>
 	 */
 	void evaluate(String expression, Source context, NodeCallbackHandler callbackHandler) throws XPathException;
 }

--- a/spring-xml/src/main/java/org/springframework/xml/xsd/commons/CommonsXsdSchema.java
+++ b/spring-xml/src/main/java/org/springframework/xml/xsd/commons/CommonsXsdSchema.java
@@ -45,7 +45,7 @@ import org.springframework.xml.xsd.XsdSchema;
  * Implementation of the {@link XsdSchema} interface that uses Apache WS-Commons XML Schema.
  *
  * @author Arjen Poutsma
- * @see <a href="http://ws.apache.org/commons/XmlSchema/">Commons XML Schema</a>
+ * @see <a href="https://ws.apache.org/commons/XmlSchema/">Commons XML Schema</a>
  * @since 1.5.0
  */
 public class CommonsXsdSchema implements XsdSchema {

--- a/spring-xml/src/main/java/org/springframework/xml/xsd/commons/CommonsXsdSchemaCollection.java
+++ b/spring-xml/src/main/java/org/springframework/xml/xsd/commons/CommonsXsdSchemaCollection.java
@@ -55,7 +55,7 @@ import org.springframework.xml.xsd.XsdSchemaCollection;
  * simplifies the deployment of the schemas.
  *
  * @author Arjen Poutsma
- * @see <a href="http://ws.apache.org/commons/XmlSchema/">Commons XML Schema</a>
+ * @see <a href="https://ws.apache.org/commons/XmlSchema/">Commons XML Schema</a>
  * @since 1.5.0
  */
 public class CommonsXsdSchemaCollection implements XsdSchemaCollection, InitializingBean, ResourceLoaderAware {
@@ -213,7 +213,7 @@ public class CommonsXsdSchemaCollection implements XsdSchemaCollection, Initiali
 			if (external instanceof XmlSchemaImport) {
 				XmlSchemaImport schemaImport = (XmlSchemaImport) external;
 				XmlSchema importedSchema = schemaImport.getSchema();
-				if (!"http://www.w3.org/XML/1998/namespace".equals(schemaImport.getNamespace()) &&
+				if (!"https://www.w3.org/XML/1998/namespace".equals(schemaImport.getNamespace()) &&
 						importedSchema != null && !processedImports.contains(importedSchema)) {
 					inlineIncludes(importedSchema, processedIncludes, processedImports);
 					findImports(importedSchema, processedImports, processedIncludes);

--- a/spring-xml/src/test/java/org/springframework/xml/dom/DomContentHandlerTest.java
+++ b/spring-xml/src/test/java/org/springframework/xml/dom/DomContentHandlerTest.java
@@ -66,7 +66,7 @@ public class DomContentHandlerTest {
 
 	@Test
 	public void testContentHandlerDocumentNamespacePrefixes() throws Exception {
-		xmlReader.setFeature("http://xml.org/sax/features/namespace-prefixes", true);
+		xmlReader.setFeature("http://www.xml.org/sax/features/namespace-prefixes", true);
 		handler = new DomContentHandler(result);
 		expected = documentBuilder.parse(new InputSource(new StringReader(XML_1)));
 		xmlReader.setContentHandler(handler);

--- a/spring-xml/src/test/java/org/springframework/xml/transform/TraxUtilsTest.java
+++ b/spring-xml/src/test/java/org/springframework/xml/transform/TraxUtilsTest.java
@@ -257,7 +257,7 @@ public class TraxUtilsTest {
 
 	@Test
 	public void testDoWithSystemIdSource() throws Exception {
-		String systemId = "http://www.springframework.org/dtd/spring-beans.dtd";
+		String systemId = "https://www.springframework.org/dtd/spring-beans.dtd";
 
 		TraxUtils.SourceCallback mock = createMock(TraxUtils.SourceCallback.class);
 		mock.source(systemId);
@@ -271,7 +271,7 @@ public class TraxUtilsTest {
 
 	@Test
 	public void testDoWithSystemIdResult() throws Exception {
-		String systemId = "http://www.springframework.org/dtd/spring-beans.dtd";
+		String systemId = "https://www.springframework.org/dtd/spring-beans.dtd";
 
 		TraxUtils.ResultCallback mock = createMock(TraxUtils.ResultCallback.class);
 		mock.result(systemId);

--- a/spring-xml/src/test/java/org/springframework/xml/xsd/commons/CommonsXsdSchemaTest.java
+++ b/spring-xml/src/test/java/org/springframework/xml/xsd/commons/CommonsXsdSchemaTest.java
@@ -52,7 +52,7 @@ public class CommonsXsdSchemaTest extends AbstractXsdSchemaTestCase {
 		Element schemaElement = result.getDocumentElement();
 		Element elementElement = (Element) schemaElement.getFirstChild();
 		assertNotNull("No expectedContentTypes found",
-				elementElement.getAttributeNS("http://www.w3.org/2005/05/xmlmime", "expectedContentTypes"));
+				elementElement.getAttributeNS("https://www.w3.org/2005/05/xmlmime", "expectedContentTypes"));
 	}
 
 

--- a/spring-xml/src/test/resources/org/springframework/xml/xsd/xmime.xsd
+++ b/spring-xml/src/test/resources/org/springframework/xml/xsd/xmime.xsd
@@ -5,7 +5,7 @@
            elementFormDefault="qualified"
            attributeFormDefault="unqualified"
 
-           xmlns:xmime="http://www.w3.org/2005/05/xmlmime">
+           xmlns:xmime="https://www.w3.org/2005/05/xmlmime">
     <xs:element name="BinaryData" type="xs:base64Binary" xmime:expectedContentTypes="application/octet-stream"/>
 </xs:schema>
 

--- a/spring-xml/src/test/resources/org/springframework/xml/xsd/xml.xsd
+++ b/spring-xml/src/test/resources/org/springframework/xml/xsd/xml.xsd
@@ -1,6 +1,6 @@
 <?xml version='1.0'?>
 <?xml-stylesheet href="../2008/09/xsd.xsl" type="text/xsl"?>
-<xs:schema targetNamespace="http://www.w3.org/XML/1998/namespace" 
+<xs:schema targetNamespace="https://www.w3.org/XML/1998/namespace" 
   xmlns:xs="http://www.w3.org/2001/XMLSchema" 
   xmlns   ="http://www.w3.org/1999/xhtml"
   xml:lang="en">
@@ -16,10 +16,10 @@
       suitable for import by other schema documents.
      </p>
      <p>
-      See <a href="http://www.w3.org/XML/1998/namespace.html">
-      http://www.w3.org/XML/1998/namespace.html</a> and
-      <a href="http://www.w3.org/TR/REC-xml">
-      http://www.w3.org/TR/REC-xml</a> for information 
+      See <a href="https://www.w3.org/XML/1998/namespace.html">
+      https://www.w3.org/XML/1998/namespace.html</a> and
+      <a href="https://www.w3.org/TR/REC-xml">
+      https://www.w3.org/TR/REC-xml</a> for information 
       about this namespace.
      </p>
      <p>
@@ -61,11 +61,11 @@
       going to be a realistic possibility.  
      </p>
      <p>
-      See BCP 47 at <a href="http://www.rfc-editor.org/rfc/bcp/bcp47.txt">
-       http://www.rfc-editor.org/rfc/bcp/bcp47.txt</a>
+      See BCP 47 at <a href="https://www.rfc-editor.org/rfc/bcp/bcp47.txt">
+       https://www.rfc-editor.org/rfc/bcp/bcp47.txt</a>
       and the IANA language subtag registry at
-      <a href="http://www.iana.org/assignments/language-subtag-registry">
-       http://www.iana.org/assignments/language-subtag-registry</a>
+      <a href="https://www.iana.org/assignments/language-subtag-registry">
+       https://www.iana.org/assignments/language-subtag-registry</a>
       for further information.
      </p>
      <p>
@@ -124,7 +124,7 @@
      
      <p>
       See <a
-      href="http://www.w3.org/TR/xmlbase/">http://www.w3.org/TR/xmlbase/</a>
+      href="https://www.w3.org/TR/xmlbase/">https://www.w3.org/TR/xmlbase/</a>
       for information about this attribute.
      </p>
     </div>
@@ -146,7 +146,7 @@
      
      <p>
       See <a
-      href="http://www.w3.org/TR/xml-id/">http://www.w3.org/TR/xml-id/</a>
+      href="https://www.w3.org/TR/xml-id/">https://www.w3.org/TR/xml-id/</a>
       for information about this attribute.
      </p>
     </div>
@@ -206,15 +206,15 @@
      <pre>
           &lt;schema . . .>
            . . .
-           &lt;import namespace="http://www.w3.org/XML/1998/namespace"
-                      schemaLocation="http://www.w3.org/2001/xml.xsd"/>
+           &lt;import namespace="https://www.w3.org/XML/1998/namespace"
+                      schemaLocation="https://www.w3.org/2001/xml.xsd"/>
      </pre>
      <p>
       or
      </p>
      <pre>
-           &lt;import namespace="http://www.w3.org/XML/1998/namespace"
-                      schemaLocation="http://www.w3.org/2009/01/xml.xsd"/>
+           &lt;import namespace="https://www.w3.org/XML/1998/namespace"
+                      schemaLocation="https://www.w3.org/2009/01/xml.xsd"/>
      </pre>
      <p>
       Subsequently, qualified reference to any of the attributes or the
@@ -242,25 +242,25 @@
      <p>
       In keeping with the XML Schema WG's standard versioning
       policy, this schema document will persist at
-      <a href="http://www.w3.org/2009/01/xml.xsd">
-       http://www.w3.org/2009/01/xml.xsd</a>.
+      <a href="https://www.w3.org/2009/01/xml.xsd">
+       https://www.w3.org/2009/01/xml.xsd</a>.
      </p>
      <p>
       At the date of issue it can also be found at
-      <a href="http://www.w3.org/2001/xml.xsd">
-       http://www.w3.org/2001/xml.xsd</a>.
+      <a href="https://www.w3.org/2001/xml.xsd">
+       https://www.w3.org/2001/xml.xsd</a>.
      </p>
      <p>
       The schema document at that URI may however change in the future,
       in order to remain compatible with the latest version of XML
       Schema itself, or with the XML namespace itself.  In other words,
       if the XML Schema or XML namespaces change, the version of this
-      document at <a href="http://www.w3.org/2001/xml.xsd">
-       http://www.w3.org/2001/xml.xsd 
+      document at <a href="https://www.w3.org/2001/xml.xsd">
+       https://www.w3.org/2001/xml.xsd 
       </a> 
       will change accordingly; the version at 
-      <a href="http://www.w3.org/2009/01/xml.xsd">
-       http://www.w3.org/2009/01/xml.xsd 
+      <a href="https://www.w3.org/2009/01/xml.xsd">
+       https://www.w3.org/2009/01/xml.xsd 
       </a> 
       will not change.
      </p>
@@ -269,14 +269,14 @@
       document are at:
      </p>
      <ul>
-      <li><a href="http://www.w3.org/2009/01/xml.xsd">
-	http://www.w3.org/2009/01/xml.xsd</a></li>
-      <li><a href="http://www.w3.org/2007/08/xml.xsd">
-	http://www.w3.org/2007/08/xml.xsd</a></li>
-      <li><a href="http://www.w3.org/2004/10/xml.xsd">
-	http://www.w3.org/2004/10/xml.xsd</a></li>
-      <li><a href="http://www.w3.org/2001/03/xml.xsd">
-	http://www.w3.org/2001/03/xml.xsd</a></li>
+      <li><a href="https://www.w3.org/2009/01/xml.xsd">
+	https://www.w3.org/2009/01/xml.xsd</a></li>
+      <li><a href="https://www.w3.org/2007/08/xml.xsd">
+	https://www.w3.org/2007/08/xml.xsd</a></li>
+      <li><a href="https://www.w3.org/2004/10/xml.xsd">
+	https://www.w3.org/2004/10/xml.xsd</a></li>
+      <li><a href="https://www.w3.org/2001/03/xml.xsd">
+	https://www.w3.org/2001/03/xml.xsd</a></li>
      </ul>
     </div>
    </div>

--- a/spring-xml/src/test/resources/org/springframework/xml/xsd/xmlNamespace.xsd
+++ b/spring-xml/src/test/resources/org/springframework/xml/xsd/xmlNamespace.xsd
@@ -4,7 +4,7 @@
             xmlns="http://www.springframework.org/spring-ws/xmlNamespace" elementFormDefault="qualified"
             attributeFormDefault="unqualified">
 
-    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="xml.xsd"/>
+    <xsd:import namespace="https://www.w3.org/XML/1998/namespace" schemaLocation="xml.xsd"/>
 
     <xsd:element name="GetOrderRequest">
         <xsd:complexType>

--- a/src/api/overview.html
+++ b/src/api/overview.html
@@ -1,7 +1,7 @@
 <html>
 <body>
 <p>
-This is the public API documentation for <a href="http://github.com/SpringSource/spring-ws" target="_top">Spring Web Services</a>.
+This is the public API documentation for <a href="https://github.com/SpringSource/spring-ws" target="_top">Spring Web Services</a>.
 </p>
 </body>
 </html>

--- a/src/dist/readme.txt
+++ b/src/dist/readme.txt
@@ -6,7 +6,7 @@ https://jira.springsource.org/browse/SWS
 
 Please consult the documentation located within the 'docs/reference'
 directory of this release and also visit the official Spring Web Services home at
-http://projects.spring.io/spring-ws
+https://projects.spring.io/spring-ws
 
 There you will find links to the forum, issue tracker, and other resources.
 

--- a/src/main/asciidoctor/client.adoc
+++ b/src/main/asciidoctor/client.adoc
@@ -23,7 +23,7 @@ The `WebServiceTemplate` class uses an URI as the message destination. You can e
 
 There are two implementations of the `WebServiceMessageSender` interface for sending messages via HTTP. The default implementation is the `HttpUrlConnectionMessageSender`, which uses the facilities provided by Java itself. The alternative is the `HttpComponentsMessageSender`, which uses the https://hc.apache.org/httpcomponents-client-ga[Apache HttpComponents HttpClient]. Use the latter if you need more advanced and easy-to-use functionality (such as authentication, HTTP connection pooling, and so forth).
 
-To use the HTTP transport, either set the `defaultUri` to something like `http://example.com/services`, or supply the *uri* parameter for one of the methods.
+To use the HTTP transport, either set the `defaultUri` to something like `https://example.com/services`, or supply the *uri* parameter for one of the methods.
 
 The following example shows how the default configuration can be used for HTTP transports:
 
@@ -35,7 +35,7 @@ The following example shows how the default configuration can be used for HTTP t
 
     <bean id="webServiceTemplate" class="org.springframework.ws.client.core.WebServiceTemplate">
         <constructor-arg ref="messageFactory"/>
-        <property name="defaultUri" value="http://example.com/WebService"/>
+        <property name="defaultUri" value="https://example.com/WebService"/>
     </bean>
 
 </beans>
@@ -56,7 +56,7 @@ The following example shows how override the default configuration, and to use A
             </property>
         </bean>
     </property>
-    <property name="defaultUri" value="http://example.com/WebService"/>
+    <property name="defaultUri" value="https://example.com/WebService"/>
 </bean>
 ----
 
@@ -176,7 +176,7 @@ import org.springframework.ws.transport.WebServiceMessageSender;
 public class WebServiceClient {
 
     private static final String MESSAGE =
-        "<message xmlns=\"http://tempuri.org\">Hello Web Service World</message>";
+        "<message xmlns=\"https://www.bing.com/\">Hello Web Service World</message>";
 
     private final WebServiceTemplate webServiceTemplate = new WebServiceTemplate();
 
@@ -220,7 +220,7 @@ Please note that the `WebServiceTemplate` class is thread-safe once configured (
 
 === Sending and receiving POJOs - marshalling and unmarshalling
 
-In order to facilitate the sending of plain Java objects, the `WebServiceTemplate` has a number of `send(..)` methods that take an `Object` as an argument for a message's data content. The method `marshalSendAndReceive(..)` in the `WebServiceTemplate` class delegates the conversion of the request object to XML to a `Marshaller`, and the conversion of the response XML to an object to an `Unmarshaller`. (For more information about marshalling and unmarshaller, refer to http://static.springsource.org/spring/docs/3.0.x/spring-framework-reference/html/oxm.html[the Spring documentation].) By using the marshallers, your application code can focus on the business object that is being sent or received and not be concerned with the details of how it is represented as XML. In order to use the marshalling functionality, you have to set a marshaller and unmarshaller with the `marshaller`/`unmarshaller` properties of the `WebServiceTemplate` class.
+In order to facilitate the sending of plain Java objects, the `WebServiceTemplate` has a number of `send(..)` methods that take an `Object` as an argument for a message's data content. The method `marshalSendAndReceive(..)` in the `WebServiceTemplate` class delegates the conversion of the request object to XML to a `Marshaller`, and the conversion of the response XML to an object to an `Unmarshaller`. (For more information about marshalling and unmarshaller, refer to https://docs.spring.io/spring/docs/3.0.x/spring-framework-reference/html/oxm.html[the Spring documentation].) By using the marshallers, your application code can focus on the business object that is being sent or received and not be concerned with the details of how it is represented as XML. In order to use the marshalling functionality, you have to set a marshaller and unmarshaller with the `marshaller`/`unmarshaller` properties of the `WebServiceTemplate` class.
 
 === `WebServiceMessageCallback`
 
@@ -248,11 +248,11 @@ In addition to the <<server-ws-addressing,server-side WS-Addressing>> support, S
 
 For setting WS-Addressing headers on the client, you can use the `org.springframework.ws.soap.addressing.client.ActionCallback`. This callback takes the desired Action header as a parameter. It also has constructors for specifying the WS-Addressing version, and a `To` header. If not specified, the `To` header will default to the URL of the connection being made.
 
-Here is an example of setting the `Action` header to `http://samples/RequestOrder`:
+Here is an example of setting the `Action` header to `https://samples/RequestOrder`:
 
 [source,java]
 ----
-webServiceTemplate.marshalSendAndReceive(o, new ActionCallback("http://samples/RequestOrder"));
+webServiceTemplate.marshalSendAndReceive(o, new ActionCallback("https://samples/RequestOrder"));
 ----
 
 === `WebServiceMessageExtractor`
@@ -448,7 +448,7 @@ You can set up multiple request expectations by chaining `andExpect()` calls, li
 
 [source,java]
 ----
-mockServer.expect(connectionTo("http://example.com")).
+mockServer.expect(connectionTo("https://example.com")).
  andExpect(payload(expectedRequestPayload)).
  andExpect(validPayload(schemaResource)).
  andRespond(...);

--- a/src/main/asciidoctor/common.adoc
+++ b/src/main/asciidoctor/common.adoc
@@ -114,9 +114,9 @@ Both the `SaajSoapMessageFactory` and the `AxiomSoapMessageFactory` have a `soap
        xmlns:util="http://www.springframework.org/schema/util"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-       http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+       https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
        http://www.springframework.org/schema/util
-       http://www.springframework.org/schema/util/spring-util-2.0.xsd">
+       https://www.springframework.org/schema/util/spring-util-2.0.xsd">
 
     <bean id="messageFactory" class="org.springframework.ws.soap.saaj.SaajSoapMessageFactory">
         <property name="soapVersion">
@@ -178,7 +178,7 @@ The `XPathExpression` is an abstraction over a compiled XPath expression, such a
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-          http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+          https://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
 
     <bean id="nameExpression" class="org.springframework.xml.xpath.XPathExpressionFactoryBean">
         <property name="expression" value="/Contacts/Contact/Name"/>
@@ -295,7 +295,7 @@ With this configuration, a typical output will be:
 
 ----
 TRACE [client.MessageTracing.sent] Sent request [<SOAP-ENV:Envelope xmlns:SOAP-ENV="...
-DEBUG [server.MessageTracing.received] Received request [SaajSoapMessage {http://example.com}request] ...
-DEBUG [server.MessageTracing.sent] Sent response [SaajSoapMessage {http://example.com}response] ...
-DEBUG [client.MessageTracing.received] Received response [SaajSoapMessage {http://example.com}response] ...
+DEBUG [server.MessageTracing.received] Received request [SaajSoapMessage {https://example.com}request] ...
+DEBUG [server.MessageTracing.sent] Sent response [SaajSoapMessage {https://example.com}response] ...
+DEBUG [client.MessageTracing.received] Received response [SaajSoapMessage {https://example.com}response] ...
 ----

--- a/src/main/asciidoctor/security.adoc
+++ b/src/main/asciidoctor/security.adoc
@@ -19,13 +19,13 @@ NOTE: Note that WS-Security (especially encryption and signing) requires substan
 [[security-xws-security-interceptor]]
 == `XwsSecurityInterceptor`
 
-The `XwsSecurityInterceptor` is an `EndpointInterceptor` (see <<server-endpoint-interceptor>>) that is based on SUN's XML and Web Services Security package (XWSS). This WS-Security implementation is part of the Java Web Services Developer Pack (http://java.sun.com/webservices/[_Java WSDP_]).
+The `XwsSecurityInterceptor` is an `EndpointInterceptor` (see <<server-endpoint-interceptor>>) that is based on SUN's XML and Web Services Security package (XWSS). This WS-Security implementation is part of the Java Web Services Developer Pack (https://java.sun.com/webservices/[_Java WSDP_]).
 
 Like any other endpoint interceptor, it is defined in the endpoint mapping (see <<server-endpoint-mapping>>). This means that you can be selective about adding WS-Security support: some endpoint mappings require it, while others do not.
 
 NOTE: Note that XWSS requires both a SUN 1.5 JDK and the SUN SAAJ reference implementation. The WSS4J interceptor does not have these requirements (see <<security-wss4j-security-interceptor>>).
 
-The `XwsSecurityInterceptor` requires a *security policy file* to operate. This XML file tells the interceptor what security aspects to require from incoming SOAP messages, and what aspects to add to outgoing messages. The basic format of the policy file will be explained in the following sections, but you can find a more in-depth tutorial http://java.sun.com/webservices/docs/1.6/tutorial/doc/XWS-SecurityIntro4.html#wp564887[_here_]. You can set the policy with the `policyConfiguration` property, which requires a Spring resource. The policy file can contain multiple elements, e.g. require a username token on incoming messages, and sign all outgoing messages. It contains a `SecurityConfiguration` element as root (not a `JAXRPCSecurity` element).
+The `XwsSecurityInterceptor` requires a *security policy file* to operate. This XML file tells the interceptor what security aspects to require from incoming SOAP messages, and what aspects to add to outgoing messages. The basic format of the policy file will be explained in the following sections, but you can find a more in-depth tutorial https://java.sun.com/webservices/docs/1.6/tutorial/doc/XWS-SecurityIntro4.html#wp564887[_here_]. You can set the policy with the `policyConfiguration` property, which requires a Spring resource. The policy file can contain multiple elements, e.g. require a username token on incoming messages, and sign all outgoing messages. It contains a `SecurityConfiguration` element as root (not a `JAXRPCSecurity` element).
 
 Additionally, the security interceptor requires one or more`CallbackHandler`s to operate. These handlers are used to retrieve certificates, private keys, validate user credentials, etc. Spring-WS offers handlers for most common security concerns, e.g. authenticating against a Spring Security authentication manager, signing outgoing messages based on a X509 certificate. The following sections will indicate what callback handler to use for which security concern. You can set the callback handlers using the `callbackHandler` or `callbackHandlers` property.
 
@@ -66,7 +66,7 @@ The `java.security.KeyStore` class represents a storage facility for cryptograph
 
 ==== KeyTool
 
-Supplied with your Java Virtual Machine is the *keytool* program, a key and certificate management utility. You can use this tool to create new keystores, add new private keys and certificates to them, etc. It is beyond the scope of this document to provide a full reference of the *keytool* command, but you can find a reference http://java.sun.com/j2se/1.5.0/docs/tooldocs/windows/keytool.html[_here_] , or by giving the command `keytool -help` on the command line.
+Supplied with your Java Virtual Machine is the *keytool* program, a key and certificate management utility. You can use this tool to create new keystores, add new private keys and certificates to them, etc. It is beyond the scope of this document to provide a full reference of the *keytool* command, but you can find a reference https://java.sun.com/j2se/1.5.0/docs/tooldocs/windows/keytool.html[_here_] , or by giving the command `keytool -help` on the command line.
 
 ==== KeyStoreFactoryBean
 
@@ -163,11 +163,11 @@ The simplest form of username authentication uses*plain text passwords*. In this
 
 WARNING: Note that plain text passwords are not very secure. Therefore, you should always add additional security measures to your transport layer if you are using them (using HTTPS instead of plain HTTP, for instance).
 
-To require that every incoming message contains a `UsernameToken` with a plain text password, the security policy file should contain a `RequireUsernameToken` element, with the `passwordDigestRequired` attribute set to`false`. You can find a reference of possible child elements http://java.sun.com/webservices/docs/1.6/tutorial/doc/XWS-SecurityIntro4.html#wp567459[_here_].
+To require that every incoming message contains a `UsernameToken` with a plain text password, the security policy file should contain a `RequireUsernameToken` element, with the `passwordDigestRequired` attribute set to`false`. You can find a reference of possible child elements https://java.sun.com/webservices/docs/1.6/tutorial/doc/XWS-SecurityIntro4.html#wp567459[_here_].
 
 [source,xml]
 ----
-<xwss:SecurityConfiguration xmlns:xwss="http://java.sun.com/xml/ns/xwss/config">
+<xwss:SecurityConfiguration xmlns:xwss="https://java.sun.com/xml/ns/xwss/config">
     ...
     <xwss:RequireUsernameToken passwordDigestRequired="false" nonceRequired="false"/>
     ...
@@ -224,7 +224,7 @@ The `SpringPlainTextPasswordValidationCallbackHandler` requires an `Authenticati
 
 ===== JaasPlainTextPasswordValidationCallbackHandler
 
-The `JaasPlainTextPasswordValidationCallbackHandler` is based on the standard http://java.sun.com/products/jaas/[_Java Authentication and Authorization Service_]. It is beyond the scope of this document to provide a full introduction into JAAS, but there is a http://www.javaworld.com/javaworld/jw-09-2002/jw-0913-jaas.html[_good tutorial_] available.
+The `JaasPlainTextPasswordValidationCallbackHandler` is based on the standard https://java.sun.com/products/jaas/[_Java Authentication and Authorization Service_]. It is beyond the scope of this document to provide a full introduction into JAAS, but there is a https://www.javaworld.com/javaworld/jw-09-2002/jw-0913-jaas.html[_good tutorial_] available.
 
 The `JaasPlainTextPasswordValidationCallbackHandler` requires only a `loginContextName` to operate. It creates a new JAAS `LoginContext` using this name, and handles the standard JAAS `NameCallback` and `PasswordCallback` using the username and password provided in the SOAP message. This means that this callback handler integrates with any JAAS `LoginModule` that fires these callbacks during the `login()` phase, which is standard behavior.
 
@@ -244,11 +244,11 @@ In this case, the callback handler uses the `LoginContext` named "MyLoginModule"
 
 When using password digests, the SOAP message also contains a `UsernameToken` element, which itself contains a `Username` element and a `Password` element. The difference is that the password is not sent as plain text, but as a *digest*. The recipient compares this digest to the digest he calculated from the known password of the user, and if they are the same, the user is authenticated. It can be compared to the Digest Authentication provided by HTTP servers.
 
-To require that every incoming message contains a `UsernameToken` element with a password digest, the security policy file should contain a `RequireUsernameToken` element, with the `passwordDigestRequired` attribute set to`true`. Additionally, the `nonceRequired` should be set to`true`: You can find a reference of possible child elements http://java.sun.com/webservices/docs/1.6/tutorial/doc/XWS-SecurityIntro4.html#wp567459[_here_].
+To require that every incoming message contains a `UsernameToken` element with a password digest, the security policy file should contain a `RequireUsernameToken` element, with the `passwordDigestRequired` attribute set to`true`. Additionally, the `nonceRequired` should be set to`true`: You can find a reference of possible child elements https://java.sun.com/webservices/docs/1.6/tutorial/doc/XWS-SecurityIntro4.html#wp567459[_here_].
 
 [source,xml]
 ----
-<xwss:SecurityConfiguration xmlns:xwss="http://java.sun.com/xml/ns/xwss/config">
+<xwss:SecurityConfiguration xmlns:xwss="https://java.sun.com/xml/ns/xwss/config">
     ...
     <xwss:RequireUsernameToken passwordDigestRequired="true" nonceRequired="true"/>
     ...
@@ -282,11 +282,11 @@ The `SpringDigestPasswordValidationCallbackHandler` requires an Spring Security 
 
 A more secure way of authentication uses X509 certificates. In this scenerario, the SOAP message contains a`BinarySecurityToken`, which contains a Base 64-encoded version of a X509 certificate. The certificate is used by the recipient to authenticate. The certificate stored in the message is also used to sign the message (see <<security-verifying-signatures>>).
 
-To make sure that all incoming SOAP messages carry a`BinarySecurityToken`, the security policy file should contain a `RequireSignature` element. This element can further carry other elements, which will be covered in <<security-verifying-signatures>>. You can find a reference of possible child elements http://java.sun.com/webservices/docs/1.6/tutorial/doc/XWS-SecurityIntro4.html#wp565769[_here_].
+To make sure that all incoming SOAP messages carry a`BinarySecurityToken`, the security policy file should contain a `RequireSignature` element. This element can further carry other elements, which will be covered in <<security-verifying-signatures>>. You can find a reference of possible child elements https://java.sun.com/webservices/docs/1.6/tutorial/doc/XWS-SecurityIntro4.html#wp565769[_here_].
 
 [source,xml]
 ----
-<xwss:SecurityConfiguration xmlns:xwss="http://java.sun.com/xml/ns/xwss/config">
+<xwss:SecurityConfiguration xmlns:xwss="https://java.sun.com/xml/ns/xwss/config">
     ...
     <xwss:RequireSignature requireTimestamp="false">
     ...
@@ -375,7 +375,7 @@ The `SpringCertificateValidationCallbackHandler` requires an Spring Security `Au
 </beans>
 ----
 
-In this case, we are using a custom user details service to obtain authentication details based on the certificate. Refer to the http://www.springframework.org/security[_Spring Security reference documentation_] for more information about authentication against X509 certificates.
+In this case, we are using a custom user details service to obtain authentication details based on the certificate. Refer to the https://www.springframework.org/security[_Spring Security reference documentation_] for more information about authentication against X509 certificates.
 
 ===== JaasCertificateValidationCallbackHandler
 
@@ -402,11 +402,11 @@ The *digital signature* of a message is a piece of information based on both the
 
 Just like <<security-certificate-authentication,certificate-based authentication>>, a signed message contains a `BinarySecurityToken`, which contains the certificate used to sign the message. Additionally, it contains a `SignedInfo` block, which indicates what part of the message was signed.
 
-To make sure that all incoming SOAP messages carry a`BinarySecurityToken`, the security policy file should contain a `RequireSignature` element. It can also contain a `SignatureTarget` element, which specifies the target message part which was expected to be signed, and various other subelements. You can also define the private key alias to use, whether to use a symmetric instead of a private key, and many other properties. You can find a reference of possible child elements http://java.sun.com/webservices/docs/1.6/tutorial/doc/XWS-SecurityIntro4.html#wp565769[_here_].
+To make sure that all incoming SOAP messages carry a`BinarySecurityToken`, the security policy file should contain a `RequireSignature` element. It can also contain a `SignatureTarget` element, which specifies the target message part which was expected to be signed, and various other subelements. You can also define the private key alias to use, whether to use a symmetric instead of a private key, and many other properties. You can find a reference of possible child elements https://java.sun.com/webservices/docs/1.6/tutorial/doc/XWS-SecurityIntro4.html#wp565769[_here_].
 
 [source,xml]
 ----
-<xwss:SecurityConfiguration xmlns:xwss="http://java.sun.com/xml/ns/xwss/config">
+<xwss:SecurityConfiguration xmlns:xwss="https://java.sun.com/xml/ns/xwss/config">
     <xwss:RequireSignature requireTimestamp="false"/>
 </xwss:SecurityConfiguration>
 ----
@@ -435,11 +435,11 @@ As described in <<security-key-store-callback-handler>>, the `KeyStoreCallbackHa
 
 When signing a message, the `XwsSecurityInterceptor` adds the `BinarySecurityToken` to the message, and a `SignedInfo` block, which indicates what part of the message was signed.
 
-To sign all outgoing SOAP messages, the security policy file should contain a `Sign` element. It can also contain a `SignatureTarget` element, which specifies the target message part which was expected to be signed, and various other subelements. You can also define the private key alias to use, whether to use a symmetric instead of a private key, and many other properties. You can find a reference of possible child elements http://java.sun.com/webservices/docs/1.6/tutorial/doc/XWS-SecurityIntro4.html#wp565497[_here_].
+To sign all outgoing SOAP messages, the security policy file should contain a `Sign` element. It can also contain a `SignatureTarget` element, which specifies the target message part which was expected to be signed, and various other subelements. You can also define the private key alias to use, whether to use a symmetric instead of a private key, and many other properties. You can find a reference of possible child elements https://java.sun.com/webservices/docs/1.6/tutorial/doc/XWS-SecurityIntro4.html#wp565497[_here_].
 
 [source,xml]
 ----
-<xwss:SecurityConfiguration xmlns:xwss="http://java.sun.com/xml/ns/xwss/config">
+<xwss:SecurityConfiguration xmlns:xwss="https://java.sun.com/xml/ns/xwss/config">
 	<xwss:Sign includeTimestamp="false" />
 </xwss:SecurityConfiguration>
 ----
@@ -471,11 +471,11 @@ When *encrypting*, the message is transformed into a form that can only be read 
 
 ==== Decryption
 
-To decrypt incoming SOAP messages, the security policy file should contain a `RequireEncryption` element. This element can further carry a `EncryptionTarget` element which indicates which part of the message should be encrypted, and a `SymmetricKey` to indicate that a shared secret instead of the regular private key should be used to decrypt the message. You can read a description of the other elements http://java.sun.com/webservices/docs/1.6/tutorial/doc/XWS-SecurityIntro4.html#wp565951[_here_].
+To decrypt incoming SOAP messages, the security policy file should contain a `RequireEncryption` element. This element can further carry a `EncryptionTarget` element which indicates which part of the message should be encrypted, and a `SymmetricKey` to indicate that a shared secret instead of the regular private key should be used to decrypt the message. You can read a description of the other elements https://java.sun.com/webservices/docs/1.6/tutorial/doc/XWS-SecurityIntro4.html#wp565951[_here_].
 
 [source,xml]
 ----
-<xwss:SecurityConfiguration xmlns:xwss="http://java.sun.com/xml/ns/xwss/config">
+<xwss:SecurityConfiguration xmlns:xwss="https://java.sun.com/xml/ns/xwss/config">
     <xwss:RequireEncryption />
 </xwss:SecurityConfiguration>
 ----
@@ -503,11 +503,11 @@ As described in <<security-key-store-callback-handler>>, the `KeyStoreCallbackHa
 
 ==== Encryption
 
-To encrypt outgoing SOAP messages, the security policy file should contain a `Encrypt` element. This element can further carry a `EncryptionTarget` element which indicates which part of the message should be encrypted, and a `SymmetricKey` to indicate that a shared secret instead of the regular public key should be used to encrypt the message. You can read a description of the other elements http://java.sun.com/webservices/docs/1.6/tutorial/doc/XWS-SecurityIntro4.html#wp565951[_here_].
+To encrypt outgoing SOAP messages, the security policy file should contain a `Encrypt` element. This element can further carry a `EncryptionTarget` element which indicates which part of the message should be encrypted, and a `SymmetricKey` to indicate that a shared secret instead of the regular public key should be used to encrypt the message. You can read a description of the other elements https://java.sun.com/webservices/docs/1.6/tutorial/doc/XWS-SecurityIntro4.html#wp565951[_here_].
 
 [source,xml]
 ----
-<xwss:SecurityConfiguration xmlns:xwss="http://java.sun.com/xml/ns/xwss/config">
+<xwss:SecurityConfiguration xmlns:xwss="https://java.sun.com/xml/ns/xwss/config">
     <xwss:Encrypt />
 </xwss:SecurityConfiguration>
 ----
@@ -958,9 +958,9 @@ If the `EmbeddedKeyName` type is chosen, you need to specify the *secret key* to
 </bean>
 ----
 
-The `securementEncryptionKeyTransportAlgorithm` property defines which algorithm to use to encrypt the generated symmetric key. Supported values are `http://www.w3.org/2001/04/xmlenc#rsa-1_5`, which is the default, and `http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p`.
+The `securementEncryptionKeyTransportAlgorithm` property defines which algorithm to use to encrypt the generated symmetric key. Supported values are `https://www.w3.org/2001/04/xmlenc#rsa-1_5`, which is the default, and `https://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p`.
 
-The symmetric encryption algorithm to use can be set via the `securementEncryptionSymAlgorithm` property. Supported values are `http://www.w3.org/2001/04/xmlenc#aes128-cbc` (default value), `http://www.w3.org/2001/04/xmlenc#tripledes-cbc`, `http://www.w3.org/2001/04/xmlenc#aes256-cbc`, `http://www.w3.org/2001/04/xmlenc#aes192-cbc`.
+The symmetric encryption algorithm to use can be set via the `securementEncryptionSymAlgorithm` property. Supported values are `https://www.w3.org/2001/04/xmlenc#aes128-cbc` (default value), `https://www.w3.org/2001/04/xmlenc#tripledes-cbc`, `https://www.w3.org/2001/04/xmlenc#aes256-cbc`, `https://www.w3.org/2001/04/xmlenc#aes192-cbc`.
 
 Finally, the `securementEncryptionParts` property defines which parts of the message will be encrypted. The value of this property is a list of semi-colon separated element names that identify the elements to encrypt. An encryption mode specifier and a namespace identification, each inside a pair of curly brackets, may precede each element name. The encryption mode specifier is either `{Content}` or `{Element}` footnote:[Please refer to the W3C XML Encryption specification about the differences between Element and Content encryption.] . The following example identifies the `echoResponse` from the echo sample:
 

--- a/src/main/asciidoctor/server.adoc
+++ b/src/main/asciidoctor/server.adoc
@@ -110,7 +110,7 @@ The WSDL defined in the '`orders.wsdl`' file on the classpath can then be access
 http://localhost:8080/spring-ws/orders.wsdl
 ----
 
-NOTE: All `WsdlDefinition` bean definitions are exposed by the `MessageDispatcherServlet` under their bean name with the suffix `.wsdl`. So if the bean name is `echo`, the host name is "server", and the Servlet context (war name) is "spring-ws", the WSDL can be obtained via `http://server/spring-ws/echo.wsdl`
+NOTE: All `WsdlDefinition` bean definitions are exposed by the `MessageDispatcherServlet` under their bean name with the suffix `.wsdl`. So if the bean name is `echo`, the host name is "server", and the Servlet context (war name) is "spring-ws", the WSDL can be obtained via `https://server/spring-ws/echo.wsdl`
 
 Another nice feature of the `MessageDispatcherServlet` (or more correctly the `WsdlDefinitionHandlerAdapter`) is that it is able to transform the value of the '`location`' of all the WSDL that it exposes to reflect the URL of the incoming request.
 
@@ -316,7 +316,7 @@ The following piece of configuration shows how to use the server-side email supp
 
 === Embedded HTTP Server transport
 
-Spring Web Services provides a transport based on Sun's JRE 1.6 http://java.sun.com/javase/6/docs/jre/api/net/httpserver/spec/index.html[HTTP server]. The embedded HTTP Server is a standalone server that is simple to configure. It lends itself to a lighter  alternative to conventional servlet containers.
+Spring Web Services provides a transport based on Sun's JRE 1.6 https://java.sun.com/javase/6/docs/jre/api/net/httpserver/spec/index.html[HTTP server]. The embedded HTTP Server is a standalone server that is simple to configure. It lends itself to a lighter  alternative to conventional servlet containers.
 
 When using the embedded HTTP server, no external deployment descriptor is needed (`web.xml`). You only need to define an instance of the server and configure it to handle incoming requests. The remoting module in the Core Spring Framework contains a convenient factory bean for the HTTP server: the `SimpleHttpServerFactoryBean`. The most important property is `contexts`, which maps context paths to corresponding `HttpHandler`s.
 
@@ -360,7 +360,7 @@ The following snippet shows a simple configuration example of the HTTP server tr
 </beans>
 ----
 
-For more information on the `SimpleHttpServerFactoryBean`, refer to the http://static.springframework.org/spring/docs/2.5.x/api/org/springframework/remoting/support/SimpleHttpServerFactoryBean.html[Javadoc].
+For more information on the `SimpleHttpServerFactoryBean`, refer to the https://docs.spring.io/spring/docs/2.5.x/api/org/springframework/remoting/support/SimpleHttpServerFactoryBean.html[Javadoc].
 
 === XMPP transport
 
@@ -436,13 +436,13 @@ public class AnnotationOrderEndpoint {
       this.orderService = orderService;
   }
 
-  @PayloadRoot(localPart = "order", namespace = "http://samples")                              // <5>
+  @PayloadRoot(localPart = "order", namespace = "https://samples")                              // <5>
   public void order(@RequestPayload Element orderElement) {                                    // <3>
     Order order = createOrder(orderElement);
     orderService.createOrder(order);
   }
 
-  @PayloadRoot(localPart = "orderRequest", namespace = "http://samples")                       // <5>
+  @PayloadRoot(localPart = "orderRequest", namespace = "https://samples")                       // <5>
   @ResponsePayload
   public Order getOrder(@RequestPayload OrderRequest orderRequest, SoapHeader header) {        // <4>
     checkSoapHeaderForSomething(header);
@@ -460,7 +460,7 @@ public class AnnotationOrderEndpoint {
 For more information about endpoint methods, refer to <<server-atEndpoint-methods>>.
 <4> The `getOrder` method takes a `OrderRequest` as a parameter, annotated with `@RequestPayload` as well. This parameter is a JAXB2-supported object (it is annotated with `@XmlRootElement`). This means that the payload of the message is passed on to this method as a unmarshalled object. The `SoapHeader` type is also given as a parameter. On invocation, this parameter will contain the SOAP header of the request message. The method is also annotated with `@ResponsePayload`, indicating that the return value (the `Order`) is used as the payload of the response message.
 For more information about endpoint methods, refer to <<server-atEndpoint-methods>>.
-<5> The two handling methods of this endpoint are marked with `@PayloadRoot`, indicating what sort of request messages can be handled by the method: the `getOrder` method will be invoked for requests with a `orderRequest` local name and a `http://samples` namespace URI; the order method for requests with a `order` local name.
+<5> The two handling methods of this endpoint are marked with `@PayloadRoot`, indicating what sort of request messages can be handled by the method: the `getOrder` method will be invoked for requests with a `orderRequest` local name and a `https://samples` namespace URI; the order method for requests with a `order` local name.
 For more information about `@PayloadRoot`, refer to <<server-endpoint-mapping>>.
 
 To enable the support for `@Endpoint` and related Spring-WS annotations, you will need to add the following to your Spring application context:
@@ -471,9 +471,9 @@ To enable the support for `@Endpoint` and related Spring-WS annotations, you wil
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   *xmlns:sws="http://www.springframework.org/schema/web-services"*
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-      http://www.springframework.org/schema/beans/spring-beans.xsd
+      https://www.springframework.org/schema/beans/spring-beans.xsd
     *http://www.springframework.org/schema/web-services
-      http://www.springframework.org/schema/web-services/web-services.xsd">
+      https://www.springframework.org/schema/web-services/web-services.xsd">
 
   <sws:annotation-driven />*
 
@@ -518,7 +518,7 @@ public class MyConfiguration extends WsConfigurerAdapter {
 
 In the next couple of sections, a more elaborate description of the `@Endpoint` programming model is given.
 
-NOTE: Endpoints, like any other Spring Bean, are scoped as a singleton by default, i.e. one instance of the bean definition is created per container. Being a singleton implies that more than one thread can use it at the same time, so the endpoint has to be thread safe. If you want to use a different scope, such as prototype, refer to the http://static.springframework.org/spring/docs/2.5.x/reference/beans.html#beans-factory-scopes[Spring Reference documentation].
+NOTE: Endpoints, like any other Spring Bean, are scoped as a singleton by default, i.e. one instance of the bean definition is created per container. Being a singleton implies that more than one thread can use it at the same time, so the endpoint has to be thread safe. If you want to use a different scope, such as prototype, refer to the https://docs.spring.io/spring/docs/2.5.x/reference/beans.html#beans-factory-scopes[Spring Reference documentation].
 
  Note that all abstract base classes provided in Spring-WS are thread safe, unless otherwise indicated in the class-level Javadoc.
 
@@ -534,7 +534,7 @@ Here is an example of a handling method:
 
 [source,java]
 ----
-@PayloadRoot(localPart = "order", namespace = "http://samples")
+@PayloadRoot(localPart = "order", namespace = "https://samples")
 public void order(@RequestPayload Element orderElement) {
   Order order = createOrder(orderElement);
   orderService.createOrder(order);
@@ -589,7 +589,7 @@ The following table describes the supported parameter types. It shows the suppor
 | Enabled when StAX is on the classpath.
 
 | XPath
-| Any boolean, double, `String`, `org.w3c.Node`, `org.w3c.dom.NodeList`, or type that can be converted from a `String` by a Spring 3 http://static.springsource.org/spring/docs/3.0.x/spring-framework-reference/html/validation.html#core-convert[conversion service], and that is annotated with `@XPathParam`.
+| Any boolean, double, `String`, `org.w3c.Node`, `org.w3c.dom.NodeList`, or type that can be converted from a `String` by a Spring 3 https://docs.spring.io/spring/docs/3.0.x/spring-framework-reference/html/validation.html#core-convert[conversion service], and that is annotated with `@XPathParam`.
 | No
 | Enabled by default, see <<server-xpath-param,the section called `XPathParam`>>.
 
@@ -609,7 +609,7 @@ The following table describes the supported parameter types. It shows the suppor
 | Enabled when JAXB2 is on the classpath.
 
 | OXM
-| Any type supported by a Spring OXM http://static.springsource.org/spring/docs/3.0.x/spring-framework-reference/html/oxm.html#d0e26164[`Unmarshaller`].
+| Any type supported by a Spring OXM https://docs.spring.io/spring/docs/3.0.x/spring-framework-reference/html/oxm.html#d0e26164[`Unmarshaller`].
 | Yes
 | Enabled when the `unmarshaller` attribute of `<sws:annotation-driven/>` is specified.
 |===
@@ -664,8 +664,8 @@ public class AnnotationOrderEndpoint {
     this.orderService = orderService;
   }
 
-  @PayloadRoot(localPart = "orderRequest", namespace = "http://samples")
-  *@Namespace(prefix = "s", uri="http://samples")*
+  @PayloadRoot(localPart = "orderRequest", namespace = "https://samples")
+  *@Namespace(prefix = "s", uri="https://samples")*
   public Order getOrder(*@XPathParam("/s:orderRequest/@id") int orderId*) {
     Order order = orderService.getOrder(orderId);
     // create Source from order and return it
@@ -674,7 +674,7 @@ public class AnnotationOrderEndpoint {
 }
 ----
 
-Since we use the prefix `s` in our XPath expression, we must bind it to the `http://samples` namespace. This is accomplished with the `@Namespace` annotation. Alternatively, we could have placed this annotation on the type-level to use the same namespace mapping for all handler methods, or even the package-level (in `package-info.java`) to use it for multiple endpoints.
+Since we use the prefix `s` in our XPath expression, we must bind it to the `https://samples` namespace. This is accomplished with the `@Namespace` annotation. Alternatively, we could have placed this annotation on the type-level to use the same namespace mapping for all handler methods, or even the package-level (in `package-info.java`) to use it for multiple endpoints.
 
 Using the `@XPathParam`, you can bind to all the data types supported by XPath: 
                             
@@ -684,7 +684,7 @@ Using the `@XPathParam`, you can bind to all the data types supported by XPath:
 * `Node`
 * `NodeList`
 
-In addition to this list, you can use any type that can be converted from a `String` by a Spring 3 http://static.springsource.org/spring/docs/3.0.x/spring-framework-reference/html/validation.html#core-convert[conversion service].
+In addition to this list, you can use any type that can be converted from a `String` by a Spring 3 https://docs.spring.io/spring/docs/3.0.x/spring-framework-reference/html/validation.html#core-convert[conversion service].
 
 ==== Handling method return types
 
@@ -738,7 +738,7 @@ The following table describes the supported return types. It shows the supported
 | Enabled when JAXB2 is on the classpath.
 
 | OXM
-| Any type supported by a Spring OXM http://static.springsource.org/spring/docs/3.0.x/spring-framework-reference/html/oxm.html#d0e26096[`Marshaller`].
+| Any type supported by a Spring OXM https://docs.spring.io/spring/docs/3.0.x/spring-framework-reference/html/oxm.html#d0e26096[`Marshaller`].
 | Yes
 | Enabled when the `marshaller` attribute of `<sws:annotation-driven/>` is specified.
 |===
@@ -772,13 +772,13 @@ WS-Addressing specifies a transport-neutral routing mechanism. It is based on a 
 [source,xml]
 ----
 <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://www.w3.org/2003/05/soap-envelope"
-    xmlns:wsa="http://www.w3.org/2005/08/addressing">
+    xmlns:wsa="https://www.w3.org/2005/08/addressing">
   <SOAP-ENV::Header>
     <wsa:MessageID>urn:uuid:21363e0d-2645-4eb7-8afd-2f5ee1bb25cf</wsa:MessageID>
     <wsa:ReplyTo>
-      <wsa:Address>http://example.com/business/client1</wsa:Address>
+      <wsa:Address>https://example.com/business/client1</wsa:Address>
     </wsa:ReplyTo>
-    <wsa:To S:mustUnderstand="true">http://example/com/fabrikam</wsa:To>
+    <wsa:To S:mustUnderstand="true">https://example/com/fabrikam</wsa:To>
     <wsa:Action>http://example.com/fabrikam/mail/Delete</wsa:Action>
   </SOAP-ENV:Header>
   <SOAP-ENV:Body>
@@ -789,7 +789,7 @@ WS-Addressing specifies a transport-neutral routing mechanism. It is based on a 
 </SOAP-ENV:Envelope>
 ----
 
-In this example, the destination is set to `http://example/com/fabrikam`, while the action is set to `http://example.com/fabrikam/mail/Delete`. Additionally, there is a message identifier, and an reply-to address. By default, this address is the "anonymous" address, indicating that a response should be sent using the same channel as the request (i.e. the HTTP response), but it can also be another address, as indicated in this example.
+In this example, the destination is set to `https://example/com/fabrikam`, while the action is set to `http://example.com/fabrikam/mail/Delete`. Additionally, there is a message identifier, and an reply-to address. By default, this address is the "anonymous" address, indicating that a response should be sent using the same channel as the request (i.e. the HTTP response), but it can also be another address, as indicated in this example.
 
 In Spring Web Services, WS-Addressing is implemented as an endpoint mapping. Using this mapping, you associate WS-Addressing actions with endpoints, similar to the `SoapActionAnnotationMethodEndpointMapping` described above.
 
@@ -814,12 +814,12 @@ public class AnnotationOrderEndpoint {
         this.orderService = orderService;
     }
 
-    @Action("http://samples/RequestOrder")
+    @Action("https://samples/RequestOrder")
     public Order getOrder(OrderRequest orderRequest) {
         return orderService.getOrder(orderRequest.getId());
     }
 
-    @Action("http://samples/CreateOrder")
+    @Action("https://samples/CreateOrder")
     public void order(Order order) {
         orderService.createOrder(order);
     }
@@ -827,7 +827,7 @@ public class AnnotationOrderEndpoint {
 }
 ----
 
-The mapping above routes requests which have a WS-Addressing `Action` of `http://samples/RequestOrder` to the `getOrder` method. Requests with `http://samples/CreateOrder` will be routed to the `order` method..
+The mapping above routes requests which have a WS-Addressing `Action` of `https://samples/RequestOrder` to the `getOrder` method. Requests with `https://samples/CreateOrder` will be routed to the `order` method..
 
 By default, the `AnnotationActionEndpointMapping` supports both the 1.0 (May 2006), and the August 2004 editions of WS-Addressing. These two versions are most popular, and are interoperable with Axis 1 and 2, JAX-WS, XFire, Windows Communication Foundation (WCF), and Windows Services Enhancements (WSE) 3.0. If necessary, specific versions of the spec can be injected into the `versions` property.
 
@@ -846,10 +846,10 @@ Endpoint interceptors are typically defined by using a `<sws:interceptors>` elem
 ----
 <sws:interceptors>
   <bean class="samples.MyGlobalInterceptor"/>
-  <sws:payloadRoot namespaceUri="http://www.example.com">
+  <sws:payloadRoot namespaceUri="https://www.example.com">
     <bean class="samples.MyPayloadRootInterceptor"/>
   </sws:payloadRoot>
-  <sws:soapAction value="http://www.example.com/SoapAction">
+  <sws:soapAction value="https://www.example.com/SoapAction">
     <bean class="samples.MySoapActionInterceptor1"/>
     <ref bean="mySoapActionInterceptor2"/>
   </sws:soapAction>
@@ -858,7 +858,7 @@ Endpoint interceptors are typically defined by using a `<sws:interceptors>` elem
 <bean id="mySoapActionInterceptor2" class="samples.MySoapActionInterceptor2"/>
 ----
 
-Here, we define one 'global' interceptor (`MyGlobalInterceptor`) that intercepts all request and responses. We also define an interceptor that only applies to XML messages that have the `http://www.example.com` as a payload root namespace. Here, we could have defined a `localPart` attribute in addition to the `namespaceUri` to further limit the messages the interceptor applies to. Finally, we define two interceptors that apply when the message has a `http://www.example.com/SoapAction` SOAP action. Notice how the second interceptor is actually a reference to a bean definition outside of the `<interceptors>` element. You can use bean references anywhere inside the `<interceptors>` element.
+Here, we define one 'global' interceptor (`MyGlobalInterceptor`) that intercepts all request and responses. We also define an interceptor that only applies to XML messages that have the `https://www.example.com` as a payload root namespace. Here, we could have defined a `localPart` attribute in addition to the `namespaceUri` to further limit the messages the interceptor applies to. Finally, we define two interceptors that apply when the message has a `https://www.example.com/SoapAction` SOAP action. Notice how the second interceptor is actually a reference to a bean definition outside of the `<interceptors>` element. You can use bean references anywhere inside the `<interceptors>` element.
 
 When using `@Configuration` classes, you can extend from `WsConfigurerAdapter` to add interceptors. Like so:
 

--- a/src/main/asciidoctor/tutorial.adoc
+++ b/src/main/asciidoctor/tutorial.adoc
@@ -70,8 +70,8 @@ Now that we have seen some examples of the XML data that we will use, it makes s
 
 * DTDs
 * https://www.w3.org/XML/Schema[XML Schema (XSD)]
-* http://www.relaxng.org/[RELAX NG]
-* http://www.schematron.com/[Schematron]
+* https://relaxng.org/[RELAX NG]
+* http://schematron.com/[Schematron]
 
 DTDs have limited namespace support, so they are not suitable for Web services. Relax NG and Schematron certainly are easier than XML Schema. Unfortunately, they are not so widely supported across platforms. We will use XML Schema.
 
@@ -270,7 +270,7 @@ Adding a concrete part is pretty standard: just refer to the abstract part you d
     </wsdl:portType>
     <wsdl:binding name="HumanResourceBinding" type="tns:HumanResource">          <!--4--><!--5-->
         <soap:binding style="document"                                           <!--6-->
-            transport="http://schemas.xmlsoap.org/soap/http"/>                   <!--7-->
+            transport="http://schemas.xmlsoap.org/soap/http/"/>                   <!--7-->
         <wsdl:operation name="Holiday">
             <soap:operation soapAction="http://mycompany.com/RequestHoliday"/>   <!--8-->
             <wsdl:input name="HolidayRequest">
@@ -292,7 +292,7 @@ Adding a concrete part is pretty standard: just refer to the abstract part you d
 <4> We define the `HumanResource` port type, which gets used in the `binding`.
 <5> We define the `HumanResourceBinding` binding, which gets used in the `port`.
 <6> We use a document/literal style.
-<7> The literal `http://schemas.xmlsoap.org/soap/http` signifies a HTTP transport.
+<7> The literal `http://schemas.xmlsoap.org/soap/http/` signifies a HTTP transport.
 <8> The `soapAction` attribute signifies the `SOAPAction` HTTP header that will be sent with every request.
 <9> The `http://localhost:8080/holidayService/` address is the URL where the Web service can be invoked.
 
@@ -320,7 +320,7 @@ This command will create a new directory called `holidayService`. In this direct
 <web-app xmlns="http://java.sun.com/xml/ns/j2ee"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee
-             http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd"
+             https://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd"
          version="2.4">
 
     <display-name>MyCompany HR Holiday Service</display-name>
@@ -472,9 +472,9 @@ Here is how we would configure these classes in our `spring-ws-servlet.xml` Spri
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns:context="http://www.springframework.org/schema/context"
   xmlns:sws="http://www.springframework.org/schema/web-services"
-  xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-  http://www.springframework.org/schema/web-services http://www.springframework.org/schema/web-services/web-services-2.0.xsd
-  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+  xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+  http://www.springframework.org/schema/web-services https://www.springframework.org/schema/web-services/web-services-2.0.xsd
+  http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-3.0.xsd">
 
   <context:component-scan base-package="com.mycompany.hr"/>
 
@@ -564,7 +564,7 @@ servlet in `web.xml` (shown below).
 </init-param>
 ----
 
-You can create a WAR file using *mvn install*. If you deploy the application (to Tomcat, Jetty, etc.), and point your browser at http://localhost:8080/holidayService/holiday.wsdl[this location], you will see the generated WSDL. This WSDL is ready to be used by clients, such as http://www.soapui.org/[soapUI], or other SOAP frameworks.
+You can create a WAR file using *mvn install*. If you deploy the application (to Tomcat, Jetty, etc.), and point your browser at http://localhost:8080/holidayService/holiday.wsdl[this location], you will see the generated WSDL. This WSDL is ready to be used by clients, such as https://www.soapui.org/[soapUI], or other SOAP frameworks.
 
 That concludes this tutorial. The tutorial code can be found in the full distribution of Spring-WS. The next step would be to look at the echo sample application that is part of the distribution. After that, look at the airline sample, which is a bit more complicated, because it uses JAXB, WS-Security, Hibernate, and a transactional service layer. Finally, you can read the rest of the reference documentation.
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://expected.com (200) with 1 occurrences could not be migrated:  
   ([https](https://expected.com) result ConnectTimeoutException).
* [ ] http://other.com (200) with 1 occurrences could not be migrated:  
   ([https](https://other.com) result SSLHandshakeException).
* [ ] http://schemas.xmlsoap.org/soap/encoding/ (200) with 9 occurrences could not be migrated:  
   ([https](https://schemas.xmlsoap.org/soap/encoding/) result AnnotatedConnectException).
* [ ] http://schemas.xmlsoap.org/wsdl/ (200) with 18 occurrences could not be migrated:  
   ([https](https://schemas.xmlsoap.org/wsdl/) result AnnotatedConnectException).
* [ ] http://schemas.xmlsoap.org/wsdl/soap/ (200) with 17 occurrences could not be migrated:  
   ([https](https://schemas.xmlsoap.org/wsdl/soap/) result AnnotatedConnectException).
* [ ] http://schemas.xmlsoap.org/wsdl/soap12/ (200) with 5 occurrences could not be migrated:  
   ([https](https://schemas.xmlsoap.org/wsdl/soap12/) result AnnotatedConnectException).
* [ ] http://www.jdom.org/ (200) with 1 occurrences could not be migrated:  
   ([https](https://www.jdom.org/) result AnnotatedConnectException).
* [ ] http://www.ws-i.org/Profiles/BasicProfile-1.1.html (200) with 5 occurrences could not be migrated:  
   ([https](https://www.ws-i.org/Profiles/BasicProfile-1.1.html) result SSLHandshakeException).
* [ ] http://schemas.xmlsoap.org/soap/actor/next (301) with 1 occurrences could not be migrated:  
   ([https](https://schemas.xmlsoap.org/soap/actor/next) result AnnotatedConnectException).
* [ ] http://schemas.xmlsoap.org/soap/http (301) with 19 occurrences could not be migrated:  
   ([https](https://schemas.xmlsoap.org/soap/http) result AnnotatedConnectException).
* [ ] http://www.schematron.com/ (301) with 1 occurrences could not be migrated:  
   ([https](https://www.schematron.com/) result ConnectTimeoutException).
* [ ] http://xml.org/sax/features/external-general-entities (301) with 3 occurrences could not be migrated:  
   ([https](https://xml.org/sax/features/external-general-entities) result SSLHandshakeException).
* [ ] http://xml.org/sax/features/external-parameter-entities (301) with 3 occurrences could not be migrated:  
   ([https](https://xml.org/sax/features/external-parameter-entities) result SSLHandshakeException).
* [ ] http://xml.org/sax/features/namespace-prefixes (301) with 7 occurrences could not be migrated:  
   ([https](https://xml.org/sax/features/namespace-prefixes) result SSLHandshakeException).
* [ ] http://xml.org/sax/features/namespaces (301) with 3 occurrences could not be migrated:  
   ([https](https://xml.org/sax/features/namespaces) result SSLHandshakeException).
* [ ] http://xml.org/sax/properties/lexical-handler (301) with 4 occurrences could not be migrated:  
   ([https](https://xml.org/sax/properties/lexical-handler) result SSLHandshakeException).
* [ ] http://example.com:80/context/myService.wsdl (404) with 1 occurrences could not be migrated:  
   ([https](https://example.com:80/context/myService.wsdl) result NotSslRecordException).
* [ ] http://example.com:80/context/services/myService (404) with 1 occurrences could not be migrated:  
   ([https](https://example.com:80/context/services/myService) result NotSslRecordException).
* [ ] http://example.com:80/echo/services (404) with 1 occurrences could not be migrated:  
   ([https](https://example.com:80/echo/services) result NotSslRecordException).
* [ ] http://example.com:80/echo/services/imported.xsd (404) with 2 occurrences could not be migrated:  
   ([https](https://example.com:80/echo/services/imported.xsd) result NotSslRecordException).
* [ ] http://mycompany.com/RequestHoliday (404) with 2 occurrences could not be migrated:  
   ([https](https://mycompany.com/RequestHoliday) result ConnectTimeoutException).
* [ ] http://mycompany.com/employees/schemas (404) with 1 occurrences could not be migrated:  
   ([https](https://mycompany.com/employees/schemas) result ConnectTimeoutException).
* [ ] http://mycompany.com/hr/definitions (404) with 6 occurrences could not be migrated:  
   ([https](https://mycompany.com/hr/definitions) result ConnectTimeoutException).
* [ ] http://mycompany.com/humanresources (404) with 1 occurrences could not be migrated:  
   ([https](https://mycompany.com/humanresources) result ConnectTimeoutException).
* [ ] http://tempuri.org/Action (404) with 2 occurrences could not be migrated:  
   ([https](https://tempuri.org/Action) result ConnectTimeoutException).
* [ ] http://tempuri.org/SOAPAction (404) with 1 occurrences could not be migrated:  
   ([https](https://tempuri.org/SOAPAction) result ConnectTimeoutException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://www.relaxng.org/ (301) with 1 occurrences migrated to:  
  https://relaxng.org/ ([https](https://www.relaxng.org/) result SSLHandshakeException).
* [ ] http://example.com:8080/context/myService.wsdl (ConnectTimeoutException) with 2 occurrences migrated to:  
  https://example.com:8080/context/myService.wsdl ([https](https://example.com:8080/context/myService.wsdl) result ConnectTimeoutException).
* [ ] http://example.com:8080/context/service (ConnectTimeoutException) with 3 occurrences migrated to:  
  https://example.com:8080/context/service ([https](https://example.com:8080/context/service) result ConnectTimeoutException).
* [ ] http://example.com:8080/context/services/myService (ConnectTimeoutException) with 2 occurrences migrated to:  
  https://example.com:8080/context/services/myService ([https](https://example.com:8080/context/services/myService) result ConnectTimeoutException).
* [ ] http://example.com:8080/service (ConnectTimeoutException) with 2 occurrences migrated to:  
  https://example.com:8080/service ([https](https://example.com:8080/service) result ConnectTimeoutException).
* [ ] http://example.com:8080/services/bookFlight=bookFlightEndpoint (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://example.com:8080/services/bookFlight=bookFlightEndpoint ([https](https://example.com:8080/services/bookFlight=bookFlightEndpoint) result ConnectTimeoutException).
* [ ] http://www.example.com:8080 (ConnectTimeoutException) with 2 occurrences migrated to:  
  https://www.example.com:8080 ([https](https://www.example.com:8080) result ConnectTimeoutException).
* [ ] http://www.example.com:8080=7 (ConnectTimeoutException) with 2 occurrences migrated to:  
  https://www.example.com:8080=7 ([https](https://www.example.com:8080=7) result ConnectTimeoutException).
* [ ] http://www.jaxen.org/ (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://www.jaxen.org/ ([https](https://www.jaxen.org/) result ConnectTimeoutException).
* [ ] http://www.w3.org/2001/xml.xsd (ReadTimeoutException) with 8 occurrences migrated to:  
  https://www.w3.org/2001/xml.xsd ([https](https://www.w3.org/2001/xml.xsd) result ReadTimeoutException).
* [ ] http://childnamespace (UnknownHostException) with 1 occurrences migrated to:  
  https://childnamespace ([https](https://childnamespace) result UnknownHostException).
* [ ] http://example/com/fabrikam (UnknownHostException) with 2 occurrences migrated to:  
  https://example/com/fabrikam ([https](https://example/com/fabrikam) result UnknownHostException).
* [ ] http://fabrikam123.example/mail/Delete (UnknownHostException) with 2 occurrences migrated to:  
  https://fabrikam123.example/mail/Delete ([https](https://fabrikam123.example/mail/Delete) result UnknownHostException).
* [ ] http://rootnamespace (UnknownHostException) with 1 occurrences migrated to:  
  https://rootnamespace ([https](https://rootnamespace) result UnknownHostException).
* [ ] http://samples (UnknownHostException) with 7 occurrences migrated to:  
  https://samples ([https](https://samples) result UnknownHostException).
* [ ] http://samples/CreateOrder (UnknownHostException) with 2 occurrences migrated to:  
  https://samples/CreateOrder ([https](https://samples/CreateOrder) result UnknownHostException).
* [ ] http://samples/RequestOrder (UnknownHostException) with 4 occurrences migrated to:  
  https://samples/RequestOrder ([https](https://samples/RequestOrder) result UnknownHostException).
* [ ] http://server/spring-ws/echo.wsdl (UnknownHostException) with 1 occurrences migrated to:  
  https://server/spring-ws/echo.wsdl ([https](https://server/spring-ws/echo.wsdl) result UnknownHostException).
* [ ] http://springws.cas.de (UnknownHostException) with 4 occurrences migrated to:  
  https://springws.cas.de ([https](https://springws.cas.de) result UnknownHostException).
* [ ] http://www.springframework.org=10 (UnknownHostException) with 1 occurrences migrated to:  
  https://www.springframework.org=10 ([https](https://www.springframework.org=10) result UnknownHostException).
* [ ] http://www/springframework.org/role (UnknownHostException) with 2 occurrences migrated to:  
  https://www/springframework.org/role ([https](https://www/springframework.org/role) result UnknownHostException).
* [ ] http://apache.org/xml/features/disallow-doctype-decl (404) with 3 occurrences migrated to:  
  https://apache.org/xml/features/disallow-doctype-decl ([https](https://apache.org/xml/features/disallow-doctype-decl) result 404).
* [ ] http://apache.org/xml/features/nonvalidating/load-external-dtd (404) with 3 occurrences migrated to:  
  https://apache.org/xml/features/nonvalidating/load-external-dtd ([https](https://apache.org/xml/features/nonvalidating/load-external-dtd) result 404).
* [ ] http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0 (404) with 6 occurrences migrated to:  
  https://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0 ([https](https://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0) result 404).
* [ ] http://example.com/WebService (404) with 2 occurrences migrated to:  
  https://example.com/WebService ([https](https://example.com/WebService) result 404).
* [ ] http://example.com/business/client1 (404) with 4 occurrences migrated to:  
  https://example.com/business/client1 ([https](https://example.com/business/client1) result 404).
* [ ] http://example.com/context/myService.wsdl (404) with 1 occurrences migrated to:  
  https://example.com/context/myService.wsdl ([https](https://example.com/context/myService.wsdl) result 404).
* [ ] http://example.com/context/services/myService (404) with 1 occurrences migrated to:  
  https://example.com/context/services/myService ([https](https://example.com/context/services/myService) result 404).
* [ ] http://example.com/foo/bar (404) with 1 occurrences migrated to:  
  https://example.com/foo/bar ([https](https://example.com/foo/bar) result 404).
* [ ] http://example.com/myService (404) with 2 occurrences migrated to:  
  https://example.com/myService ([https](https://example.com/myService) result 404).
* [ ] http://example.com/services (404) with 2 occurrences migrated to:  
  https://example.com/services ([https](https://example.com/services) result 404).
* [ ] http://example.com/soap11 (404) with 2 occurrences migrated to:  
  https://example.com/soap11 ([https](https://example.com/soap11) result 404).
* [ ] http://example.com/soap12 (404) with 2 occurrences migrated to:  
  https://example.com/soap12 ([https](https://example.com/soap12) result 404).
* [ ] http://example.com/someuniquestring (404) with 2 occurrences migrated to:  
  https://example.com/someuniquestring ([https](https://example.com/someuniquestring) result 404).
* [ ] http://example.org/paymentv2 (404) with 2 occurrences migrated to:  
  https://example.org/paymentv2 ([https](https://example.org/paymentv2) result 404).
* [ ] http://hc.apache.org/httpcomponents-client (404) with 1 occurrences migrated to:  
  https://hc.apache.org/httpcomponents-client ([https](https://hc.apache.org/httpcomponents-client) result 404).
* [ ] http://springframework.org/DoIt (404) with 2 occurrences migrated to:  
  https://springframework.org/DoIt ([https](https://springframework.org/DoIt) result 404).
* [ ] http://springframework.org/other (404) with 3 occurrences migrated to:  
  https://springframework.org/other ([https](https://springframework.org/other) result 404).
* [ ] http://springframework.org/ws (404) with 8 occurrences migrated to:  
  https://springframework.org/ws ([https](https://springframework.org/ws) result 404).
* [ ] http://www.example.com/SoapAction (404) with 2 occurrences migrated to:  
  https://www.example.com/SoapAction ([https](https://www.example.com/SoapAction) result 404).
* [ ] http://www.example.org/schema (404) with 16 occurrences migrated to:  
  https://www.example.org/schema ([https](https://www.example.org/schema) result 404).
* [ ] http://www.springframework.org/actor (404) with 2 occurrences migrated to:  
  https://www.springframework.org/actor ([https](https://www.springframework.org/actor) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd with 6 occurrences migrated to:  
  https://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd ([https](https://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd) result 200).
* [ ] http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd with 2 occurrences migrated to:  
  https://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd ([https](https://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd) result 200).
* [ ] http://docs.oasis-open.org/wss/oasis-wss-wssecurity-secext-1.1.xsd with 1 occurrences migrated to:  
  https://docs.oasis-open.org/wss/oasis-wss-wssecurity-secext-1.1.xsd ([https](https://docs.oasis-open.org/wss/oasis-wss-wssecurity-secext-1.1.xsd) result 200).
* [ ] http://static.springframework.org/spring/docs/2.5.x/reference/beans.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/2.5.x/reference/beans.html ([https](https://static.springframework.org/spring/docs/2.5.x/reference/beans.html) result 200).
* [ ] http://static.springsource.org/spring/docs/3.0.x/spring-framework-reference/html/oxm.html (301) with 3 occurrences migrated to:  
  https://docs.spring.io/spring/docs/3.0.x/spring-framework-reference/html/oxm.html ([https](https://static.springsource.org/spring/docs/3.0.x/spring-framework-reference/html/oxm.html) result 200).
* [ ] http://static.springsource.org/spring/docs/3.0.x/spring-framework-reference/html/validation.html (301) with 2 occurrences migrated to:  
  https://docs.spring.io/spring/docs/3.0.x/spring-framework-reference/html/validation.html ([https](https://static.springsource.org/spring/docs/3.0.x/spring-framework-reference/html/validation.html) result 200).
* [ ] http://example.com with 41 occurrences migrated to:  
  https://example.com ([https](https://example.com) result 200).
* [ ] http://example.org with 4 occurrences migrated to:  
  https://example.org ([https](https://example.org) result 200).
* [ ] http://relaxng.org/ns/structure/1.0 with 1 occurrences migrated to:  
  https://relaxng.org/ns/structure/1.0 ([https](https://relaxng.org/ns/structure/1.0) result 200).
* [ ] http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html with 1 occurrences migrated to:  
  https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html ([https](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html) result 200).
* [ ] http://tools.ietf.org/id/draft-merrick-jms-iri-00.txt with 1 occurrences migrated to:  
  https://tools.ietf.org/id/draft-merrick-jms-iri-00.txt ([https](https://tools.ietf.org/id/draft-merrick-jms-iri-00.txt) result 200).
* [ ] http://unicode.org/faq/utf_bom.html with 1 occurrences migrated to:  
  https://unicode.org/faq/utf_bom.html ([https](https://unicode.org/faq/utf_bom.html) result 200).
* [ ] http://ws.apache.org/wss4j/ with 2 occurrences migrated to:  
  https://ws.apache.org/wss4j/ ([https](https://ws.apache.org/wss4j/) result 200).
* [ ] http://tempuri.org (302) with 3 occurrences migrated to:  
  https://www.bing.com/ ([https](https://tempuri.org) result 200).
* [ ] http://actual.com (301) with 1 occurrences migrated to:  
  https://www.dynamo.com/assets.htm ([https](https://actual.com) result 200).
* [ ] http://ehcache.sourceforge.net (301) with 1 occurrences migrated to:  
  https://www.ehcache.org/ ([https](https://ehcache.sourceforge.net) result 200).
* [ ] http://www.example.com with 4 occurrences migrated to:  
  https://www.example.com ([https](https://www.example.com) result 200).
* [ ] http://www.example.org with 1 occurrences migrated to:  
  https://www.example.org ([https](https://www.example.org) result 200).
* [ ] http://www.ietf.org/rfc/rfc2368.txt with 1 occurrences migrated to:  
  https://www.ietf.org/rfc/rfc2368.txt ([https](https://www.ietf.org/rfc/rfc2368.txt) result 200).
* [ ] http://www.ietf.org/rfc/rfc3066.txt with 1 occurrences migrated to:  
  https://www.ietf.org/rfc/rfc3066.txt ([https](https://www.ietf.org/rfc/rfc3066.txt) result 200).
* [ ] http://www.rfc-editor.org/rfc/bcp/bcp47.txt with 2 occurrences migrated to:  
  https://www.rfc-editor.org/rfc/bcp/bcp47.txt ([https](https://www.rfc-editor.org/rfc/bcp/bcp47.txt) result 200).
* [ ] http://www.soapui.org/ with 1 occurrences migrated to:  
  https://www.soapui.org/ ([https](https://www.soapui.org/) result 200).
* [ ] http://www.springframework.org/dtd/spring-beans.dtd with 2 occurrences migrated to:  
  https://www.springframework.org/dtd/spring-beans.dtd ([https](https://www.springframework.org/dtd/spring-beans.dtd) result 200).
* [ ] http://www.springframework.org/schema/beans/spring-beans-2.0.xsd with 2 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans-2.0.xsd ([https](https://www.springframework.org/schema/beans/spring-beans-2.0.xsd) result 200).
* [ ] http://www.springframework.org/schema/beans/spring-beans-3.0.xsd with 2 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans-3.0.xsd ([https](https://www.springframework.org/schema/beans/spring-beans-3.0.xsd) result 200).
* [ ] http://www.springframework.org/schema/beans/spring-beans.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans.xsd ([https](https://www.springframework.org/schema/beans/spring-beans.xsd) result 200).
* [ ] http://www.springframework.org/schema/context/spring-context-3.0.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/context/spring-context-3.0.xsd ([https](https://www.springframework.org/schema/context/spring-context-3.0.xsd) result 200).
* [ ] http://www.springframework.org/schema/tool/spring-tool-3.0.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/tool/spring-tool-3.0.xsd ([https](https://www.springframework.org/schema/tool/spring-tool-3.0.xsd) result 200).
* [ ] http://www.springframework.org/schema/util/spring-util-2.0.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/util/spring-util-2.0.xsd ([https](https://www.springframework.org/schema/util/spring-util-2.0.xsd) result 200).
* [ ] http://www.springframework.org/schema/web-services/web-services-2.0.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/web-services/web-services-2.0.xsd ([https](https://www.springframework.org/schema/web-services/web-services-2.0.xsd) result 200).
* [ ] http://www.springframework.org/schema/web-services/web-services.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/web-services/web-services.xsd ([https](https://www.springframework.org/schema/web-services/web-services.xsd) result 200).
* [ ] http://www.w3.org/2001/03/xml.xsd with 2 occurrences migrated to:  
  https://www.w3.org/2001/03/xml.xsd ([https](https://www.w3.org/2001/03/xml.xsd) result 200).
* [ ] http://www.w3.org/2001/06/soap-envelope with 1 occurrences migrated to:  
  https://www.w3.org/2001/06/soap-envelope ([https](https://www.w3.org/2001/06/soap-envelope) result 200).
* [ ] http://www.w3.org/2003/05/soap-encoding with 1 occurrences migrated to:  
  https://www.w3.org/2003/05/soap-encoding ([https](https://www.w3.org/2003/05/soap-encoding) result 200).
* [ ] http://www.w3.org/2004/10/xml.xsd with 2 occurrences migrated to:  
  https://www.w3.org/2004/10/xml.xsd ([https](https://www.w3.org/2004/10/xml.xsd) result 200).
* [ ] http://www.w3.org/2005/05/xmlmime with 2 occurrences migrated to:  
  https://www.w3.org/2005/05/xmlmime ([https](https://www.w3.org/2005/05/xmlmime) result 200).
* [ ] http://www.w3.org/2005/08/xml.xsd with 2 occurrences migrated to:  
  https://www.w3.org/2005/08/xml.xsd ([https](https://www.w3.org/2005/08/xml.xsd) result 200).
* [ ] http://www.w3.org/2007/08/xml.xsd with 2 occurrences migrated to:  
  https://www.w3.org/2007/08/xml.xsd ([https](https://www.w3.org/2007/08/xml.xsd) result 200).
* [ ] http://www.w3.org/2009/01/xml.xsd with 7 occurrences migrated to:  
  https://www.w3.org/2009/01/xml.xsd ([https](https://www.w3.org/2009/01/xml.xsd) result 200).
* [ ] http://www.w3.org/Consortium/Legal/IPR-FAQ-20000620.html with 2 occurrences migrated to:  
  https://www.w3.org/Consortium/Legal/IPR-FAQ-20000620.html ([https](https://www.w3.org/Consortium/Legal/IPR-FAQ-20000620.html) result 200).
* [ ] http://www.w3.org/Consortium/Legal/copyright-software-19980720 with 2 occurrences migrated to:  
  https://www.w3.org/Consortium/Legal/copyright-software-19980720 ([https](https://www.w3.org/Consortium/Legal/copyright-software-19980720) result 200).
* [ ] http://www.w3.org/Submission/2004/SUBM-ws-addressing-20040810/ with 1 occurrences migrated to:  
  https://www.w3.org/Submission/2004/SUBM-ws-addressing-20040810/ ([https](https://www.w3.org/Submission/2004/SUBM-ws-addressing-20040810/) result 200).
* [ ] http://www.w3.org/TR/2000/NOTE-SOAP-20000508/ with 3 occurrences migrated to:  
  https://www.w3.org/TR/2000/NOTE-SOAP-20000508/ ([https](https://www.w3.org/TR/2000/NOTE-SOAP-20000508/) result 200).
* [ ] http://www.w3.org/TR/2003/PR-soap12-part1-20030507/ with 1 occurrences migrated to:  
  https://www.w3.org/TR/2003/PR-soap12-part1-20030507/ ([https](https://www.w3.org/TR/2003/PR-soap12-part1-20030507/) result 200).
* [ ] http://www.w3.org/TR/2005/REC-xop10-20050125/ with 3 occurrences migrated to:  
  https://www.w3.org/TR/2005/REC-xop10-20050125/ ([https](https://www.w3.org/TR/2005/REC-xop10-20050125/) result 200).
* [ ] http://www.w3.org/TR/soap12-part0/ with 1 occurrences migrated to:  
  https://www.w3.org/TR/soap12-part0/ ([https](https://www.w3.org/TR/soap12-part0/) result 200).
* [ ] http://www.w3.org/TR/ws-addr-core/ with 5 occurrences migrated to:  
  https://www.w3.org/TR/ws-addr-core/ ([https](https://www.w3.org/TR/ws-addr-core/) result 200).
* [ ] http://www.w3.org/TR/ws-addr-soap/ with 2 occurrences migrated to:  
  https://www.w3.org/TR/ws-addr-soap/ ([https](https://www.w3.org/TR/ws-addr-soap/) result 200).
* [ ] http://www.w3.org/TR/xml-id/ with 3 occurrences migrated to:  
  https://www.w3.org/TR/xml-id/ ([https](https://www.w3.org/TR/xml-id/) result 200).
* [ ] http://www.w3.org/TR/xmlbase/ with 3 occurrences migrated to:  
  https://www.w3.org/TR/xmlbase/ ([https](https://www.w3.org/TR/xmlbase/) result 200).
* [ ] http://www.w3.org/XML/1998/namespace with 13 occurrences migrated to:  
  https://www.w3.org/XML/1998/namespace ([https](https://www.w3.org/XML/1998/namespace) result 200).
* [ ] http://www.w3.org/XML/1998/namespace.html with 3 occurrences migrated to:  
  https://www.w3.org/XML/1998/namespace.html ([https](https://www.w3.org/XML/1998/namespace.html) result 200).
* [ ] http://static.springframework.org/spring/docs/2.5.x/api/org/springframework/remoting/support/SimpleHttpServerFactoryBean.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/2.5.x/api/org/springframework/remoting/support/SimpleHttpServerFactoryBean.html ([https](https://static.springframework.org/spring/docs/2.5.x/api/org/springframework/remoting/support/SimpleHttpServerFactoryBean.html) result 301).
* [ ] http://github.com/SpringSource/spring-ws with 1 occurrences migrated to:  
  https://github.com/SpringSource/spring-ws ([https](https://github.com/SpringSource/spring-ws) result 301).
* [ ] http://jakarta.apache.org/commons/httpclient with 1 occurrences migrated to:  
  https://jakarta.apache.org/commons/httpclient ([https](https://jakarta.apache.org/commons/httpclient) result 301).
* [ ] http://jira.springframework.org/browse/SWS-393 with 1 occurrences migrated to:  
  https://jira.springframework.org/browse/SWS-393 ([https](https://jira.springframework.org/browse/SWS-393) result 301).
* [ ] http://jira.springframework.org/browse/SWS-502 with 1 occurrences migrated to:  
  https://jira.springframework.org/browse/SWS-502 ([https](https://jira.springframework.org/browse/SWS-502) result 301).
* [ ] http://opensource.atlassian.com/projects/spring/browse/SWS-35 with 2 occurrences migrated to:  
  https://opensource.atlassian.com/projects/spring/browse/SWS-35 ([https](https://opensource.atlassian.com/projects/spring/browse/SWS-35) result 301).
* [ ] http://projects.spring.io/spring-ws with 1 occurrences migrated to:  
  https://projects.spring.io/spring-ws ([https](https://projects.spring.io/spring-ws) result 301).
* [ ] http://springframework.org with 39 occurrences migrated to:  
  https://springframework.org ([https](https://springframework.org) result 301).
* [ ] http://ws.apache.org/commons/XmlSchema/ with 2 occurrences migrated to:  
  https://ws.apache.org/commons/XmlSchema/ ([https](https://ws.apache.org/commons/XmlSchema/) result 301).
* [ ] http://www.javaworld.com/javaworld/jw-09-2002/jw-0913-jaas.html with 1 occurrences migrated to:  
  https://www.javaworld.com/javaworld/jw-09-2002/jw-0913-jaas.html ([https](https://www.javaworld.com/javaworld/jw-09-2002/jw-0913-jaas.html) result 301).
* [ ] http://www.springframework.org with 50 occurrences migrated to:  
  https://www.springframework.org ([https](https://www.springframework.org) result 301).
* [ ] http://www.springframework.org/security with 1 occurrences migrated to:  
  https://www.springframework.org/security ([https](https://www.springframework.org/security) result 301).
* [ ] http://www.w3.org/2005/08/addressing with 2 occurrences migrated to:  
  https://www.w3.org/2005/08/addressing ([https](https://www.w3.org/2005/08/addressing) result 301).
* [ ] http://www.w3.org/TR/2006/REC-ws-addr-core-20060509 with 1 occurrences migrated to:  
  https://www.w3.org/TR/2006/REC-ws-addr-core-20060509 ([https](https://www.w3.org/TR/2006/REC-ws-addr-core-20060509) result 301).
* [ ] http://www.w3.org/TR/REC-xml with 3 occurrences migrated to:  
  https://www.w3.org/TR/REC-xml ([https](https://www.w3.org/TR/REC-xml) result 301).
* [ ] http://www.w3.org/TR/xpath with 9 occurrences migrated to:  
  https://www.w3.org/TR/xpath ([https](https://www.w3.org/TR/xpath) result 301).
* [ ] http://www.w3.org/TR/xpath/ with 6 occurrences migrated to:  
  https://www.w3.org/TR/xpath/ ([https](https://www.w3.org/TR/xpath/) result 301).
* [ ] http://xwss.java.net/ with 1 occurrences migrated to:  
  https://xwss.java.net/ ([https](https://xwss.java.net/) result 301).
* [ ] http://java.sun.com/j2se/1.4.2/docs/guide/security/jsse/JSSERefGuide.html with 3 occurrences migrated to:  
  https://java.sun.com/j2se/1.4.2/docs/guide/security/jsse/JSSERefGuide.html ([https](https://java.sun.com/j2se/1.4.2/docs/guide/security/jsse/JSSERefGuide.html) result 302).
* [ ] http://java.sun.com/j2se/1.5.0/docs/tooldocs/windows/keytool.html with 1 occurrences migrated to:  
  https://java.sun.com/j2se/1.5.0/docs/tooldocs/windows/keytool.html ([https](https://java.sun.com/j2se/1.5.0/docs/tooldocs/windows/keytool.html) result 302).
* [ ] http://java.sun.com/javase/6/docs/jre/api/net/httpserver/spec/index.html with 1 occurrences migrated to:  
  https://java.sun.com/javase/6/docs/jre/api/net/httpserver/spec/index.html ([https](https://java.sun.com/javase/6/docs/jre/api/net/httpserver/spec/index.html) result 302).
* [ ] http://java.sun.com/products/jaas/ with 2 occurrences migrated to:  
  https://java.sun.com/products/jaas/ ([https](https://java.sun.com/products/jaas/) result 302).
* [ ] http://java.sun.com/webservices/ with 1 occurrences migrated to:  
  https://java.sun.com/webservices/ ([https](https://java.sun.com/webservices/) result 302).
* [ ] http://java.sun.com/webservices/docs/1.6/tutorial/doc/XWS-SecurityIntro4.html with 9 occurrences migrated to:  
  https://java.sun.com/webservices/docs/1.6/tutorial/doc/XWS-SecurityIntro4.html ([https](https://java.sun.com/webservices/docs/1.6/tutorial/doc/XWS-SecurityIntro4.html) result 302).
* [ ] http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd with 1 occurrences migrated to:  
  https://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd ([https](https://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd) result 302).
* [ ] http://java.sun.com/xml/ns/xwss/config with 7 occurrences migrated to:  
  https://java.sun.com/xml/ns/xwss/config ([https](https://java.sun.com/xml/ns/xwss/config) result 302).
* [ ] http://www.iana.org/assignments/lang-tag-apps.htm with 1 occurrences migrated to:  
  https://www.iana.org/assignments/lang-tag-apps.htm ([https](https://www.iana.org/assignments/lang-tag-apps.htm) result 302).
* [ ] http://www.iana.org/assignments/language-subtag-registry with 2 occurrences migrated to:  
  https://www.iana.org/assignments/language-subtag-registry ([https](https://www.iana.org/assignments/language-subtag-registry) result 302).
* [ ] http://www.w3.org/2001/04/xmlenc with 8 occurrences migrated to:  
  https://www.w3.org/2001/04/xmlenc ([https](https://www.w3.org/2001/04/xmlenc) result 302).
* [ ] http://www.w3.org/Consortium/Legal/ with 2 occurrences migrated to:  
  https://www.w3.org/Consortium/Legal/ ([https](https://www.w3.org/Consortium/Legal/) result 302).
* [ ] http://www.w3.org/2000/09/xmldsig with 3 occurrences migrated to:  
  https://www.w3.org/2000/09/xmldsig ([https](https://www.w3.org/2000/09/xmldsig) result 303).

# Ignored
These URLs were intentionally ignored.

* http://codex.corp.obade.com/codex/schemas with 2 occurrences
* http://example.com/fabrikam with 2 occurrences
* http://example.com/fabrikam/mail/Add with 1 occurrences
* http://example.com/fabrikam/mail/Delete with 5 occurrences
* http://fabrikam123.com/payloads with 1 occurrences
* http://java.sun.com/xml/ns/j2ee with 2 occurrences
* http://localhost with 10 occurrences
* http://localhost:8080/ with 9 occurrences
* http://localhost:8080/AnotherWebService with 1 occurrences
* http://localhost:8080/WebService with 2 occurrences
* http://localhost:8080/airline/services&quot;/&gt with 1 occurrences
* http://localhost:8080/context/service with 2 occurrences
* http://localhost:8080/context/services/myService with 2 occurrences
* http://localhost:8080/echo/services with 1 occurrences
* http://localhost:8080/echo/services/imported.xsd with 2 occurrences
* http://localhost:8080/holidayService/ with 2 occurrences
* http://localhost:8080/holidayService/holiday.wsdl with 2 occurrences
* http://localhost:8080/ordersService/ with 2 occurrences
* http://localhost:8080/service with 1 occurrences
* http://localhost:8080/services with 3 occurrences
* http://localhost:8080/spring-ws/echo.wsdl with 1 occurrences
* http://localhost:8080/spring-ws/orders.wsdl with 1 occurrences
* http://mycompany.com/hr/schemas with 25 occurrences
* http://mycompany.com/hr/schemas/holiday with 7 occurrences
* http://schemas.xmlsoap.org/soap/envelope/ with 51 occurrences
* http://schemas.xmlsoap.org/ws/2004/08/addressing with 1 occurrences
* http://springframework.org/spring-ws with 79 occurrences
* http://springframework.org/spring-ws/ with 4 occurrences
* http://springframework.org/spring-ws/1 with 2 occurrences
* http://springframework.org/spring-ws/2 with 2 occurrences
* http://springframework.org/spring-ws/Action with 7 occurrences
* http://springframework.org/spring-ws/AnotherAction with 1 occurrences
* http://springframework.org/spring-ws/Fault with 1 occurrences
* http://springframework.org/spring-ws/NoEndpoint with 1 occurrences
* http://springframework.org/spring-ws/NoResponse with 1 occurrences
* http://springframework.org/spring-ws/Response with 1 occurrences
* http://springframework.org/spring-ws/SoapAction with 5 occurrences
* http://springframework.org/spring-ws/SoapAction1 with 2 occurrences
* http://springframework.org/spring-ws/SoapAction2 with 2 occurrences
* http://springframework.org/spring-ws/SoapAction3 with 2 occurrences
* http://springframework.org/spring-ws/SoapAction4 with 2 occurrences
* http://springframework.org/spring-ws/test with 2 occurrences
* http://test with 3 occurrences
* http://www.springframework.org/schema/beans with 13 occurrences
* http://www.springframework.org/schema/context with 2 occurrences
* http://www.springframework.org/schema/tool with 4 occurrences
* http://www.springframework.org/schema/util with 2 occurrences
* http://www.springframework.org/schema/web-services with 8 occurrences
* http://www.springframework.org/spring-ws with 6 occurrences
* http://www.springframework.org/spring-ws/custom with 1 occurrences
* http://www.springframework.org/spring-ws/destinationProvider with 1 occurrences
* http://www.springframework.org/spring-ws/import/definitions with 3 occurrences
* http://www.springframework.org/spring-ws/imported/schema with 10 occurrences
* http://www.springframework.org/spring-ws/importing/schema with 8 occurrences
* http://www.springframework.org/spring-ws/include/definitions with 3 occurrences
* http://www.springframework.org/spring-ws/include/schema with 12 occurrences
* http://www.springframework.org/spring-ws/role with 1 occurrences
* http://www.springframework.org/spring-ws/samples/airline/BookFlight=bookFlightEndpoint with 2 occurrences
* http://www.springframework.org/spring-ws/samples/airline/GetFlights=getFlightsEndpoint with 2 occurrences
* http://www.springframework.org/spring-ws/samples/airline/schemas with 2 occurrences
* http://www.springframework.org/spring-ws/samples/echo with 11 occurrences
* http://www.springframework.org/spring-ws/samples/echo/imported with 4 occurrences
* http://www.springframework.org/spring-ws/schema with 6 occurrences
* http://www.springframework.org/spring-ws/single/definitions with 10 occurrences
* http://www.springframework.org/spring-ws/single/schema with 19 occurrences
* http://www.springframework.org/spring-ws/test/multipleSchemas1 with 1 occurrences
* http://www.springframework.org/spring-ws/test/multipleSchemas2 with 1 occurrences
* http://www.springframework.org/spring-ws/test/transformation with 1 occurrences
* http://www.springframework.org/spring-ws/test/validation with 14 occurrences
* http://www.springframework.org/spring-ws/wsdl with 8 occurrences
* http://www.springframework.org/spring-ws/wsdl/definitions with 4 occurrences
* http://www.springframework.org/spring-ws/wsdl/schemas with 3 occurrences
* http://www.springframework.org/spring-ws/wsdl/service with 1 occurrences
* http://www.springframework.org/spring-ws/xmlNamespace with 3 occurrences
* http://www.w3.org/1999/XSL/Transform with 1 occurrences
* http://www.w3.org/1999/xhtml with 1 occurrences
* http://www.w3.org/2001/XMLSchema with 92 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 9 occurrences
* http://www.w3.org/2003/05/soap-envelope with 31 occurrences