### PR TITLE
replace Collections.sort() by List.sort()

### DIFF
--- a/spring-ws-core/src/main/java/org/springframework/ws/server/MessageDispatcher.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/server/MessageDispatcher.java
@@ -403,8 +403,8 @@ public class MessageDispatcher implements WebServiceMessageReceiver, BeanNameAwa
 			Map<String, EndpointAdapter> matchingBeans = BeanFactoryUtils.beansOfTypeIncludingAncestors(applicationContext,
 					EndpointAdapter.class, true, false);
 			if (!matchingBeans.isEmpty()) {
-				endpointAdapters = new ArrayList<EndpointAdapter>(matchingBeans.values());
-				Collections.sort(endpointAdapters, new OrderComparator());
+				endpointAdapters = new ArrayList<>(matchingBeans.values());
+				endpointAdapters.sort(new OrderComparator());
 			} else {
 				endpointAdapters = defaultStrategiesHelper.getDefaultStrategies(EndpointAdapter.class, applicationContext);
 				if (logger.isDebugEnabled()) {
@@ -425,8 +425,8 @@ public class MessageDispatcher implements WebServiceMessageReceiver, BeanNameAwa
 			Map<String, EndpointExceptionResolver> matchingBeans = BeanFactoryUtils
 					.beansOfTypeIncludingAncestors(applicationContext, EndpointExceptionResolver.class, true, false);
 			if (!matchingBeans.isEmpty()) {
-				endpointExceptionResolvers = new ArrayList<EndpointExceptionResolver>(matchingBeans.values());
-				Collections.sort(endpointExceptionResolvers, new OrderComparator());
+				endpointExceptionResolvers = new ArrayList<>(matchingBeans.values());
+				endpointExceptionResolvers.sort(new OrderComparator());
 			} else {
 				endpointExceptionResolvers = defaultStrategiesHelper.getDefaultStrategies(EndpointExceptionResolver.class,
 						applicationContext);
@@ -448,8 +448,8 @@ public class MessageDispatcher implements WebServiceMessageReceiver, BeanNameAwa
 			Map<String, EndpointMapping> matchingBeans = BeanFactoryUtils.beansOfTypeIncludingAncestors(applicationContext,
 					EndpointMapping.class, true, false);
 			if (!matchingBeans.isEmpty()) {
-				endpointMappings = new ArrayList<EndpointMapping>(matchingBeans.values());
-				Collections.sort(endpointMappings, new OrderComparator());
+				endpointMappings = new ArrayList<>(matchingBeans.values());
+				endpointMappings.sort(new OrderComparator());
 			} else {
 				endpointMappings = defaultStrategiesHelper.getDefaultStrategies(EndpointMapping.class, applicationContext);
 				if (logger.isDebugEnabled()) {

--- a/spring-ws-core/src/main/java/org/springframework/ws/support/DefaultStrategiesHelper.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/support/DefaultStrategiesHelper.java
@@ -115,29 +115,27 @@ public class DefaultStrategiesHelper {
 			throws BeanInitializationException {
 		String key = strategyInterface.getName();
 		try {
-			List<T> result;
 			String value = defaultStrategies.getProperty(key);
-			if (value != null) {
-				String[] classNames = StringUtils.commaDelimitedListToStringArray(value);
-				result = new ArrayList<T>(classNames.length);
-				ClassLoader classLoader = null;
-				if (applicationContext != null) {
-					classLoader = applicationContext.getClassLoader();
-				}
-				if (classLoader == null) {
-					classLoader = DefaultStrategiesHelper.class.getClassLoader();
-				}
-				for (String className : classNames) {
-					Class<T> clazz = (Class<T>) ClassUtils.forName(className, classLoader);
-					Assert.isTrue(strategyInterface.isAssignableFrom(clazz),
-							clazz.getName() + " is not a " + strategyInterface.getName());
-					T strategy = instantiateBean(clazz, applicationContext);
-					result.add(strategy);
-				}
-			} else {
-				result = Collections.emptyList();
+			if (value == null) {
+				return Collections.emptyList();
 			}
-			Collections.sort(result, new OrderComparator());
+			String[] classNames = StringUtils.commaDelimitedListToStringArray(value);
+			List<T>  result = new ArrayList<>(classNames.length);
+			ClassLoader classLoader = null;
+			if (applicationContext != null) {
+				classLoader = applicationContext.getClassLoader();
+			}
+			if (classLoader == null) {
+				classLoader = DefaultStrategiesHelper.class.getClassLoader();
+			}
+			for (String className : classNames) {
+				Class<T> clazz = (Class<T>) ClassUtils.forName(className, classLoader);
+				Assert.isTrue(strategyInterface.isAssignableFrom(clazz),
+						clazz.getName() + " is not a " + strategyInterface.getName());
+				T strategy = instantiateBean(clazz, applicationContext);
+				result.add(strategy);
+			}
+			result.sort(new OrderComparator());
 			return result;
 		} catch (ClassNotFoundException ex) {
 			throw new BeanInitializationException("Could not find default strategy class for interface [" + key + "]", ex);


### PR DESCRIPTION
Since java 8 `List.sort()` can be used instead of `Collections.sort() ` to sort an list.
I also refactor `getDefaultStrategies`  to directly `return Collections.emptyList();` if the result of `defaultStrategies.getProperty(key)` is `null`. This reduces the complexity of the method and prevent the not needed call to `sort() `for `Collections.emptyList()`.