### PR TITLE
Fix failing soapEnvelopeDiffMatcher

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,8 +122,7 @@
         <wss4j.version>2.4.1</wss4j.version>
         <xmlsec.version>3.0.1</xmlsec.version>
         <xml-schema-core.version>2.2.2</xml-schema-core.version>
-        <xmlunit1.version>1.6</xmlunit1.version>
-        <xmlunit.version>2.7.0</xmlunit.version>
+        <xmlunit2.version>2.9.0</xmlunit2.version>
         <xom.version>1.3.7</xom.version>
         <spring-asciidoctor-backends.version>0.0.3</spring-asciidoctor-backends.version>
     </properties>
@@ -219,7 +218,7 @@
         <dependency>
             <groupId>org.xmlunit</groupId>
             <artifactId>xmlunit-assertj</artifactId>
-            <version>${xmlunit.version}</version>
+            <version>${xmlunit2.version}</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/spring-ws-test/pom.xml
+++ b/spring-ws-test/pom.xml
@@ -35,9 +35,9 @@
 		</dependency>
 
 		<dependency>
-			<groupId>xmlunit</groupId>
-			<artifactId>xmlunit</artifactId>
-			<version>${xmlunit1.version}</version>
+			<groupId>org.xmlunit</groupId>
+			<artifactId>xmlunit-core</artifactId>
+			<version>${xmlunit2.version}</version>
 		</dependency>
 
 		<dependency>

--- a/spring-ws-test/src/main/java/org/springframework/ws/test/support/matcher/DiffMatcher.java
+++ b/spring-ws-test/src/main/java/org/springframework/ws/test/support/matcher/DiffMatcher.java
@@ -18,8 +18,8 @@ package org.springframework.ws.test.support.matcher;
 
 import static org.springframework.ws.test.support.AssertionErrors.*;
 
-import org.custommonkey.xmlunit.Diff;
 import org.springframework.ws.WebServiceMessage;
