### PR TITLE
Remove unnecessary boxing for integers

### DIFF
--- a/spring-ws-core/src/main/java/org/springframework/ws/transport/http/LocationTransformerObjectSupport.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/transport/http/LocationTransformerObjectSupport.java
@@ -94,7 +94,7 @@ public abstract class LocationTransformerObjectSupport extends TransformerObject
 
 		String scheme = StringUtils.hasText(xForwardedProto) ? xForwardedProto : request.getScheme();
 		String serverName = StringUtils.hasText(xForwardedHost) ? xForwardedHost : request.getServerName();
-		int serverPort = StringUtils.hasText(xForwardedPort) ? Integer.valueOf(xForwardedPort) : request.getServerPort();
+		int serverPort = StringUtils.hasText(xForwardedPort) ? Integer.parseInt(xForwardedPort) : request.getServerPort();
 
 		StringBuilder url = new StringBuilder(scheme);
 		url.append("://").append(serverName).append(':').append(serverPort);

--- a/spring-ws-core/src/test/java/org/springframework/ws/server/endpoint/adapter/DefaultMethodEndpointAdapterTest.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/server/endpoint/adapter/DefaultMethodEndpointAdapterTest.java
@@ -142,7 +142,7 @@ public class DefaultMethodEndpointAdapterTest {
 		expect(argumentResolver1.supportsParameter(isA(MethodParameter.class))).andReturn(false);
 		expect(argumentResolver2.supportsParameter(isA(MethodParameter.class))).andReturn(true);
 		expect(argumentResolver2.resolveArgument(eq(messageContext), isA(MethodParameter.class)))
-				.andReturn(new Integer(42));
+				.andReturn(42);
 
 		expect(returnValueHandler.supportsReturnType(isA(MethodParameter.class))).andReturn(true);
 		returnValueHandler.handleReturnValue(eq(messageContext), isA(MethodParameter.class), eq(value));


### PR DESCRIPTION
`Integer.valueOf` returns an `Integer`. In this case the target type is `int`. So `Integer.parseInt` prevents unnecessary boxing.

`new Integer(42)` is deprecated and auto boxing will be used to convert from an `int` to an `Integer` if needed.