### PR TITLE
Add ability to override Wss4J default values for InclusivePrefixes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -86,10 +86,10 @@ pipeline {
 						sh "PROFILE=spring-buildsnapshot,java11,convergence ci/test.sh"
 					}
 				}
-				stage("Test: baseline (jdk15)") {
+				stage("Test: baseline (jdk16)") {
 					agent {
 						docker {
-							image 'adoptopenjdk/openjdk15:latest'
+							image 'adoptopenjdk/openjdk16:latest'
 							args '-v $HOME/.m2:/root/.m2'
 						}
 					}
@@ -100,10 +100,10 @@ pipeline {
 						sh "PROFILE=distribute,java11,convergence ci/test.sh"
 					}
 				}
-				stage("Test: spring-buildsnapshot (jdk15)") {
+				stage("Test: spring-buildsnapshot (jdk16)") {
 					agent {
 						docker {
-							image 'adoptopenjdk/openjdk15:latest'
+							image 'adoptopenjdk/openjdk16:latest'
 							args '-v $HOME/.m2:/root/.m2'
 						}
 					}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -156,7 +156,7 @@ pipeline {
 						slackSend(
                                 color: (currentBuild.currentResult == 'SUCCESS') ? 'good' : 'danger',
                                 channel: '#spring-ws',
-                                message: "@here Spring WS ${PROJECT_VERSION} is staged on Sonatype awaiting closure and release.")
+                                message: "Spring WS ${PROJECT_VERSION} is staged on Sonatype awaiting closure and release.")
 					} else {
 						sh "PROFILE=distribute,${RELEASE_TYPE} ci/build-and-deploy-to-artifactory.sh"
 					}

--- a/README.adoc
+++ b/README.adoc
@@ -46,6 +46,7 @@ You can also import the project into your IDE.
 NOTE: You can chain the previous set of commands together using `&&`.
 
 The pipeline will build and release the "release" branch. It will also build a new a new snapshot and stage it on artifactory.
+For releases that go to Maven Central, the user much manually check out and verify the artifacts before releasing them.
 
 === Running CI tasks locally
 

--- a/docs.xml
+++ b/docs.xml
@@ -9,11 +9,33 @@
 	<fileSets>
 		<fileSet>
 			<!--
-				Adds reference manual (html and pdf) to the distribution archive
+				Adds reference manual (html) to the distribution archive
 				under the 'docs/reference' directory see pom.xml 'maven-javadoc-plugin' declaration.
 			-->
-			<directory>target/site/reference</directory>
-			<outputDirectory>reference</outputDirectory>
+			<directory>target/site/reference/html</directory>
+			<outputDirectory>reference/html</outputDirectory>
+		</fileSet>
+		<fileSet>
+			<!--
+				Adds reference manual (pdf) to the distribution archive
+				under the 'docs/reference' directory see pom.xml 'maven-javadoc-plugin' declaration.
+			-->
+			<directory>target/site/reference/pdf</directory>
+			<includes>
+				<include>index.pdf</include>
+			</includes>
+			<outputDirectory>reference/pdf</outputDirectory>
+		</fileSet>
+		<fileSet>
+		<!--
+			Adds reference manual (epub) to the distribution archive
+			under the 'docs/reference' directory see pom.xml 'maven-javadoc-plugin' declaration.
+		-->
+			<directory>target/site/reference/epub</directory>
+			<includes>
+				<include>index.epub</include>
+			</includes>
+			<outputDirectory>reference/epub</outputDirectory>
 		</fileSet>
 		<fileSet>
 			<!--

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.ws</groupId>
 	<artifactId>spring-ws</artifactId>
-	<version>3.1.0-SNAPSHOT</version>
+	<version>3.1.0</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Web Services</name>

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
 		<smack.version>4.2.1</smack.version>
 		<soap-api.version>1.4.0</soap-api.version>
 		<spring.version>5.3.7</spring.version>
-		<spring-security.version>5.5.0-RC2</spring-security.version>
+		<spring-security.version>5.5.0</spring-security.version>
 		<stax.version>1.7.8</stax.version>
 		<sun-mail.version>1.6.0</sun-mail.version>
 		<woodstox.version>4.2.0</woodstox.version>
@@ -240,7 +240,7 @@
 			<id>spring-buildsnapshot</id>
 			<properties>
 				<spring.version>5.3.8-SNAPSHOT</spring.version>
-				<spring-security.version>5.5.0-SNAPSHOT</spring-security.version>
+				<spring-security.version>5.5.1-SNAPSHOT</spring-security.version>
 			</properties>
 		</profile>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.springframework.ws</groupId>
 	<artifactId>spring-ws</artifactId>
-	<version>3.1.2-SNAPSHOT</version>
+	<version>3.1.3-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Web Services</name>
@@ -102,8 +102,7 @@
 		<jetty.version>6.1.26</jetty.version>
 		<jms.version>2.0.1</jms.version>
 		<junit.version>5.7.0</junit.version>
-		<log4j.version>1.2.17</log4j.version>
-		<log4j2.version>2.11.0</log4j2.version>
+		<log4j2.version>2.15.0</log4j2.version>
 		<mail.version>1.4.7</mail.version>
 		<mock-javamail.version>1.9</mock-javamail.version>
 		<saaj-impl.version>1.5.2</saaj-impl.version>
@@ -112,12 +111,12 @@
 		<soap-api.version>1.4.0</soap-api.version>
 		<spring.version>5.3.7</spring.version>
 		<spring-security.version>5.5.0</spring-security.version>
-		<stax.version>1.7.8</stax.version>
+		<stax.version>1.8.3</stax.version>
 		<sun-mail.version>1.6.0</sun-mail.version>
 		<woodstox.version>4.2.0</woodstox.version>
 		<wsdl4j.version>1.6.3</wsdl4j.version>
 		<wss4j.version>2.3.0</wss4j.version>
-		<xmlsec.version>2.2.0</xmlsec.version>
+		<xmlsec.version>2.3.0</xmlsec.version>
 		<xml-schema-core.version>2.2.2</xml-schema-core.version>
 		<xmlunit1.version>1.6</xmlunit1.version>
 		<xmlunit.version>2.7.0</xmlunit.version>
@@ -271,6 +270,21 @@
 									</rules>
 									<fail>true</fail>
 								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+
+					<plugin>
+						<groupId>org.basepom.maven</groupId>
+						<artifactId>duplicate-finder-maven-plugin</artifactId>
+						<version>1.5.0</version>
+						<executions>
+							<execution>
+								<id>check-for-duplicates</id>
+								<goals>
+									<goal>check</goal>
+								</goals>
+								<phase>validate</phase>
 							</execution>
 						</executions>
 					</plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
 		<xmlunit.version>2.7.0</xmlunit.version>
 		<xws-security.version>3.0</xws-security.version>
 		<xom.version>1.2.5</xom.version>
-		<docs.resources.version>0.2.1.RELEASE</docs.resources.version>
+		<docs.resources.version>0.2.5</docs.resources.version>
 	</properties>
 
 	<dependencyManagement>
@@ -535,12 +535,17 @@
 					<plugin>
 						<groupId>org.asciidoctor</groupId>
 						<artifactId>asciidoctor-maven-plugin</artifactId>
-						<version>1.5.6</version>
+						<version>2.1.0</version>
 						<dependencies>
 							<dependency>
 								<groupId>org.asciidoctor</groupId>
 								<artifactId>asciidoctorj-pdf</artifactId>
-								<version>1.5.0-alpha.15</version>
+								<version>1.5.4</version>
+							</dependency>
+							<dependency>
+								<groupId>org.asciidoctor</groupId>
+								<artifactId>asciidoctorj-epub3</artifactId>
+								<version>1.5.1</version>
 							</dependency>
 						</dependencies>
 						<executions>
@@ -577,7 +582,22 @@
 									<goal>process-asciidoc</goal>
 								</goals>
 								<configuration>
+									<outputDirectory>${project.build.directory}/site/reference/pdf</outputDirectory>
 									<backend>pdf</backend>
+									<sourceHighlighter>coderay</sourceHighlighter>
+								</configuration>
+							</execution>
+
+							<execution>
+								<id>epub</id>
+								<phase>generate-resources</phase>
+								<inherited>false</inherited>
+								<goals>
+									<goal>process-asciidoc</goal>
+								</goals>
+								<configuration>
+									<outputDirectory>${project.build.directory}/site/reference/epub</outputDirectory>
+									<backend>epub3</backend>
 									<sourceHighlighter>coderay</sourceHighlighter>
 								</configuration>
 							</execution>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.ws</groupId>
 	<artifactId>spring-ws</artifactId>
-	<version>3.1.1-SNAPSHOT</version>
+	<version>3.1.1</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Web Services</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.ws</groupId>
 	<artifactId>spring-ws</artifactId>
-	<version>3.1.1</version>
+	<version>3.1.2-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Web Services</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.ws</groupId>
 	<artifactId>spring-ws</artifactId>
-	<version>3.1.0</version>
+	<version>3.1.1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Web Services</name>

--- a/pom.xml
+++ b/pom.xml
@@ -240,7 +240,6 @@
 			<id>spring-buildsnapshot</id>
 			<properties>
 				<spring.version>5.3.8-SNAPSHOT</spring.version>
-				<spring-security.version>5.5.1-SNAPSHOT</spring-security.version>
 			</properties>
 		</profile>
 

--- a/pom.xml
+++ b/pom.xml
@@ -406,10 +406,8 @@
 			<id>central</id>
 
 			<properties>
-				<maven.main.skip>true</maven.main.skip>
 				<maven.test.skip>true</maven.test.skip>
 				<maven.kotlin.skip>true</maven.kotlin.skip>
-				<maven.install.skip>true</maven.install.skip>
 				<skipTests>true</skipTests>
 			</properties>
 

--- a/spring-ws-core/pom.xml
+++ b/spring-ws-core/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.ws</groupId>
 		<artifactId>spring-ws</artifactId>
-		<version>3.1.1</version>
+		<version>3.1.2-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>spring-ws-core</artifactId>

--- a/spring-ws-core/pom.xml
+++ b/spring-ws-core/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.ws</groupId>
 		<artifactId>spring-ws</artifactId>
-		<version>3.1.2-SNAPSHOT</version>
+		<version>3.1.3-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>spring-ws-core</artifactId>

--- a/spring-ws-core/pom.xml
+++ b/spring-ws-core/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.ws</groupId>
 		<artifactId>spring-ws</artifactId>
-		<version>3.1.0-SNAPSHOT</version>
+		<version>3.1.0</version>
 	</parent>
 
 	<artifactId>spring-ws-core</artifactId>

--- a/spring-ws-core/pom.xml
+++ b/spring-ws-core/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.ws</groupId>
 		<artifactId>spring-ws</artifactId>
-		<version>3.1.1-SNAPSHOT</version>
+		<version>3.1.1</version>
 	</parent>
 
 	<artifactId>spring-ws-core</artifactId>

--- a/spring-ws-core/pom.xml
+++ b/spring-ws-core/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.ws</groupId>
 		<artifactId>spring-ws</artifactId>
-		<version>3.1.0</version>
+		<version>3.1.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>spring-ws-core</artifactId>

--- a/spring-ws-core/src/main/java/org/springframework/ws/transport/TransportInputStream.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/transport/TransportInputStream.java
@@ -47,7 +47,9 @@ public abstract class TransportInputStream extends InputStream {
 
 	@Override
 	public void close() throws IOException {
-		getInputStream().close();
+		if (inputStream != null) {
+			getInputStream().close();
+		}
 	}
 
 	@Override

--- a/spring-ws-core/src/main/java/org/springframework/ws/transport/TransportOutputStream.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/transport/TransportOutputStream.java
@@ -45,12 +45,16 @@ public abstract class TransportOutputStream extends OutputStream {
 
 	@Override
 	public void close() throws IOException {
-		getOutputStream().close();
+		if (outputStream != null) {
+			getOutputStream().close();
+		}
 	}
 
 	@Override
 	public void flush() throws IOException {
-		getOutputStream().flush();
+		if (outputStream != null) {
+			getOutputStream().flush();
+		}
 	}
 
 	@Override

--- a/spring-ws-security/pom.xml
+++ b/spring-ws-security/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.ws</groupId>
 		<artifactId>spring-ws</artifactId>
-		<version>3.1.0</version>
+		<version>3.1.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>spring-ws-security</artifactId>

--- a/spring-ws-security/pom.xml
+++ b/spring-ws-security/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.ws</groupId>
 		<artifactId>spring-ws</artifactId>
-		<version>3.1.2-SNAPSHOT</version>
+		<version>3.1.3-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>spring-ws-security</artifactId>

--- a/spring-ws-security/pom.xml
+++ b/spring-ws-security/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.ws</groupId>
 		<artifactId>spring-ws</artifactId>
-		<version>3.1.1</version>
+		<version>3.1.2-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>spring-ws-security</artifactId>

--- a/spring-ws-security/pom.xml
+++ b/spring-ws-security/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.ws</groupId>
 		<artifactId>spring-ws</artifactId>
-		<version>3.1.1-SNAPSHOT</version>
+		<version>3.1.1</version>
 	</parent>
 
 	<artifactId>spring-ws-security</artifactId>

--- a/spring-ws-security/pom.xml
+++ b/spring-ws-security/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.ws</groupId>
 		<artifactId>spring-ws</artifactId>
-		<version>3.1.0-SNAPSHOT</version>
+		<version>3.1.0</version>
 	</parent>
 
 	<artifactId>spring-ws-security</artifactId>

--- a/spring-ws-security/src/main/java/org/springframework/ws/soap/security/wss4j2/Wss4jSecurityInterceptor.java
+++ b/spring-ws-security/src/main/java/org/springframework/ws/soap/security/wss4j2/Wss4jSecurityInterceptor.java
@@ -179,6 +179,8 @@ public class Wss4jSecurityInterceptor extends AbstractWsSecurityInterceptor impl
 
 	private boolean bspCompliant;
 
+	private boolean addInclusivePrefixes = true;
+
 	private boolean securementUseDerivedKey;
 
 	private CallbackHandler samlCallbackHandler;
@@ -542,6 +544,15 @@ public class Wss4jSecurityInterceptor extends AbstractWsSecurityInterceptor impl
 	}
 
 	/**
+	 * Sets whether to add an InclusiveNamespaces PrefixList as a CanonicalizationMethod child
+	 * when generating Signatures using WSConstants.C14N_EXCL_OMIT_COMMENTS. Default is {@code true}.
+	 */
+	public void setAddInclusivePrefixes(boolean addInclusivePrefixes) {
+		this.handler.setOption(WSHandlerConstants.ADD_INCLUSIVE_PREFIXES, addInclusivePrefixes);
+		this.addInclusivePrefixes = addInclusivePrefixes;
+	}
+
+	/**
 	 * Sets whether the RSA 1.5 key transport algorithm is allowed.
 	 */
 	public void setAllowRSA15KeyTransportAlgorithm(boolean allow) {
@@ -676,6 +687,9 @@ public class Wss4jSecurityInterceptor extends AbstractWsSecurityInterceptor impl
 		if (requestData.getBSPEnforcer() != null) {
 			requestData.getBSPEnforcer().setDisableBSPRules(!bspCompliant);
 		}
+
+		requestData.setAddInclusivePrefixes(addInclusivePrefixes);
+
 		// allow for qualified password types for .Net interoperability
 		requestData.setAllowNamespaceQualifiedPasswordTypes(true);
 

--- a/spring-ws-security/src/test/java/org/springframework/ws/soap/security/wss4j2/SaajWss4jMessageInterceptorSignTest.java
+++ b/spring-ws-security/src/test/java/org/springframework/ws/soap/security/wss4j2/SaajWss4jMessageInterceptorSignTest.java
@@ -83,4 +83,45 @@ public class SaajWss4jMessageInterceptorSignTest extends Wss4jMessageInterceptor
 
 		interceptor.validateMessage(message, messageContext);
 	}
+
+	@Test
+	public void testSignWithoutInclusivePrefixesAndValidate() throws Exception {
+
+		Transformer transformer = TransformerFactoryUtils.newInstance().newTransformer();
+		interceptor.setSecurementActions("Signature");
+		interceptor.setEnableSignatureConfirmation(false);
+		interceptor.setSecurementPassword("123456");
+		interceptor.setSecurementUsername("rsaKey");
+		interceptor.setAddInclusivePrefixes(false);
+		SOAPMessage saajMessage = saajSoap11MessageFactory.createMessage();
+		transformer.transform(new StringSource(PAYLOAD), new DOMResult(saajMessage.getSOAPBody()));
+		SoapMessage message = new SaajSoapMessage(saajMessage, saajSoap11MessageFactory);
+		MessageContext messageContext = new DefaultMessageContext(message, new SaajSoapMessageFactory(saajSoap11MessageFactory));
+
+		interceptor.secureMessage(message, messageContext);
+
+		SOAPHeader header = ((SaajSoapMessage) message).getSaajMessage().getSOAPHeader();
+		Iterator<?> iterator = header.getChildElements(
+				new QName("http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd", "Security"));
+
+		assertThat(iterator.hasNext()).isTrue();
+
+		SOAPHeaderElement securityHeader = (SOAPHeaderElement) iterator.next();
+		iterator = securityHeader.getChildElements(new QName("http://www.w3.org/2000/09/xmldsig#", "Signature"));
+
+		assertThat(iterator.hasNext()).isTrue();
+
+		ByteArrayOutputStream bos = new ByteArrayOutputStream();
+		message.writeTo(bos);
+
+		MimeHeaders mimeHeaders = new MimeHeaders();
+		mimeHeaders.addHeader("Content-Type", "text/xml");
+		ByteArrayInputStream bis = new ByteArrayInputStream(bos.toByteArray());
+
+		SOAPMessage signed = saajSoap11MessageFactory.createMessage(mimeHeaders, bis);
+		message = new SaajSoapMessage(signed, saajSoap11MessageFactory);
+		messageContext = new DefaultMessageContext(message, new SaajSoapMessageFactory(saajSoap11MessageFactory));
+
+		interceptor.validateMessage(message, messageContext);
+	}
 }

--- a/spring-ws-security/src/test/java/org/springframework/ws/soap/security/wss4j2/SaajWss4jSecurityInterceptorDefaultsTest.java
+++ b/spring-ws-security/src/test/java/org/springframework/ws/soap/security/wss4j2/SaajWss4jSecurityInterceptorDefaultsTest.java
@@ -1,0 +1,69 @@
+package org.springframework.ws.soap.security.wss4j2;
+
+import org.apache.wss4j.dom.handler.RequestData;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.ws.context.DefaultMessageContext;
+import org.springframework.ws.context.MessageContext;
+import org.springframework.ws.soap.SoapMessage;
+import org.springframework.ws.soap.saaj.SaajSoapMessage;
+import org.springframework.ws.soap.saaj.SaajSoapMessageFactory;
+import org.springframework.xml.transform.StringSource;
+import org.springframework.xml.transform.TransformerFactoryUtils;
+
+import javax.xml.soap.SOAPException;
+import javax.xml.soap.SOAPMessage;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.dom.DOMResult;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.util.AssertionErrors.assertEquals;
+
+public class SaajWss4jSecurityInterceptorDefaultsTest extends Wss4jTestCase {
+
+	private static final String PAYLOAD = "<tru:StockSymbol xmlns:tru=\"http://fabrikam123.com/payloads\">QQQ</tru:StockSymbol>";
+
+
+	@Test
+	public void testThatTheDefaultValueForAddInclusivePrefixesMatchesWss4JDefaultValue() {
+		Wss4jSecurityInterceptor subject = new Wss4jSecurityInterceptor();
+		RequestData requestData = new RequestData();
+		Boolean springDefault = (Boolean) ReflectionTestUtils.getField(subject, Wss4jSecurityInterceptor.class, "addInclusivePrefixes");
+		assertEquals("Spring-ws default for addInclusivePrefixes matches Wss4j default", requestData.isAddInclusivePrefixes(), springDefault);
+	}
+
+	@Test
+	public void testThatInitializeValidationRequestDataSetsInclusivePrefixesUsingDefaults() throws TransformerException, SOAPException {
+		Wss4jSecurityInterceptor subject = new Wss4jSecurityInterceptor();
+
+		Transformer transformer = TransformerFactoryUtils.newInstance().newTransformer();
+
+		SOAPMessage saajMessage = saajSoap11MessageFactory.createMessage();
+		transformer.transform(new StringSource(PAYLOAD), new DOMResult(saajMessage.getSOAPBody()));
+		SoapMessage message = new SaajSoapMessage(saajMessage, saajSoap11MessageFactory);
+		MessageContext messageContext = new DefaultMessageContext(message, new SaajSoapMessageFactory(saajSoap11MessageFactory));
+
+		RequestData validationData = ReflectionTestUtils.invokeMethod(subject, "initializeValidationRequestData", messageContext);
+
+		assertTrue(validationData.isAddInclusivePrefixes());
+	}
+
+
+	@Test
+	public void testThatInitializeValidationRequestDataSetsInclusivePrefixesUsingNotUsingInclusivePrefixes() throws TransformerException, SOAPException {
+		Wss4jSecurityInterceptor subject = new Wss4jSecurityInterceptor();
+		subject.setAddInclusivePrefixes(false);
+				Transformer transformer = TransformerFactoryUtils.newInstance().newTransformer();
+
+		SOAPMessage saajMessage = saajSoap11MessageFactory.createMessage();
+		transformer.transform(new StringSource(PAYLOAD), new DOMResult(saajMessage.getSOAPBody()));
+		SoapMessage message = new SaajSoapMessage(saajMessage, saajSoap11MessageFactory);
+		MessageContext messageContext = new DefaultMessageContext(message, new SaajSoapMessageFactory(saajSoap11MessageFactory));
+
+		RequestData validationData = ReflectionTestUtils.invokeMethod(subject, "initializeValidationRequestData", messageContext);
+
+		assertFalse(validationData.isAddInclusivePrefixes());
+	}
+}

--- a/spring-ws-security/src/test/java/org/springframework/ws/soap/security/wss4j2/SaajWss4jSecurityInterceptorDefaultsTest.java
+++ b/spring-ws-security/src/test/java/org/springframework/ws/soap/security/wss4j2/SaajWss4jSecurityInterceptorDefaultsTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2005-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.ws.soap.security.wss4j2;
 
 import org.apache.wss4j.dom.handler.RequestData;

--- a/spring-ws-support/.gitignore
+++ b/spring-ws-support/.gitignore
@@ -3,4 +3,4 @@ target
 .classpath
 .project
 .settings
-
+data

--- a/spring-ws-support/pom.xml
+++ b/spring-ws-support/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.ws</groupId>
 		<artifactId>spring-ws</artifactId>
-		<version>3.1.1-SNAPSHOT</version>
+		<version>3.1.1</version>
 	</parent>
 
 	<artifactId>spring-ws-support</artifactId>

--- a/spring-ws-support/pom.xml
+++ b/spring-ws-support/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.ws</groupId>
 		<artifactId>spring-ws</artifactId>
-		<version>3.1.1</version>
+		<version>3.1.2-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>spring-ws-support</artifactId>

--- a/spring-ws-support/pom.xml
+++ b/spring-ws-support/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.ws</groupId>
 		<artifactId>spring-ws</artifactId>
-		<version>3.1.0</version>
+		<version>3.1.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>spring-ws-support</artifactId>

--- a/spring-ws-support/pom.xml
+++ b/spring-ws-support/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.ws</groupId>
 		<artifactId>spring-ws</artifactId>
-		<version>3.1.2-SNAPSHOT</version>
+		<version>3.1.3-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>spring-ws-support</artifactId>

--- a/spring-ws-support/pom.xml
+++ b/spring-ws-support/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.ws</groupId>
 		<artifactId>spring-ws</artifactId>
-		<version>3.1.0-SNAPSHOT</version>
+		<version>3.1.0</version>
 	</parent>
 
 	<artifactId>spring-ws-support</artifactId>

--- a/spring-ws-test/pom.xml
+++ b/spring-ws-test/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.ws</groupId>
 		<artifactId>spring-ws</artifactId>
-		<version>3.1.1</version>
+		<version>3.1.2-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>spring-ws-test</artifactId>

--- a/spring-ws-test/pom.xml
+++ b/spring-ws-test/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.ws</groupId>
 		<artifactId>spring-ws</artifactId>
-		<version>3.1.0</version>
+		<version>3.1.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>spring-ws-test</artifactId>

--- a/spring-ws-test/pom.xml
+++ b/spring-ws-test/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.ws</groupId>
 		<artifactId>spring-ws</artifactId>
-		<version>3.1.0-SNAPSHOT</version>
+		<version>3.1.0</version>
 	</parent>
 
 	<artifactId>spring-ws-test</artifactId>

--- a/spring-ws-test/pom.xml
+++ b/spring-ws-test/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.ws</groupId>
 		<artifactId>spring-ws</artifactId>
-		<version>3.1.1-SNAPSHOT</version>
+		<version>3.1.1</version>
 	</parent>
 
 	<artifactId>spring-ws-test</artifactId>

--- a/spring-ws-test/pom.xml
+++ b/spring-ws-test/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.ws</groupId>
 		<artifactId>spring-ws</artifactId>
-		<version>3.1.2-SNAPSHOT</version>
+		<version>3.1.3-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>spring-ws-test</artifactId>

--- a/spring-xml/pom.xml
+++ b/spring-xml/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.ws</groupId>
 		<artifactId>spring-ws</artifactId>
-		<version>3.1.1-SNAPSHOT</version>
+		<version>3.1.1</version>
 	</parent>
 
 	<artifactId>spring-xml</artifactId>

--- a/spring-xml/pom.xml
+++ b/spring-xml/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.ws</groupId>
 		<artifactId>spring-ws</artifactId>
-		<version>3.1.0-SNAPSHOT</version>
+		<version>3.1.0</version>
 	</parent>
 
 	<artifactId>spring-xml</artifactId>

--- a/spring-xml/pom.xml
+++ b/spring-xml/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.ws</groupId>
 		<artifactId>spring-ws</artifactId>
-		<version>3.1.1</version>
+		<version>3.1.2-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>spring-xml</artifactId>

--- a/spring-xml/pom.xml
+++ b/spring-xml/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.ws</groupId>
 		<artifactId>spring-ws</artifactId>
-		<version>3.1.0</version>
+		<version>3.1.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>spring-xml</artifactId>

--- a/spring-xml/pom.xml
+++ b/spring-xml/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.ws</groupId>
 		<artifactId>spring-ws</artifactId>
-		<version>3.1.2-SNAPSHOT</version>
+		<version>3.1.3-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>spring-xml</artifactId>


### PR DESCRIPTION
This adds the ability to control wss4j's InclusivePrefixes settings.

This sets the defaults to match wss4j defaults.

https://github.com/spring-projects/spring-ws/pull/75 should be closed since it would have changed the default behavour of spring-ws.

Tests verify changes and I feel some of the test are overkill but I wanted to ensure that there was no reason not to merge this PR.

I have tested these changes in the 2.4.7 branch of spring-ws, and will be upgrading to this version once the change is merged.

Thanks!