### PR TITLE
Wss4jSecurityInterceptor not propagating TTL

### DIFF
--- a/spring-ws-security/src/main/java/org/springframework/ws/soap/security/wss4j2/Wss4jSecurityInterceptor.java
+++ b/spring-ws-security/src/main/java/org/springframework/ws/soap/security/wss4j2/Wss4jSecurityInterceptor.java
@@ -668,7 +668,13 @@ public class Wss4jSecurityInterceptor extends AbstractWsSecurityInterceptor impl
 
 		requestData.setCallbackHandler(validationCallbackHandler);
 
+		messageContext.setProperty(WSHandlerConstants.TIMESTAMP_STRICT, timestampStrict);
 		messageContext.setProperty(WSHandlerConstants.TTL_TIMESTAMP, Integer.toString(validationTimeToLive));
+		messageContext.setProperty(WSHandlerConstants.TTL_FUTURE_TIMESTAMP, Integer.toString(futureTimeToLive));
+		
+		requestData.setTimeStampStrict(timestampStrict);
+		requestData.setTimeStampTTL(validationTimeToLive);
+		requestData.setTimeStampFutureTTL(futureTimeToLive);
 
 		requestData.setAllowRSA15KeyTransportAlgorithm(allowRSA15KeyTransportAlgorithm);
 

--- a/spring-ws-security/src/test/java/org/springframework/ws/soap/security/wss4j2/Wss4jMessageInterceptorTimestampTestCase.java
+++ b/spring-ws-security/src/test/java/org/springframework/ws/soap/security/wss4j2/Wss4jMessageInterceptorTimestampTestCase.java
@@ -75,6 +75,22 @@ public abstract class Wss4jMessageInterceptorTimestampTestCase extends Wss4jTest
 	}
 
 	@Test
+	public void testValidateTimestampWithExpiredTtlCustomTtl() throws Exception {
+
+		assertThatExceptionOfType(WsSecurityValidationException.class).isThrownBy(() -> {
+
+			Wss4jSecurityInterceptor interceptor = new Wss4jSecurityInterceptor();
+			interceptor.setValidationActions("Timestamp");
+			interceptor.setValidationTimeToLive(1);
+			interceptor.afterPropertiesSet();
+			SoapMessage message = getMessageWithTimestamp();
+			Thread.sleep(2000);
+			MessageContext context = new DefaultMessageContext(message, getSoap11MessageFactory());
+			interceptor.validateMessage(message, context);
+		});
+	}
+
+	@Test
 	public void testSecureTimestampWithCustomTtl() throws Exception {
 
 		Wss4jSecurityInterceptor interceptor = new Wss4jSecurityInterceptor();


### PR DESCRIPTION
Wss4jSecurityInterceptor not propagating time to live values when
validating ws-security soap header timestamp

https://github.com/spring-projects/spring-ws/issues/1150