+import org.xmlunit.diff.Diff;
 
 /**
  * Implementation of {@link WebServiceMessageMatcher} based on XMLUnit's {@link Diff}.
@@ -33,7 +33,7 @@ public abstract class DiffMatcher implements WebServiceMessageMatcher {
 	public final void match(WebServiceMessage message) throws AssertionError {
 
 		Diff diff = createDiff(message);
-		assertTrue("Messages are different, " + diff.toString(), diff.similar(), "Payload", message.getPayloadSource());
+		assertTrue("Messages are different, " + diff.toString(), !diff.hasDifferences(), "Payload", message.getPayloadSource());
 	}
 
 	/**

--- a/spring-ws-test/src/main/java/org/springframework/ws/test/support/matcher/PayloadDiffMatcher.java
+++ b/spring-ws-test/src/main/java/org/springframework/ws/test/support/matcher/PayloadDiffMatcher.java
@@ -22,11 +22,12 @@ import javax.xml.transform.Source;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.dom.DOMResult;
 
-import org.custommonkey.xmlunit.Diff;
 import org.springframework.util.Assert;
 import org.springframework.ws.WebServiceMessage;
 import org.springframework.xml.transform.TransformerHelper;
 import org.w3c.dom.Document;
+import org.xmlunit.builder.DiffBuilder;
+import org.xmlunit.diff.Diff;
 
 /**
  * Matches {@link Source} payloads.
@@ -58,7 +59,10 @@ public class PayloadDiffMatcher extends DiffMatcher {
 	protected Diff createDiff(Source payload) {
 		Document expectedDocument = createDocumentFromSource(expected);
 		Document actualDocument = createDocumentFromSource(payload);
-		return new Diff(expectedDocument, actualDocument);
+		return DiffBuilder.compare(expectedDocument)
+				.withTest(actualDocument)
+				.checkForSimilar()
+				.build();
 	}
 
 	private Document createDocumentFromSource(Source source) {

--- a/spring-ws-test/src/main/java/org/springframework/ws/test/support/matcher/SoapEnvelopeDiffMatcher.java
+++ b/spring-ws-test/src/main/java/org/springframework/ws/test/support/matcher/SoapEnvelopeDiffMatcher.java
@@ -24,12 +24,12 @@ import javax.xml.transform.Source;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.dom.DOMResult;
 
-import org.custommonkey.xmlunit.Diff;
-import org.custommonkey.xmlunit.XMLUnit;
 import org.springframework.util.Assert;
 import org.springframework.ws.soap.SoapMessage;
 import org.springframework.xml.transform.TransformerHelper;
 import org.w3c.dom.Document;
+import org.xmlunit.builder.DiffBuilder;
+import org.xmlunit.diff.Diff;
 
 /**
  * Matches {@link Source} SOAP envelopes.
@@ -43,10 +43,6 @@ public class SoapEnvelopeDiffMatcher extends AbstractSoapMessageMatcher {
 
 	private final TransformerHelper transformerHelper = new TransformerHelper();
 
-	static {
-		XMLUnit.setIgnoreWhitespace(true);
-	}
-
 	public SoapEnvelopeDiffMatcher(Source expected) {
 
 		Assert.notNull(expected, "'expected' must not be null");
@@ -58,8 +54,12 @@ public class SoapEnvelopeDiffMatcher extends AbstractSoapMessageMatcher {
 
 		Document actualDocument = soapMessage.getDocument();
 		Document expectedDocument = createDocumentFromSource(expected);
-		Diff diff = new Diff(expectedDocument, actualDocument);
-		assertTrue("Envelopes are different, " + diff.toString(), diff.similar());
+		Diff diff = DiffBuilder.compare(expectedDocument)
+				.ignoreWhitespace()
+				.withTest(actualDocument)
+				.checkForSimilar()
+				.build();
+		assertTrue("Envelopes are different, " + diff.toString(), !diff.hasDifferences());
 	}
 
 	private Document createDocumentFromSource(Source source) {

--- a/spring-ws-test/src/test/java/org/springframework/ws/test/client/MockWebServiceServerTest.java
+++ b/spring-ws-test/src/test/java/org/springframework/ws/test/client/MockWebServiceServerTest.java
@@ -21,6 +21,7 @@ import static org.easymock.EasyMock.*;
 import static org.springframework.ws.test.client.RequestMatchers.*;
 import static org.springframework.ws.test.client.ResponseCreators.*;
 
+import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.soap.MessageFactory;
 
 import java.net.URI;
@@ -36,6 +37,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.context.support.StaticApplicationContext;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.Resource;
+import org.springframework.oxm.jaxb.Jaxb2Marshaller;
 import org.springframework.ws.client.core.WebServiceTemplate;
 import org.springframework.ws.client.core.support.WebServiceGatewaySupport;
 import org.springframework.ws.soap.SoapMessage;
@@ -46,14 +48,14 @@ import org.springframework.xml.transform.StringResult;
 import org.springframework.xml.transform.StringSource;
 import org.xmlunit.assertj.XmlAssert;
 
-public class MockWebServiceServerTest {
+class MockWebServiceServerTest {
 
 	private WebServiceTemplate template;
 
 	private MockWebServiceServer server;
 
 	@BeforeEach
-	public void setUp() {
+	void setUp() {
 
 		template = new WebServiceTemplate();
 		template.setDefaultUri("http://example.com");
@@ -62,7 +64,7 @@ public class MockWebServiceServerTest {
 	}
 
 	@Test
-	public void createServerWebServiceTemplate() {
+	void createServerWebServiceTemplate() {
 
 		WebServiceTemplate template = new WebServiceTemplate();
 
@@ -72,7 +74,7 @@ public class MockWebServiceServerTest {
 	}
 
 	@Test
-	public void createServerGatewaySupport() {
+	void createServerGatewaySupport() {
 
 		MyClient client = new MyClient();
 
@@ -82,7 +84,7 @@ public class MockWebServiceServerTest {
 	}
 
 	@Test
-	public void createServerApplicationContextWebServiceTemplate() {
+	void createServerApplicationContextWebServiceTemplate() {
 
 		StaticApplicationContext applicationContext = new StaticApplicationContext();
 		applicationContext.registerSingleton("webServiceTemplate", WebServiceTemplate.class);
@@ -94,7 +96,7 @@ public class MockWebServiceServerTest {
 	}
 
 	@Test
-	public void createServerApplicationContextWebServiceGatewaySupport() {
+	void createServerApplicationContextWebServiceGatewaySupport() {
 
 		StaticApplicationContext applicationContext = new StaticApplicationContext();
 		applicationContext.registerSingleton("myClient", MyClient.class);
@@ -105,7 +107,7 @@ public class MockWebServiceServerTest {
 	}
 
 	@Test
-	public void createServerApplicationContextEmpty() {
+	void createServerApplicationContextEmpty() {
 
 		assertThatIllegalArgumentException().isThrownBy(() -> {
 
@@ -118,7 +120,7 @@ public class MockWebServiceServerTest {
 	}
 
 	@Test
-	public void mocks() throws Exception {
+	void mocks() throws Exception {
 
 		URI uri = URI.create("http://example.com");
 
@@ -143,7 +145,7 @@ public class MockWebServiceServerTest {
 	}
 
 	@Test
-	public void payloadMatch() {
+	void payloadMatch() {
 
 		Source request = new StringSource("<request xmlns='http://example.com'/>");
 		Source response = new StringSource("<response xmlns='http://example.com'/>");
@@ -157,7 +159,7 @@ public class MockWebServiceServerTest {
 	}
 
 	@Test
-	public void payloadNonMatch() {
+	void payloadNonMatch() {
 
 		assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> {
 
@@ -172,7 +174,7 @@ public class MockWebServiceServerTest {
 	}
 
 	@Test
-	public void soapHeaderMatch() {
+	void soapHeaderMatch() {
 
 		final QName soapHeaderName = new QName("http://example.com", "mySoapHeader");
 
@@ -186,7 +188,7 @@ public class MockWebServiceServerTest {
 	}
 
 	@Test
-	public void soapHeaderNonMatch() {
+	void soapHeaderNonMatch() {
 
 		assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> {
 
@@ -200,7 +202,7 @@ public class MockWebServiceServerTest {
 	}
 
 	@Test
-	public void connectionMatch() {
+	void connectionMatch() {
 
 		String uri = "http://example.com";
 		server.expect(connectionTo(uri));
@@ -210,7 +212,7 @@ public class MockWebServiceServerTest {
 	}
 
 	@Test
-	public void connectionNonMatch() {
+	void connectionNonMatch() {
 
 		assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> {
 
@@ -224,7 +226,7 @@ public class MockWebServiceServerTest {
 	}
 
 	@Test
-	public void unexpectedConnection() {
+	void unexpectedConnection() {
 
 		assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> {
 
@@ -239,7 +241,7 @@ public class MockWebServiceServerTest {
 	}
 
 	@Test
-	public void xsdMatch() throws Exception {
+	void xsdMatch() throws Exception {
 
 		Resource schema = new ByteArrayResource(
 				"<schema xmlns=\"http://www.w3.org/2001/XMLSchema\" targetNamespace=\"http://example.com\" elementFormDefault=\"qualified\"><element name=\"request\"/></schema>"
@@ -253,7 +255,7 @@ public class MockWebServiceServerTest {
 	}
 
 	@Test
-	public void xsdNonMatch() {
+	void xsdNonMatch() {
 
 		assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> {
 
@@ -270,7 +272,7 @@ public class MockWebServiceServerTest {
 	}
 
 	@Test
-	public void xpathExistsMatch() {
+	void xpathExistsMatch() {
 
 		final Map<String, String> ns = Collections.singletonMap("ns", "http://example.com");
 
@@ -281,7 +283,7 @@ public class MockWebServiceServerTest {
 	}
 
 	@Test
-	public void xpathExistsNonMatch() {
+	void xpathExistsNonMatch() {
 
 		assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> {
 
@@ -295,7 +297,7 @@ public class MockWebServiceServerTest {
 	}
 
 	@Test
-	public void anythingMatch() {
+	void anythingMatch() {
 
 		Source request = new StringSource("<request xmlns='http://example.com'/>");
 		Source response = new StringSource("<response xmlns='http://example.com'/>");
@@ -311,7 +313,7 @@ public class MockWebServiceServerTest {
 	}
 
 	@Test
-	public void recordWhenReplay() {
+	void recordWhenReplay() {
 
 		assertThatIllegalStateException().isThrownBy(() -> {
 
@@ -331,7 +333,43 @@ public class MockWebServiceServerTest {
 	}
 
 	@Test
-	public void verifyFailure() {
+	void soapEnvelopeMatch() {
+		final Jaxb2Marshaller marshaller = new Jaxb2Marshaller();
+		marshaller.setClassesToBeBound(EnvelopeMatcherRequest.class, EnvelopeMatcherResponse.class);
+
+		template = new WebServiceTemplate(marshaller);
+		template.setDefaultUri("http://example.com");
+		server = MockWebServiceServer.createServer(template);
+
+		Source expectedSoapRequest = new StringSource("""
+				<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+					 <SOAP-ENV:Header/>
+					 <SOAP-ENV:Body>
+						 <EnvelopeMatcherRequest>
+							 <myData>123456</myData>
+						 </EnvelopeMatcherRequest>
+					 </SOAP-ENV:Body>
+				</SOAP-ENV:Envelope>""");
+		Source soapResponse = new StringSource("""
+				<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+				  <SOAP-ENV:Body>
+				    <EnvelopeMatcherResponse>
+				      <myData>654321</myData>
+				    </EnvelopeMatcherResponse>
+				  </SOAP-ENV:Body>
+				</SOAP-ENV:Envelope>""");
+
+		server.expect(soapEnvelope(expectedSoapRequest)).andRespond(withSoapEnvelope(soapResponse));
+
+		final EnvelopeMatcherRequest r = new EnvelopeMatcherRequest();
+		r.setMyData("123456");
+		final EnvelopeMatcherResponse rs = (EnvelopeMatcherResponse) template.marshalSendAndReceive(r);
+
+		assertThat(rs.getMyData()).isEqualTo("654321");
+	}
+
+	@Test
+	void verifyFailure() {
 
 		assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> {
 
@@ -341,12 +379,12 @@ public class MockWebServiceServerTest {
 	}
 
 	@Test
-	public void verifyOnly() {
+	void verifyOnly() {
 		server.verify();
 	}
 
 	@Test
-	public void fault() {
+	void fault() {
 
 		assertThatExceptionOfType(SoapFaultClientException.class).isThrownBy(() -> {
 
@@ -359,7 +397,35 @@ public class MockWebServiceServerTest {
 		});
 	}
 
-	public static class MyClient extends WebServiceGatewaySupport {
+	static class MyClient extends WebServiceGatewaySupport {
 
+
+	}
+	@XmlRootElement(name = "EnvelopeMatcherRequest")
+	private static class EnvelopeMatcherRequest {
+
+		private String myData;
+
+		public String getMyData() {
+			return myData;
+		}
+
+		public void setMyData(final String myData) {
+			this.myData = myData;
+		}
+	}
+
+	@XmlRootElement(name = "EnvelopeMatcherResponse")
+	private static class EnvelopeMatcherResponse {
+
+		private String myData;
+
+		public String getMyData() {
+			return myData;
+		}
+
+		public void setMyData(final String myData) {
+			this.myData = myData;
+		}
 	}
 }


### PR DESCRIPTION
The SoapEnvelopeDiffMatcher was untested at the MockWebServiceServer level. Upgrading to xmlunit2 fixed the issue.

Closes: #1193

I reused the test case described here in https://github.com/spring-projects/spring-ws/issues/1193#issue-861445765 and made by https://github.com/MHajoha.

I also wondered why there where some exclusions configured for xmlunit-assertj as it does not seems to import them. But in doubt, I've let it as is.