### PR TITLE
Better conversion from ByteArrayOutputStream to String.

### DIFF
--- a/spring-ws-support/src/main/java/org/springframework/ws/transport/jms/TextMessageOutputStream.java
+++ b/spring-ws-support/src/main/java/org/springframework/ws/transport/jms/TextMessageOutputStream.java
@@ -50,7 +50,7 @@ class TextMessageOutputStream extends FilterOutputStream {
 		super.flush();
 		try {
 			ByteArrayOutputStream baos = (ByteArrayOutputStream) out;
-			String text = new String(baos.toByteArray(), encoding);
+			String text = baos.toString(encoding);
 			message.setText(text);
 		} catch (JMSException ex) {
 			throw new JmsTransportException(ex);

--- a/spring-ws-support/src/main/java/org/springframework/ws/transport/xmpp/MessageOutputStream.java
+++ b/spring-ws-support/src/main/java/org/springframework/ws/transport/xmpp/MessageOutputStream.java
@@ -48,7 +48,7 @@ class MessageOutputStream extends FilterOutputStream {
 	public void flush() throws IOException {
 		super.flush();
 		ByteArrayOutputStream bos = (ByteArrayOutputStream) out;
-		String text = new String(bos.toByteArray(), encoding);
+		String text = bos.toString(encoding);
 		message.setBody(text);
 	}
 }

--- a/spring-ws-support/src/test/java/org/springframework/ws/transport/jms/JmsMessageSenderIntegrationTest.java
+++ b/spring-ws-support/src/test/java/org/springframework/ws/transport/jms/JmsMessageSenderIntegrationTest.java
@@ -171,7 +171,7 @@ public class JmsMessageSenderIntegrationTest {
 
 			ByteArrayOutputStream bos = new ByteArrayOutputStream();
 			messageFactory.createMessage().writeTo(bos);
-			final String text = new String(bos.toByteArray(), StandardCharsets.UTF_8);
+			final String text = bos.toString(StandardCharsets.UTF_8);
 
 			jmsTemplate.send(request.getJMSReplyTo(), session -> {
 


### PR DESCRIPTION
Converting from an `ByteArrayOutputStream` to `String` by using `new String(output.toByteArray())` creates an unnecessary copy of the data. So `toString()` should be used instead. Also it is easier to read.