### PR TITLE
use Collections.emptyIterator() instead of iterator of an emptyList

### DIFF
--- a/spring-ws-core/src/main/java/org/springframework/ws/transport/http/ClientHttpRequestConnection.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/transport/http/ClientHttpRequestConnection.java
@@ -98,7 +98,7 @@ public class ClientHttpRequestConnection extends AbstractHttpSenderConnection {
 	@Override
 	public Iterator<String> getResponseHeaders(String name) throws IOException {
 		List<String> headers = response.getHeaders().get(name);
-		return headers != null ? headers.iterator() : Collections.<String> emptyList().iterator();
+		return headers != null ? headers.iterator() : Collections.emptyIterator();
 	}
 
 	@Override

--- a/spring-ws-core/src/main/java/org/springframework/ws/transport/http/HttpUrlConnection.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/transport/http/HttpUrlConnection.java
@@ -132,7 +132,7 @@ public class HttpUrlConnection extends AbstractHttpSenderConnection {
 		List<String> headerValues = headersListMappedByLowerCaseName.get(name.toLowerCase());
 
 		if (headerValues == null) {
-			return Collections.<String> emptyList().iterator();
+			return Collections.emptyIterator();
 		} else {
 			return headerValues.iterator();
 		}

--- a/spring-ws-support/src/main/java/org/springframework/ws/transport/http/HttpExchangeConnection.java
+++ b/spring-ws-support/src/main/java/org/springframework/ws/transport/http/HttpExchangeConnection.java
@@ -109,7 +109,7 @@ public class HttpExchangeConnection extends AbstractReceiverConnection
 	@Override
 	public Iterator<String> getRequestHeaders(String name) throws IOException {
 		List<String> headers = httpExchange.getRequestHeaders().get(name);
-		return headers != null ? headers.iterator() : Collections.<String> emptyList().iterator();
+		return headers != null ? headers.iterator() : Collections.emptyIterator();
 	}
 
 	@Override

--- a/spring-ws-support/src/main/java/org/springframework/ws/transport/jms/support/JmsTransportUtils.java
+++ b/spring-ws-support/src/main/java/org/springframework/ws/transport/jms/support/JmsTransportUtils.java
@@ -154,7 +154,7 @@ public abstract class JmsTransportUtils {
 		if (value != null) {
 			return Collections.singletonList(value).iterator();
 		} else {
-			return Collections.<String> emptyList().iterator();
+			return Collections.emptyIterator();
 		}
 	}
 

--- a/spring-ws-support/src/main/java/org/springframework/ws/transport/xmpp/support/XmppTransportUtils.java
+++ b/spring-ws-support/src/main/java/org/springframework/ws/transport/xmpp/support/XmppTransportUtils.java
@@ -74,7 +74,7 @@ public abstract class XmppTransportUtils {
 		if (value != null) {
 			return Collections.singletonList(value).iterator();
 		} else {
-			return Collections.<String> emptyList().iterator();
+			return Collections.emptyIterator();
 		}
 	}
 


### PR DESCRIPTION
Since Java 7 `Collections` provides an `emptyIterator`. This should be unused instead of an iterator of an `emptyList`. Also it is easier to read.