### PR TITLE
Remove null checks from instanceof checks.

### DIFF
--- a/spring-ws-core/src/main/java/org/springframework/ws/server/endpoint/MethodEndpoint.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/server/endpoint/MethodEndpoint.java
@@ -156,7 +156,7 @@ public final class MethodEndpoint {
 		if (this == o) {
 			return true;
 		}
-		if (o != null && o instanceof MethodEndpoint) {
+		if (o instanceof MethodEndpoint) {
 			MethodEndpoint other = (MethodEndpoint) o;
 			return this.bean.equals(other.bean) && this.method.equals(other.method);
 		}

--- a/spring-ws-core/src/main/java/org/springframework/ws/server/endpoint/adapter/XPathParamAnnotationMethodEndpointAdapter.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/server/endpoint/adapter/XPathParamAnnotationMethodEndpointAdapter.java
@@ -127,7 +127,7 @@ public class XPathParamAnnotationMethodEndpointAdapter extends AbstractMethodEnd
 		Element payloadElement = getRootElement(messageContext.getRequest().getPayloadSource());
 		Object[] args = getMethodArguments(payloadElement, methodEndpoint.getMethod());
 		Object result = methodEndpoint.invoke(args);
-		if (result != null && result instanceof Source) {
+		if (result instanceof Source) {
 			Source responseSource = (Source) result;
 			WebServiceMessage response = messageContext.getResponse();
 			transform(responseSource, response.getPayloadResult());

--- a/spring-ws-core/src/main/java/org/springframework/ws/soap/addressing/core/EndpointReference.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/soap/addressing/core/EndpointReference.java
@@ -90,7 +90,7 @@ public final class EndpointReference implements Serializable {
 		if (this == o) {
 			return true;
 		}
-		if (o != null && o instanceof EndpointReference) {
+		if (o instanceof EndpointReference) {
 			EndpointReference other = (EndpointReference) o;
 			return address.equals(other.address);
 		}

--- a/spring-ws-security/src/main/java/org/springframework/ws/soap/security/wss4j2/Wss4jSecurityInterceptor.java
+++ b/spring-ws-security/src/main/java/org/springframework/ws/soap/security/wss4j2/Wss4jSecurityInterceptor.java
@@ -852,7 +852,7 @@ public class Wss4jSecurityInterceptor extends AbstractWsSecurityInterceptor impl
 		if (!CollectionUtils.isEmpty(results)) {
 			WSSecurityEngineResult actionResult = results.get(0);
 			Principal principal = (Principal) actionResult.get(WSSecurityEngineResult.TAG_PRINCIPAL);
-			if (principal != null && principal instanceof WSUsernameTokenPrincipalImpl) {
+			if (principal instanceof WSUsernameTokenPrincipalImpl) {
 				WSUsernameTokenPrincipalImpl usernameTokenPrincipal = (WSUsernameTokenPrincipalImpl) principal;
 				UsernameTokenPrincipalCallback callback = new UsernameTokenPrincipalCallback(usernameTokenPrincipal);
 				try {

--- a/spring-xml/src/main/java/org/springframework/xml/namespace/QNameEditor.java
+++ b/spring-xml/src/main/java/org/springframework/xml/namespace/QNameEditor.java
@@ -62,7 +62,7 @@ public class QNameEditor extends PropertyEditorSupport {
 	@Override
 	public String getAsText() {
 		Object value = getValue();
-		if (value == null || !(value instanceof QName)) {
+		if (!(value instanceof QName)) {
 			return "";
 		} else {
 			QName qName = (QName) value;


### PR DESCRIPTION
In Java an `instanceof` check always includes an null check. So there is no need for an explicit null check.