### PR TITLE
Committing addition of wsjar protocol to fix issue with WebSphere

### DIFF
--- a/spring-xml/src/main/java/org/springframework/xml/validation/SchemaFactoryUtils.java
+++ b/spring-xml/src/main/java/org/springframework/xml/validation/SchemaFactoryUtils.java
@@ -49,7 +49,7 @@ public class SchemaFactoryUtils {
 		}
 
 		try {
-			schemaFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "file,jar:file");
+			schemaFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "file,jar:file,wsjar");
 		} catch (SAXNotRecognizedException | SAXNotSupportedException e) {
 			if (log.isWarnEnabled()) {
 				log.warn(XMLConstants.ACCESS_EXTERNAL_SCHEMA + " property not supported by " + schemaFactory.getClass().getCanonicalName());


### PR DESCRIPTION
During upgrade of Spring Integration from 4.3.16.RELEASE to 5.3.2.RELEASE, our application failed to deploy to WebSphere due to the WebSphere proprietary wsjar protocol not being present in XMLConstants.ACCESS_EXTERNAL_SCHEMA properties. This appears to be a new change in spring-xml as of 3.0.5.RELEASE.