### PR TITLE
Add support for configuring WSS4J's USE_SINGLE_CERTIFICATE option

### DIFF
--- a/spring-ws-security/src/main/java/org/springframework/ws/soap/security/wss4j2/Wss4jSecurityInterceptor.java
+++ b/spring-ws-security/src/main/java/org/springframework/ws/soap/security/wss4j2/Wss4jSecurityInterceptor.java
@@ -497,6 +497,14 @@ public class Wss4jSecurityInterceptor extends AbstractWsSecurityInterceptor impl
 	}
 
 	/**
+	 * Enables the {@code useSingleCertificate} attribute on WS-Security headers on outgoing messages. Default is
+	 * {@code true}.
+	 */
+	public void set(boolean useSingleCertificate) {
+		handler.setOption(WSHandlerConstants.USE_SINGLE_CERTIFICATE, useSingleCertificate);
+	}
+
+	/**
 	 * Set the WS-I Basic Security Profile compliance mode. Default is {@code true}.
 	 */
 	public void setBspCompliant(boolean bspCompliant) {

--- a/spring-ws-security/src/main/java/org/springframework/ws/soap/security/wss4j2/Wss4jSecurityInterceptor.java
+++ b/spring-ws-security/src/main/java/org/springframework/ws/soap/security/wss4j2/Wss4jSecurityInterceptor.java
@@ -500,7 +500,7 @@ public class Wss4jSecurityInterceptor extends AbstractWsSecurityInterceptor impl
 	 * Enables the {@code useSingleCertificate} attribute on WS-Security headers on outgoing messages. Default is
 	 * {@code true}.
 	 */
-	public void set(boolean useSingleCertificate) {
+	public void setUseSingleCertificate(boolean useSingleCertificate) {
 		handler.setOption(WSHandlerConstants.USE_SINGLE_CERTIFICATE, useSingleCertificate);
 	}
 


### PR DESCRIPTION
Enable the manipulation of the parameter USE_SINGLE_CERTIFICATE, thus enabling the choice of using valueType X509PKIPathv1 in stead of X509v3.