### PR TITLE
Remove commons-io dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,16 +141,17 @@
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
+
+			<dependency>
+				<groupId>commons-io</groupId>
+				<artifactId>commons-io</artifactId>
+				<version>${commons-io.version}</version>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 
 	<dependencies>
 
-		<dependency>
-			<groupId>commons-io</groupId>
-			<artifactId>commons-io</artifactId>
-			<version>${commons-io.version}</version>
-		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-core</artifactId>

--- a/spring-ws-core/pom.xml
+++ b/spring-ws-core/pom.xml
@@ -49,6 +49,12 @@
 			<scope>test</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<scope>test</scope>
+		</dependency>
+
 		<!--// XML-->
 		<dependency>
 			<groupId>org.jdom</groupId>


### PR DESCRIPTION
commons-io was declared as a dependency for all modules in the root POM, but was only actually used for testing in spring-ws-core.

Only including it as test-dependency in that module to avoid unnecessarily having it as transitive dependency for users of Spring WS.