### PR TITLE
OkHttp MessageSender integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
         <ehcache.version>2.10.9.2</ehcache.version>
         <greenmail.version>2.0.0-alpha-2</greenmail.version>
         <httpclient.version>4.5.3</httpclient.version>
-        <okhttp.version>4.9.1</okhttp.version>
+        <okhttp.version>4.10.0</okhttp.version>
         <jakarta-annotation.version>2.1.1</jakarta-annotation.version>
         <jakarta-jms.version>3.1.0</jakarta-jms.version>
         <jakarta-mail-api.version>2.1.0</jakarta-mail-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,7 @@
         <ehcache.version>2.10.9.2</ehcache.version>
         <greenmail.version>2.0.0-alpha-2</greenmail.version>
         <httpclient.version>4.5.3</httpclient.version>
+        <okhttp.version>4.9.1</okhttp.version>
         <jakarta-annotation.version>2.1.1</jakarta-annotation.version>
         <jakarta-jms.version>3.1.0</jakarta-jms.version>
         <jakarta-mail-api.version>2.1.0</jakarta-mail-api.version>

--- a/spring-ws-core/pom.xml
+++ b/spring-ws-core/pom.xml
@@ -154,6 +154,12 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>${okhttp.version}</version>
+            <optional>true</optional>
+        </dependency>
 
         <dependency>
             <groupId>org.eclipse.jetty</groupId>

--- a/spring-ws-core/src/main/java/org/springframework/ws/transport/http/OkHttpConnection.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/transport/http/OkHttpConnection.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2005-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.ws.transport.http;
 
 import java.io.ByteArrayOutputStream;
@@ -15,7 +31,14 @@ import okhttp3.Response;
 import okhttp3.ResponseBody;
 import org.springframework.util.Assert;
 import org.springframework.ws.WebServiceMessage;
+import org.springframework.ws.transport.WebServiceConnection;
 
