### PR TITLE
Fix flaky test in SpringSecurityPasswordValidationCallbackHandlerTest

### DIFF
--- a/spring-ws-security/src/test/java/org/springframework/ws/soap/security/wss4j2/callback/SpringSecurityPasswordValidationCallbackHandlerTest.java
+++ b/spring-ws-security/src/test/java/org/springframework/ws/soap/security/wss4j2/callback/SpringSecurityPasswordValidationCallbackHandlerTest.java
@@ -79,7 +79,7 @@ public class SpringSecurityPasswordValidationCallbackHandlerTest {
 	 * to clean {@code SecurityContextHolder} after this class
 	 */
 	@AfterAll
-	public static void beforeClassTearDown() { 
+	public static void afterClassTearDown() { 
 		SecurityContextHolder.clearContext();
 	}
 

--- a/spring-ws-security/src/test/java/org/springframework/ws/soap/security/wss4j2/callback/SpringSecurityPasswordValidationCallbackHandlerTest.java
+++ b/spring-ws-security/src/test/java/org/springframework/ws/soap/security/wss4j2/callback/SpringSecurityPasswordValidationCallbackHandlerTest.java
@@ -24,6 +24,8 @@ import java.util.Collections;
 
 import org.apache.wss4j.common.ext.WSPasswordCallback;
 import org.apache.wss4j.common.principal.WSUsernameTokenPrincipalImpl;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.security.core.Authentication;
@@ -48,6 +50,15 @@ public class SpringSecurityPasswordValidationCallbackHandlerTest {
 	private WSPasswordCallback passwordCallback;
 
 	private UserDetails user;
+	
+	/**
+	 * add a tearDown method at the beginning, 
+	 * in case {@code SecurityContextHolder} not cleaned before this class
+	 */
+	@BeforeAll
+	public static void beforeClassTearDown() { 
+		SecurityContextHolder.clearContext();
+	}
 
 	@BeforeEach
 	public void setUp() {
@@ -61,6 +72,15 @@ public class SpringSecurityPasswordValidationCallbackHandlerTest {
 		callback = new UsernameTokenPrincipalCallback(principal);
 
 		passwordCallback = new WSPasswordCallback("Ernie", null, "type", WSPasswordCallback.USERNAME_TOKEN);
+	}
+	
+	/**
+	 * add a tearDown method at the end, 
+	 * to clean {@code SecurityContextHolder} after this class
+	 */
+	@AfterAll
+	public static void beforeClassTearDown() { 
+		SecurityContextHolder.clearContext();
 	}
 
 	@Test

--- a/spring-ws-security/src/test/java/org/springframework/ws/soap/security/wss4j2/callback/SpringSecurityPasswordValidationCallbackHandlerTest.java
+++ b/spring-ws-security/src/test/java/org/springframework/ws/soap/security/wss4j2/callback/SpringSecurityPasswordValidationCallbackHandlerTest.java
@@ -50,19 +50,12 @@ public class SpringSecurityPasswordValidationCallbackHandlerTest {
 	private WSPasswordCallback passwordCallback;
 
 	private UserDetails user;
-	
-	/**
-	 * add a tearDown method at the beginning, 
-	 * in case {@code SecurityContextHolder} not cleaned before this class
-	 */
-	@BeforeAll
-	public static void beforeClassTearDown() { 
-		SecurityContextHolder.clearContext();
-	}
 
 	@BeforeEach
 	public void setUp() {
-
+		// add clearContext() at the beginning of each method in case {@code SecurityContextHolder} isn't clean
+		SecurityContextHolder.clearContext();
+		
 		callbackHandler = new SpringSecurityPasswordValidationCallbackHandler();
 
 		grantedAuthority = new SimpleGrantedAuthority("ROLE_1");
@@ -72,15 +65,6 @@ public class SpringSecurityPasswordValidationCallbackHandlerTest {
 		callback = new UsernameTokenPrincipalCallback(principal);
 
 		passwordCallback = new WSPasswordCallback("Ernie", null, "type", WSPasswordCallback.USERNAME_TOKEN);
-	}
-	
-	/**
-	 * add a tearDown method at the end, 
-	 * to clean {@code SecurityContextHolder} after this class
-	 */
-	@AfterAll
-	public static void afterClassTearDown() { 
-		SecurityContextHolder.clearContext();
 	}
 
 	@Test

--- a/spring-ws-security/src/test/java/org/springframework/ws/soap/security/wss4j2/callback/SpringSecurityPasswordValidationCallbackHandlerTest.java
+++ b/spring-ws-security/src/test/java/org/springframework/ws/soap/security/wss4j2/callback/SpringSecurityPasswordValidationCallbackHandlerTest.java
@@ -24,8 +24,6 @@ import java.util.Collections;
 
 import org.apache.wss4j.common.ext.WSPasswordCallback;
 import org.apache.wss4j.common.principal.WSUsernameTokenPrincipalImpl;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.security.core.Authentication;

--- a/spring-ws-security/src/test/java/org/springframework/ws/soap/security/xwss/callback/SpringDigestPasswordValidationCallbackHandlerTest.java
+++ b/spring-ws-security/src/test/java/org/springframework/ws/soap/security/xwss/callback/SpringDigestPasswordValidationCallbackHandlerTest.java
@@ -22,7 +22,6 @@ import static org.easymock.EasyMock.*;
 import java.util.Collections;
 
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.security.authentication.DisabledException;

--- a/spring-ws-security/src/test/java/org/springframework/ws/soap/security/xwss/callback/SpringDigestPasswordValidationCallbackHandlerTest.java
+++ b/spring-ws-security/src/test/java/org/springframework/ws/soap/security/xwss/callback/SpringDigestPasswordValidationCallbackHandlerTest.java
@@ -47,18 +47,11 @@ public class SpringDigestPasswordValidationCallbackHandlerTest {
 	private String password;
 
 	private PasswordValidationCallback callback;
-
-	/**
-	 * add a tearDown method at the beginning, 
-	 * in case {@code SecurityContextHolder} not cleaned before this class
-	 */
-	@BeforeAll
-	public static void beforeClassTearDown() { 
-		SecurityContextHolder.clearContext();
-	}
 	
 	@BeforeEach
 	public void setUp() {
+		// add clearContext() at the beginning of each method in case {@code SecurityContextHolder} isn't clean
+		SecurityContextHolder.clearContext();
 
 		callbackHandler = new SpringDigestPasswordValidationCallbackHandler();
 		userDetailsService = createMock(UserDetailsService.class);

--- a/spring-ws-security/src/test/java/org/springframework/ws/soap/security/xwss/callback/SpringDigestPasswordValidationCallbackHandlerTest.java
+++ b/spring-ws-security/src/test/java/org/springframework/ws/soap/security/xwss/callback/SpringDigestPasswordValidationCallbackHandlerTest.java
@@ -21,6 +21,7 @@ import static org.easymock.EasyMock.*;
 
 import java.util.Collections;
 
+import org.junit.BeforeClass;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -47,6 +48,15 @@ public class SpringDigestPasswordValidationCallbackHandlerTest {
 
 	private PasswordValidationCallback callback;
 
+	/**
+	 * add a tearDown method at the beginning, 
+	 * in case {@code SecurityContextHolder} not cleaned before this class
+	 */
+	@BeforeClass
+	public static void beforeClassTearDown() { 
+		SecurityContextHolder.clearContext();
+	}
+	
 	@BeforeEach
 	public void setUp() {
 

--- a/spring-ws-security/src/test/java/org/springframework/ws/soap/security/xwss/callback/SpringDigestPasswordValidationCallbackHandlerTest.java
+++ b/spring-ws-security/src/test/java/org/springframework/ws/soap/security/xwss/callback/SpringDigestPasswordValidationCallbackHandlerTest.java
@@ -21,8 +21,8 @@ import static org.easymock.EasyMock.*;
 
 import java.util.Collections;
 
-import org.junit.BeforeClass;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.security.authentication.DisabledException;
@@ -52,7 +52,7 @@ public class SpringDigestPasswordValidationCallbackHandlerTest {
 	 * add a tearDown method at the beginning, 
 	 * in case {@code SecurityContextHolder} not cleaned before this class
 	 */
-	@BeforeClass
+	@BeforeAll
 	public static void beforeClassTearDown() { 
 		SecurityContextHolder.clearContext();
 	}


### PR DESCRIPTION
Fixed flaky test that caused by `org.springframework.security.core.context.SecurityContextHolder` in class `org.springframework.ws.soap.security.xwss.callback.SpringDigestPasswordValidationCallbackHandlerTest.java` and `org.springframework.ws.soap.security.wss4j2.callback.SpringSecurityPasswordValidationCallbackHandlerTest.java`.

Existing tests are flaky because the `SecurityContextHolder` is not tear down at the beginning of the test classes.

The flaky tests are found by running _https://github.com/idflakies/iDFlakies_