### PR TITLE
Reset constructorCount in EndpointMappingTest

### DIFF
--- a/spring-ws-core/src/test/java/org/springframework/ws/server/endpoint/mapping/EndpointMappingTest.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/server/endpoint/mapping/EndpointMappingTest.java
@@ -189,7 +189,9 @@ public class EndpointMappingTest {
 
 		assertThat(result).isNotNull();
 		assertThat(MyEndpoint.constructorCount).isEqualTo(2);
+		MyEndpoint.reset();
 	}
+
 
 	private static class MyEndpoint {
 
@@ -197,6 +199,10 @@ public class EndpointMappingTest {
 
 		private MyEndpoint() {
 			constructorCount++;
+		}
+
+		private static void reset() {
+			constructorCount = 0;
 		}
 	}
 


### PR DESCRIPTION
The test `org.springframework.ws.server.endpoint.mapping.EndpointMappingTest.endpointPrototype` is not idempotent and fails if run twice in the same JVM, because it pollutes state shared among tests. It may be good to clean this state pollution so that some other tests do not fail in the future due to the shared state polluted by this test.

### Details
Running `EndpointMappingTest.endpointPrototype` twice would result in the second run failing due to the following assertion error:
```
assertThat(MyEndpoint.constructorCount).isEqualTo(2);
```
The root cause is that each time `EndpointMappingTest.endpointPrototype`, the static `MyEndpoint.constructorCount` is incremented. The suggested fix is to reset the count when the test exits.

With the proposed fix, the test does not pollute the shared state (and passes when run twice in the same JVM).