+/**
+ * Implementation of {@link WebServiceConnection} that is based on OkHttp.
+ *
+ * @author Mathias Geat
+ * @since 3.1.0
+ */
 public class OkHttpConnection extends AbstractHttpSenderConnection {
 
 	private final OkHttpClient okHttpClient;

--- a/spring-ws-core/src/main/java/org/springframework/ws/transport/http/OkHttpConnection.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/transport/http/OkHttpConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2021 the original author or authors.
+ * Copyright 2005-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ import org.springframework.ws.transport.WebServiceConnection;
  * Implementation of {@link WebServiceConnection} that is based on OkHttp.
  *
  * @author Mathias Geat
- * @since 3.1.0
+ * @since 4.1.0
  */
 public class OkHttpConnection extends AbstractHttpSenderConnection {
 

--- a/spring-ws-core/src/main/java/org/springframework/ws/transport/http/OkHttpConnection.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/transport/http/OkHttpConnection.java
@@ -1,0 +1,123 @@
+package org.springframework.ws.transport.http;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.util.Iterator;
+
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import org.springframework.util.Assert;
+import org.springframework.ws.WebServiceMessage;
+
+public class OkHttpConnection extends AbstractHttpSenderConnection {
+
+	private final OkHttpClient okHttpClient;
+	private final URI uri;
+
+	private final MediaType requestMediaType;
+	private final Request.Builder requestBuilder;
+	private ByteArrayOutputStream requestBuffer;
+
+	private Response response;
+	private InputStream responseBuffer;
+
+	public OkHttpConnection(OkHttpClient okHttpClient, URI uri, MediaType requestMediaType) {
+		Assert.notNull(okHttpClient, "okHttpClient must not be null");
+		Assert.notNull(uri, "uri must not be null");
+		Assert.notNull(requestMediaType, "requestMediaType must not be null");
+
+		this.okHttpClient = okHttpClient;
+		this.uri = uri;
+		this.requestMediaType = requestMediaType;
+		this.requestBuilder = new Request.Builder();
+	}
+
+	@Override
+	public URI getUri() {
+		return uri;
+	}
+
+	@Override
+	protected void onSendBeforeWrite(WebServiceMessage message) {
+		requestBuffer = new ByteArrayOutputStream();
+	}
+
+	@Override
+	public void addRequestHeader(String name, String value) {
+		requestBuilder.header(name, value);
+	}
+
+	@Override
+	protected OutputStream getRequestOutputStream() {
+		return requestBuffer;
+	}
+
+	@Override
+	protected void onSendAfterWrite(WebServiceMessage message) throws IOException {
+		requestBuilder
+				.url(uri.toURL())
+				.post(RequestBody.create(requestBuffer.toByteArray(), requestMediaType));
+
+		requestBuffer = null;
+
+		response = okHttpClient.newCall(requestBuilder.build()).execute();
+
+		ResponseBody responseBody = response.body();
+		if (responseBody != null) {
+			this.responseBuffer = responseBody.byteStream();
+		}
+	}
+
+	@Override
+	protected int getResponseCode() {
+		return response.code();
+	}
+
+	@Override
+	protected String getResponseMessage() {
+		return response.message();
+	}
+
+	@Override
+	protected long getResponseContentLength() {
+		ResponseBody responseBody = response.body();
+		if (responseBody != null) {
+			return responseBody.contentLength();
+		}
+
+		return 0;
+	}
+
+	@Override
+	protected InputStream getRawResponseInputStream() {
+		if (responseBuffer == null) {
+			throw new IllegalStateException("Response has no response body, cannot create input stream");
+		}
+
+		return responseBuffer;
+	}
+
+	@Override
+	public Iterator<String> getResponseHeaderNames() {
+		return response.headers().names().iterator();
+	}
+
+	@Override
+	public Iterator<String> getResponseHeaders(String name) {
+		return response.headers(name).iterator();
+	}
+
+	@Override
+	public void onClose() throws IOException {
+		if (responseBuffer != null) {
+			responseBuffer.close();
+		}
+	}
+}

--- a/spring-ws-core/src/main/java/org/springframework/ws/transport/http/OkHttpConnection.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/transport/http/OkHttpConnection.java
@@ -23,7 +23,6 @@ import java.io.OutputStream;
 import java.net.URI;
 import java.util.Iterator;
 
-import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
@@ -42,23 +41,20 @@ import org.springframework.ws.transport.WebServiceConnection;
 public class OkHttpConnection extends AbstractHttpSenderConnection {
 
 	private final OkHttpClient okHttpClient;
-	private final URI uri;
 
-	private final MediaType requestMediaType;
+	private final URI uri;
 	private final Request.Builder requestBuilder;
 	private ByteArrayOutputStream requestBuffer;
 
 	private Response response;
 	private InputStream responseBuffer;
 
-	public OkHttpConnection(OkHttpClient okHttpClient, URI uri, MediaType requestMediaType) {
+	public OkHttpConnection(OkHttpClient okHttpClient, URI uri) {
 		Assert.notNull(okHttpClient, "okHttpClient must not be null");
 		Assert.notNull(uri, "uri must not be null");
-		Assert.notNull(requestMediaType, "requestMediaType must not be null");
 
 		this.okHttpClient = okHttpClient;
 		this.uri = uri;
-		this.requestMediaType = requestMediaType;
 		this.requestBuilder = new Request.Builder();
 	}
 
@@ -86,7 +82,7 @@ public class OkHttpConnection extends AbstractHttpSenderConnection {
 	protected void onSendAfterWrite(WebServiceMessage message) throws IOException {
 		requestBuilder
 				.url(uri.toURL())
-				.post(RequestBody.create(requestBuffer.toByteArray(), requestMediaType));
+				.post(RequestBody.create(requestBuffer.toByteArray()));
 
 		requestBuffer = null;
 

--- a/spring-ws-core/src/main/java/org/springframework/ws/transport/http/OkHttpMessageSender.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/transport/http/OkHttpMessageSender.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2005-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.ws.transport.http;
 
 import java.net.URI;
@@ -7,6 +23,16 @@ import okhttp3.OkHttpClient;
 import org.springframework.util.Assert;
 import org.springframework.ws.transport.WebServiceConnection;
 
+/**
+ * {@code WebServiceMessageSender} implementation that uses <a href="https://square.github.io/okhttp/">OkHttp</a>
+ * to execute POST requests.
+ * <p>
+ * Allows to use a pre-configured OkHttpClient instance, potentially with authentication, interceptors, etc.
+ *
+ * @author Mathias Geat
+ * @see OkHttpClient
+ * @since 3.1.0
+ */
 public class OkHttpMessageSender extends AbstractHttpWebServiceMessageSender {
 
 	private static final MediaType DEFAULT_REQUEST_MEDIA_TYPE = MediaType.parse("text/xml; charset=utf-8");

--- a/spring-ws-core/src/main/java/org/springframework/ws/transport/http/OkHttpMessageSender.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/transport/http/OkHttpMessageSender.java
@@ -18,7 +18,6 @@ package org.springframework.ws.transport.http;
 
 import java.net.URI;
 
-import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import org.springframework.util.Assert;
 import org.springframework.ws.transport.WebServiceConnection;
@@ -35,26 +34,15 @@ import org.springframework.ws.transport.WebServiceConnection;
  */
 public class OkHttpMessageSender extends AbstractHttpWebServiceMessageSender {
 
-	private static final MediaType DEFAULT_REQUEST_MEDIA_TYPE = MediaType.parse("text/xml; charset=utf-8");
-
 	private final OkHttpClient okHttpClient;
-	private final MediaType requestMediaType;
 
 	public OkHttpMessageSender(OkHttpClient okHttpClient) {
-		this(okHttpClient, DEFAULT_REQUEST_MEDIA_TYPE);
-	}
-
-	public OkHttpMessageSender(OkHttpClient okHttpClient, MediaType requestMediaType) {
 		Assert.notNull(okHttpClient, "okHttpClient must not be null");
-		Assert.notNull(requestMediaType, "requestMediaType must not be null");
-
 		this.okHttpClient = okHttpClient;
-		this.requestMediaType = requestMediaType;
 	}
 
 	@Override
 	public WebServiceConnection createConnection(URI uri) {
-		return new OkHttpConnection(okHttpClient, uri, requestMediaType);
+		return new OkHttpConnection(okHttpClient, uri);
 	}
-
 }

--- a/spring-ws-core/src/main/java/org/springframework/ws/transport/http/OkHttpMessageSender.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/transport/http/OkHttpMessageSender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2021 the original author or authors.
+ * Copyright 2005-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ import org.springframework.ws.transport.WebServiceConnection;
  *
  * @author Mathias Geat
  * @see OkHttpClient
- * @since 3.1.0
+ * @since 4.1.0
  */
 public class OkHttpMessageSender extends AbstractHttpWebServiceMessageSender {
 

--- a/spring-ws-core/src/main/java/org/springframework/ws/transport/http/OkHttpMessageSender.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/transport/http/OkHttpMessageSender.java
@@ -1,0 +1,34 @@
+package org.springframework.ws.transport.http;
+
+import java.net.URI;
+
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import org.springframework.util.Assert;
+import org.springframework.ws.transport.WebServiceConnection;
+
+public class OkHttpMessageSender extends AbstractHttpWebServiceMessageSender {
+
+	private static final MediaType DEFAULT_REQUEST_MEDIA_TYPE = MediaType.parse("text/xml; charset=utf-8");
+
+	private final OkHttpClient okHttpClient;
+	private final MediaType requestMediaType;
+
+	public OkHttpMessageSender(OkHttpClient okHttpClient) {
+		this(okHttpClient, DEFAULT_REQUEST_MEDIA_TYPE);
+	}
+
+	public OkHttpMessageSender(OkHttpClient okHttpClient, MediaType requestMediaType) {
+		Assert.notNull(okHttpClient, "okHttpClient must not be null");
+		Assert.notNull(requestMediaType, "requestMediaType must not be null");
+
+		this.okHttpClient = okHttpClient;
+		this.requestMediaType = requestMediaType;
+	}
+
+	@Override
+	public WebServiceConnection createConnection(URI uri) {
+		return new OkHttpConnection(okHttpClient, uri, requestMediaType);
+	}
+
+}

--- a/spring-ws-core/src/test/java/org/springframework/ws/transport/http/OkHttpMessageSenderIntegrationTest.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/transport/http/OkHttpMessageSenderIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2021 the original author or authors.
+ * Copyright 2005-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ws-core/src/test/java/org/springframework/ws/transport/http/OkHttpMessageSenderIntegrationTest.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/transport/http/OkHttpMessageSenderIntegrationTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2005-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ws.transport.http;
+
+import okhttp3.OkHttpClient;
+
+public class OkHttpMessageSenderIntegrationTest
+		extends AbstractHttpWebServiceMessageSenderIntegrationTestCase<OkHttpMessageSender> {
+
+	@Override
+	protected OkHttpMessageSender createMessageSender() {
+		return new OkHttpMessageSender(new OkHttpClient());
+	}
+}


### PR DESCRIPTION
This is an initial draft to support [OkHttp](https://square.github.io/okhttp/) as MessageSender. As OkHttp is already supported in other Spring projects like Spring Cloud Sleuth this might be a good addition with a configurable and easy to use HTTP client.  

The implementation follows implementation of the `HttpComponentsMessageSender` but exposes less configuration options as this could all be preconfigured on the injected `OkHttpClient` (e.g. authentication, timeouts, interceptors) by creating a dedicated instance which is passed to the MessageSender.

Happy to add more features/tests and documentation if this is likely to be accepted. I wasn't sure how far the `acceptGzipEncoding` support should be implemented as OkHttp handles gzip encoding out of the box, but it would be possible to disable the default behaviour when that flag is false.