### PR TITLE
Fix Nondeterministic Ordering in Tests

### DIFF
--- a/spring-ws-core/src/test/java/org/springframework/ws/wsdl/wsdl11/DefaultWsdl11DefinitionTest.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/wsdl/wsdl11/DefaultWsdl11DefinitionTest.java
@@ -33,6 +33,8 @@ import org.springframework.xml.transform.TransformerFactoryUtils;
 import org.springframework.xml.xsd.SimpleXsdSchema;
 import org.springframework.xml.xsd.commons.CommonsXsdSchemaCollection;
 import org.w3c.dom.Document;
+import org.xmlunit.diff.DefaultNodeMatcher;
+import org.xmlunit.diff.ElementSelectors;
 
 public class DefaultWsdl11DefinitionTest {
 

--- a/spring-ws-core/src/test/java/org/springframework/ws/wsdl/wsdl11/DefaultWsdl11DefinitionTest.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/wsdl/wsdl11/DefaultWsdl11DefinitionTest.java
@@ -73,7 +73,11 @@ public class DefaultWsdl11DefinitionTest {
 		Document result = (Document) domResult.getNode();
 		Document expected = documentBuilder.parse(getClass().getResourceAsStream("single-inline.wsdl"));
 
-		assertThat(result).and(expected).ignoreWhitespace().areIdentical();
+		assertThat(result).and(expected)
+				.ignoreWhitespace()
+				.normalizeWhitespace()
+				.withNodeMatcher(new DefaultNodeMatcher(ElementSelectors.byNameAndAllAttributes))
+				.areSimilar();
 	}
 
 	@Test
@@ -96,7 +100,11 @@ public class DefaultWsdl11DefinitionTest {
 		Document result = (Document) domResult.getNode();
 		Document expected = documentBuilder.parse(getClass().getResourceAsStream("include-inline.wsdl"));
 
-		assertThat(result).and(expected).ignoreWhitespace().areIdentical();
+		assertThat(result).and(expected)
+				.ignoreWhitespace()
+				.normalizeWhitespace()
+				.withNodeMatcher(new DefaultNodeMatcher(ElementSelectors.byNameAndAllAttributes))
+				.areSimilar();
 	}
 
 	@Test
@@ -119,7 +127,11 @@ public class DefaultWsdl11DefinitionTest {
 		Document result = (Document) domResult.getNode();
 		Document expected = documentBuilder.parse(getClass().getResourceAsStream("import-inline.wsdl"));
 
-		assertThat(result).and(expected).ignoreWhitespace().areIdentical();
+		assertThat(result).and(expected)
+				.ignoreWhitespace()
+				.normalizeWhitespace()
+				.withNodeMatcher(new DefaultNodeMatcher(ElementSelectors.byNameAndAllAttributes))
+				.areSimilar();
 	}
 
 	@Test
@@ -144,6 +156,10 @@ public class DefaultWsdl11DefinitionTest {
 		Document result = (Document) domResult.getNode();
 		Document expected = documentBuilder.parse(getClass().getResourceAsStream("soap-11-12.wsdl"));
 
-		assertThat(result).and(expected).ignoreWhitespace().areIdentical();
+		assertThat(result).and(expected)
+				.ignoreWhitespace()
+				.normalizeWhitespace()
+				.withNodeMatcher(new DefaultNodeMatcher(ElementSelectors.byNameAndAllAttributes))
+				.areSimilar();
 	}
 }

--- a/spring-ws-core/src/test/java/org/springframework/ws/wsdl/wsdl11/Wsdl4jDefinitionTest.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/wsdl/wsdl11/Wsdl4jDefinitionTest.java
@@ -36,6 +36,8 @@ import org.springframework.xml.transform.TransformerFactoryUtils;
 import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
 import org.xmlunit.assertj.XmlAssert;
+import org.xmlunit.diff.DefaultNodeMatcher;
+import org.xmlunit.diff.ElementSelectors;
 
 public class Wsdl4jDefinitionTest {
 

--- a/spring-ws-core/src/test/java/org/springframework/ws/wsdl/wsdl11/Wsdl4jDefinitionTest.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/wsdl/wsdl11/Wsdl4jDefinitionTest.java
@@ -74,6 +74,11 @@ public class Wsdl4jDefinitionTest {
 		DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
 		Document expected = documentBuilder.parse(getClass().getResourceAsStream("complete.wsdl"));
 
-		XmlAssert.assertThat(result.getNode()).and(expected).ignoreWhitespace().areIdentical();
+		XmlAssert.assertThat(result.getNode())
+				.and(expected)
+				.ignoreWhitespace()
+				.normalizeWhitespace()
+				.withNodeMatcher(new DefaultNodeMatcher(ElementSelectors.byNameAndAllAttributes))
+				.areSimilar();
 	}
 }


### PR DESCRIPTION
The following tests:
`org.springframework.ws.wsdl.wsdl11.DefaultWsdl11DefinitionTest#testSoap11And12 org.springframework.ws.wsdl.wsdl11.DefaultWsdl11DefinitionTest#testImport org.springframework.ws.wsdl.wsdl11.DefaultWsdl11DefinitionTest#testInclude org.springframework.ws.wsdl.wsdl11.DefaultWsdl11DefinitionTest#testSingle org.springframework.ws.wsdl.wsdl11.Wsdl4jDefinitionTest#testGetSource`

are flaky tests. `.areIdentical()` not only compares the elements in XML, but also checks its order making the tests flaky.

To fix this, instead of using `.areIdentical` or `isIdentical`, we used `.areSimilar` or `isSimilar` since the order of the generated XML can be different every time.

Build and unit tests pass:
<img width="1251" alt="Screen Shot 2020-11-14 at 4 53 16 PM" src="https://user-images.githubusercontent.com/26520509/99158650-a2052f80-269a-11eb-8840-a68b39ba2208.png">
