### PR TITLE
Clearing context so later tests can pass

### DIFF
--- a/spring-ws-security/src/test/java/org/springframework/ws/soap/security/wss4j2/callback/SpringSecurityPasswordValidationCallbackHandlerTest.java
+++ b/spring-ws-security/src/test/java/org/springframework/ws/soap/security/wss4j2/callback/SpringSecurityPasswordValidationCallbackHandlerTest.java
@@ -112,5 +112,6 @@ public class SpringSecurityPasswordValidationCallbackHandlerTest {
 		Assert.assertEquals("Unexpected authority", grantedAuthority, authorities.iterator().next());
 
 		verify(userDetailsService);
+		SecurityContextHolder.clearContext();
 	}
 }


### PR DESCRIPTION
Currently, tests in `SpringDigestPasswordValidationCallbackHandlerTest` fail when they run right after `SpringSecurityPasswordValidationCallbackHandlerTest.testHandleUsernameTokenPrincipal`. The proposed pull request inserts a call to `SecurityContextHolder.clearContext()` at the end of `testHandleUsernameTokenPrincipal` (similar to how the call is in the `tearDown()` method in `SpringDigestPasswordValidationCallbackHandlerTest`), so the later tests can pass.

@pivotal-issuemaster This is an Obvious Fix

Please let me know if you want to discuss the changes more.