### PR TITLE
Fixed skip validation in handleResponse

### DIFF
--- a/spring-ws-security/src/main/java/org/springframework/ws/soap/security/AbstractWsSecurityInterceptor.java
+++ b/spring-ws-security/src/main/java/org/springframework/ws/soap/security/AbstractWsSecurityInterceptor.java
@@ -236,7 +236,7 @@ public abstract class AbstractWsSecurityInterceptor implements SoapEndpointInter
 		if (validateResponse) {
 			Assert.isTrue(messageContext.hasResponse(), "MessageContext contains no response");
 			Assert.isInstanceOf(SoapMessage.class, messageContext.getResponse());
-			if(skipValidationIfNoHeaderPresent && !isSecurityHeaderPresent((SoapMessage) messageContext.getRequest())){
+			if(skipValidationIfNoHeaderPresent && !isSecurityHeaderPresent((SoapMessage) messageContext.getResponse())){
 				return true;
 			}
 			try {


### PR DESCRIPTION
Changed skip validation check in
AbstractWsSecurityInterceptor#handleResponse to look for optional
security header in response, instead of request