### PR TITLE
Update document production

### DIFF
--- a/docs.xml
+++ b/docs.xml
@@ -9,11 +9,33 @@
 	<fileSets>
 		<fileSet>
 			<!--
-				Adds reference manual (html and pdf) to the distribution archive
+				Adds reference manual (html) to the distribution archive
 				under the 'docs/reference' directory see pom.xml 'maven-javadoc-plugin' declaration.
 			-->
-			<directory>target/site/reference</directory>
-			<outputDirectory>reference</outputDirectory>
+			<directory>target/site/reference/html</directory>
+			<outputDirectory>reference/html</outputDirectory>
+		</fileSet>
+		<fileSet>
+			<!--
+				Adds reference manual (pdf) to the distribution archive
+				under the 'docs/reference' directory see pom.xml 'maven-javadoc-plugin' declaration.
+			-->
+			<directory>target/site/reference/pdf</directory>
+			<includes>
+				<include>index.pdf</include>
+			</includes>
+			<outputDirectory>reference/pdf</outputDirectory>
+		</fileSet>
+		<fileSet>
+		<!--
+			Adds reference manual (epub) to the distribution archive
+			under the 'docs/reference' directory see pom.xml 'maven-javadoc-plugin' declaration.
+		-->
+			<directory>target/site/reference/epub</directory>
+			<includes>
+				<include>index.epub</include>
+			</includes>
+			<outputDirectory>reference/epub</outputDirectory>
 		</fileSet>
 		<fileSet>
 			<!--

--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
 		<xmlunit.version>2.7.0</xmlunit.version>
 		<xws-security.version>3.0</xws-security.version>
 		<xom.version>1.2.5</xom.version>
-		<docs.resources.version>0.2.1.RELEASE</docs.resources.version>
+		<docs.resources.version>0.2.5</docs.resources.version>
 	</properties>
 
 	<dependencyManagement>
@@ -535,12 +535,17 @@
 					<plugin>
 						<groupId>org.asciidoctor</groupId>
 						<artifactId>asciidoctor-maven-plugin</artifactId>
-						<version>1.5.6</version>
+						<version>2.1.0</version>
 						<dependencies>
 							<dependency>
 								<groupId>org.asciidoctor</groupId>
 								<artifactId>asciidoctorj-pdf</artifactId>
-								<version>1.5.0-alpha.15</version>
+								<version>1.5.4</version>
+							</dependency>
+							<dependency>
+								<groupId>org.asciidoctor</groupId>
+								<artifactId>asciidoctorj-epub3</artifactId>
+								<version>1.5.1</version>
 							</dependency>
 						</dependencies>
 						<executions>
@@ -577,7 +582,22 @@
 									<goal>process-asciidoc</goal>
 								</goals>
 								<configuration>
+									<outputDirectory>${project.build.directory}/site/reference/pdf</outputDirectory>
 									<backend>pdf</backend>
+									<sourceHighlighter>coderay</sourceHighlighter>
+								</configuration>
+							</execution>
+
+							<execution>
+								<id>epub</id>
+								<phase>generate-resources</phase>
+								<inherited>false</inherited>
+								<goals>
+									<goal>process-asciidoc</goal>
+								</goals>
+								<configuration>
+									<outputDirectory>${project.build.directory}/site/reference/epub</outputDirectory>
+									<backend>epub3</backend>
 									<sourceHighlighter>coderay</sourceHighlighter>
 								</configuration>
 							</execution>


### PR DESCRIPTION
Use the latest version of spring-doc-resources.
Add epub output.
Put each type of output into its own directory in the zip file.
(Previously, the assembly plugin picked up only the HTML output.)