### PR TITLE
use StandardCharsets.UTF_8 instead of String

### DIFF
--- a/spring-ws-core/src/main/java/org/springframework/ws/client/core/WebServiceTemplate.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/client/core/WebServiceTemplate.java
@@ -19,6 +19,7 @@ package org.springframework.ws.client.core;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import javax.xml.transform.*;
@@ -619,7 +620,7 @@ public class WebServiceTemplate extends WebServiceAccessor implements WebService
 		if (sentMessageTracingLogger.isTraceEnabled()) {
 			ByteArrayOutputStream os = new ByteArrayOutputStream();
 			request.writeTo(os);
-			sentMessageTracingLogger.trace("Sent request [" + os.toString("UTF-8") + "]");
+			sentMessageTracingLogger.trace("Sent request [" + os.toString(StandardCharsets.UTF_8) + "]");
 		} else if (sentMessageTracingLogger.isDebugEnabled()) {
 			sentMessageTracingLogger.debug("Sent request [" + request + "]");
 		}
@@ -672,8 +673,8 @@ public class WebServiceTemplate extends WebServiceAccessor implements WebService
 				messageContext.getRequest().writeTo(requestStream);
 				ByteArrayOutputStream responseStream = new ByteArrayOutputStream();
 				messageContext.getResponse().writeTo(responseStream);
-				receivedMessageTracingLogger.trace("Received response [" + responseStream.toString("UTF-8") + "] for request ["
-						+ requestStream.toString("UTF-8") + "]");
+				receivedMessageTracingLogger.trace("Received response [" + responseStream.toString(StandardCharsets.UTF_8) + "] for request ["
+						+ requestStream.toString(StandardCharsets.UTF_8) + "]");
 			} else if (receivedMessageTracingLogger.isDebugEnabled()) {
 				receivedMessageTracingLogger.debug("Received response [" + messageContext.getResponse() + "] for request ["
 						+ messageContext.getRequest() + "]");

--- a/spring-ws-core/src/main/java/org/springframework/ws/server/MessageDispatcher.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/server/MessageDispatcher.java
@@ -18,6 +18,7 @@ package org.springframework.ws.server;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -189,7 +190,7 @@ public class MessageDispatcher implements WebServiceMessageReceiver, BeanNameAwa
 	private String getMessageContent(WebServiceMessage message) throws IOException {
 		ByteArrayOutputStream bos = new ByteArrayOutputStream();
 		message.writeTo(bos);
-		return bos.toString("UTF-8");
+		return bos.toString(StandardCharsets.UTF_8);
 	}
 
 	/**

--- a/spring-ws-core/src/test/java/org/springframework/ws/AbstractWebServiceMessageTestCase.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/AbstractWebServiceMessageTestCase.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -71,7 +72,7 @@ public abstract class AbstractWebServiceMessageTestCase {
 	private String getExpectedString() throws IOException {
 
 		StringWriter expectedWriter = new StringWriter();
-		FileCopyUtils.copy(new InputStreamReader(payload.getInputStream(), "UTF-8"), expectedWriter);
+		FileCopyUtils.copy(new InputStreamReader(payload.getInputStream(), StandardCharsets.UTF_8), expectedWriter);
 		return expectedWriter.toString();
 	}
 
@@ -124,7 +125,7 @@ public abstract class AbstractWebServiceMessageTestCase {
 	@Test
 	public void testReaderPayload() throws Exception {
 
-		Reader reader = new InputStreamReader(payload.getInputStream(), "UTF-8");
+		Reader reader = new InputStreamReader(payload.getInputStream(), StandardCharsets.UTF_8);
 		StreamSource streamSource = new StreamSource(reader, payload.getURL().toString());
 		transformer.transform(streamSource, webServiceMessage.getPayloadResult());
 		StringWriter resultWriter = new StringWriter();
@@ -158,7 +159,7 @@ public abstract class AbstractWebServiceMessageTestCase {
 		ByteArrayOutputStream expectedStream = new ByteArrayOutputStream();
 		FileCopyUtils.copy(payload.getInputStream(), expectedStream);
 
-		assertThat(resultStream.toString("UTF-8")).and(expectedStream.toString("UTF-8")).ignoreWhitespace().areIdentical();
+		assertThat(resultStream.toString(StandardCharsets.UTF_8)).and(expectedStream.toString(StandardCharsets.UTF_8)).ignoreWhitespace().areIdentical();
 
 		validateMessage();
 	}

--- a/spring-ws-core/src/test/java/org/springframework/ws/pox/dom/DomPoxMessageTest.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/pox/dom/DomPoxMessageTest.java
@@ -19,6 +19,7 @@ package org.springframework.ws.pox.dom;
 import static org.xmlunit.assertj.XmlAssert.*;
 
 import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -83,6 +84,6 @@ public class DomPoxMessageTest {
 		ByteArrayOutputStream os = new ByteArrayOutputStream();
 		message.writeTo(os);
 
-		assertThat(os.toString("UTF-8")).and(content).ignoreWhitespace().areIdentical();
+		assertThat(os.toString(StandardCharsets.UTF_8)).and(content).ignoreWhitespace().areIdentical();
 	}
 }

--- a/spring-ws-core/src/test/java/org/springframework/ws/server/endpoint/AbstractEndpointTestCase.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/server/endpoint/AbstractEndpointTestCase.java
@@ -20,6 +20,7 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.io.Reader;
 import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -90,7 +91,7 @@ public abstract class AbstractEndpointTestCase {
 	@Test
 	public void testStreamSourceInputStream() throws Exception {
 
-		InputStream is = new ByteArrayInputStream(REQUEST.getBytes("UTF-8"));
+		InputStream is = new ByteArrayInputStream(REQUEST.getBytes(StandardCharsets.UTF_8));
 		testSource(new StreamSource(is));
 	}
 

--- a/spring-ws-core/src/test/java/org/springframework/ws/soap/saaj/SaajSoap11MessageFactoryTest.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/soap/saaj/SaajSoap11MessageFactoryTest.java
@@ -24,6 +24,7 @@ import jakarta.xml.soap.SOAPMessage;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Map;
 
@@ -49,7 +50,7 @@ public class SaajSoap11MessageFactoryTest extends AbstractSoap11MessageFactoryTe
 		SoapMessage soapMessage = (SoapMessage) messageFactory.createWebServiceMessage();
 		ByteArrayOutputStream os = new ByteArrayOutputStream();
 		soapMessage.writeTo(os);
-		String result = os.toString("UTF-8");
+		String result = os.toString(StandardCharsets.UTF_8);
 
 		assertThat(result).startsWith("<?xml version=\"1.0\"");
 	}

--- a/spring-ws-core/src/test/java/org/springframework/ws/soap/soap11/AbstractSoap11MessageTestCase.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/soap/soap11/AbstractSoap11MessageTestCase.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.*;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -64,7 +65,7 @@ public abstract class AbstractSoap11MessageTestCase extends AbstractSoapMessageT
 		String soapAction = "http://springframework.org/spring-ws/Action";
 		soapMessage.setSoapAction(soapAction);
 		soapMessage.writeTo(tos);
-		String result = bos.toString("UTF-8");
+		String result = bos.toString(StandardCharsets.UTF_8);
 
 		XmlAssert.assertThat(result)
 				.and("<" + getNS() + ":Envelope xmlns:" + getNS() + "='http://schemas.xmlsoap.org/soap/envelope/'>"
@@ -88,7 +89,7 @@ public abstract class AbstractSoap11MessageTestCase extends AbstractSoapMessageT
 	@Override
 	public void testWriteToTransportResponseAttachment() throws Exception {
 
-		InputStreamSource inputStreamSource = new ByteArrayResource("contents".getBytes("UTF-8"));
+		InputStreamSource inputStreamSource = new ByteArrayResource("contents".getBytes(StandardCharsets.UTF_8));
 		soapMessage.addAttachment("contentId", inputStreamSource, "text/plain");
 		ByteArrayOutputStream bos = new ByteArrayOutputStream();
 		MockTransportOutputStream tos = new MockTransportOutputStream(bos);
@@ -140,7 +141,7 @@ public abstract class AbstractSoap11MessageTestCase extends AbstractSoapMessageT
 		ByteArrayOutputStream bos = new ByteArrayOutputStream();
 		soapMessage.writeTo(bos);
 
-		String result = bos.toString("UTF-8");
+		String result = bos.toString(StandardCharsets.UTF_8);
 
 		XmlAssert.assertThat(result)
 				.and("<" + getNS() + ":Envelope xmlns:" + getNS() + "='http://schemas.xmlsoap.org/soap/envelope/'>"
@@ -169,7 +170,7 @@ public abstract class AbstractSoap11MessageTestCase extends AbstractSoapMessageT
 		bos = new ByteArrayOutputStream();
 		soapMessage.writeTo(bos);
 
-		String result = bos.toString("UTF-8");
+		String result = bos.toString(StandardCharsets.UTF_8);
 
 		XmlAssert.assertThat(result)
 				.and("<" + getNS() + ":Envelope xmlns:" + getNS() + "='http://schemas.xmlsoap.org/soap/envelope/'>"

--- a/spring-ws-core/src/test/java/org/springframework/ws/soap/soap12/AbstractSoap12MessageTestCase.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/soap/soap12/AbstractSoap12MessageTestCase.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.*;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -67,7 +68,7 @@ public abstract class AbstractSoap12MessageTestCase extends AbstractSoapMessageT
 		String soapAction = "http://springframework.org/spring-ws/Action";
 		soapMessage.setSoapAction(soapAction);
 		soapMessage.writeTo(tos);
-		String result = bos.toString("UTF-8");
+		String result = bos.toString(StandardCharsets.UTF_8);
 
 		XmlAssert.assertThat(result)
 				.and("<" + getNS() + ":Envelope xmlns:" + getNS() + "='http://www.w3.org/2003/05/soap-envelope'>" + getHeader()
@@ -89,7 +90,7 @@ public abstract class AbstractSoap12MessageTestCase extends AbstractSoapMessageT
 	@Override
 	public void testWriteToTransportResponseAttachment() throws Exception {
 
-		InputStreamSource inputStreamSource = new ByteArrayResource("contents".getBytes("UTF-8"));
+		InputStreamSource inputStreamSource = new ByteArrayResource("contents".getBytes(StandardCharsets.UTF_8));
 		soapMessage.addAttachment("contentId", inputStreamSource, "text/plain");
 		ByteArrayOutputStream bos = new ByteArrayOutputStream();
 		MockTransportOutputStream tos = new MockTransportOutputStream(bos);
@@ -141,7 +142,7 @@ public abstract class AbstractSoap12MessageTestCase extends AbstractSoapMessageT
 		ByteArrayOutputStream bos = new ByteArrayOutputStream();
 		soapMessage.writeTo(bos);
 
-		String result = bos.toString("UTF-8");
+		String result = bos.toString(StandardCharsets.UTF_8);
 
 		XmlAssert.assertThat(result)
 				.and("<" + getNS() + ":Envelope xmlns:" + getNS() + "='http://www.w3.org/2003/05/soap-envelope'>" + getHeader()
@@ -170,7 +171,7 @@ public abstract class AbstractSoap12MessageTestCase extends AbstractSoapMessageT
 		bos = new ByteArrayOutputStream();
 		soapMessage.writeTo(bos);
 
-		String result = bos.toString("UTF-8");
+		String result = bos.toString(StandardCharsets.UTF_8);
 
 		XmlAssert.assertThat(result)
 				.and("<" + getNS() + ":Envelope xmlns:" + getNS() + "='http://www.w3.org/2003/05/soap-envelope'>" + getHeader()

--- a/spring-ws-core/src/test/java/org/springframework/ws/transport/http/AbstractHttpWebServiceMessageSenderIntegrationTestCase.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/transport/http/AbstractHttpWebServiceMessageSenderIntegrationTestCase.java
@@ -289,7 +289,7 @@ public abstract class AbstractHttpWebServiceMessageSenderIntegrationTestCase<T e
 				assertThat(httpServletRequest.getHeader(REQUEST_HEADER_NAME)).isEqualTo(REQUEST_HEADER_VALUE);
 
 				String receivedRequest = new String(FileCopyUtils.copyToByteArray(httpServletRequest.getInputStream()),
-						"UTF-8");
+						StandardCharsets.UTF_8);
 
 				XmlAssert.assertThat(receivedRequest).and(SOAP_REQUEST).ignoreWhitespace().areIdentical();
 

--- a/spring-ws-core/src/test/java/org/springframework/ws/transport/http/HttpServletConnectionTest.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/transport/http/HttpServletConnectionTest.java
@@ -24,6 +24,7 @@ import jakarta.xml.soap.SOAPConstants;
 import jakarta.xml.soap.SOAPMessage;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerFactory;
@@ -75,7 +76,7 @@ public class HttpServletConnectionTest {
 	@Test
 	public void receive() throws Exception {
 
-		byte[] bytes = SOAP_CONTENT.getBytes("UTF-8");
+		byte[] bytes = SOAP_CONTENT.getBytes(StandardCharsets.UTF_8);
 		httpServletRequest.addHeader("Content-Type", "text/xml");
 		httpServletRequest.addHeader("Content-Length", Integer.toString(bytes.length));
 		httpServletRequest.addHeader(HEADER_NAME, HEADER_VALUE);

--- a/spring-ws-security/src/test/java/org/springframework/ws/soap/security/wss4j2/Wss4jMessageInterceptorHeaderTestCase.java
+++ b/spring-ws-security/src/test/java/org/springframework/ws/soap/security/wss4j2/Wss4jMessageInterceptorHeaderTestCase.java
@@ -19,6 +19,7 @@ package org.springframework.ws.soap.security.wss4j2;
 import static org.assertj.core.api.Assertions.*;
 
 import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 import java.util.Properties;
 
@@ -140,7 +141,7 @@ public abstract class Wss4jMessageInterceptorHeaderTestCase extends Wss4jTestCas
 		SoapMessage message = loadSoap11Message("customHeader-soap.xml");
 		MessageContext messageContext = new DefaultMessageContext(message, getSoap11MessageFactory());
 		message.writeTo(os);
-		String document = os.toString("UTF-8");
+		String document = os.toString(StandardCharsets.UTF_8);
 
 		assertXpathEvaluatesTo("Header 1 does not exist", "test1", "/SOAP-ENV:Envelope/SOAP-ENV:Header/test:header1",
 				document);
@@ -153,7 +154,7 @@ public abstract class Wss4jMessageInterceptorHeaderTestCase extends Wss4jTestCas
 
 		os = new ByteArrayOutputStream();
 		message.writeTo(os);
-		document = os.toString("UTF-8");
+		document = os.toString(StandardCharsets.UTF_8);
 
 		assertXpathEvaluatesTo("Header 1 does not exist", "test1", "/SOAP-ENV:Envelope/SOAP-ENV:Header/test:header1",
 				document);
@@ -162,7 +163,7 @@ public abstract class Wss4jMessageInterceptorHeaderTestCase extends Wss4jTestCas
 
 		os = new ByteArrayOutputStream();
 		message.writeTo(os);
-		document = os.toString("UTF-8");
+		document = os.toString(StandardCharsets.UTF_8);
 
 		assertXpathEvaluatesTo("Header 1 does not exist", "test1", "/SOAP-ENV:Envelope/SOAP-ENV:Header/test:header1",
 				document);

--- a/spring-ws-test/src/test/java/org/springframework/ws/test/client/ResponseCreatorsTest.java
+++ b/spring-ws-test/src/test/java/org/springframework/ws/test/client/ResponseCreatorsTest.java
@@ -19,6 +19,7 @@ package org.springframework.ws.test.client;
 import static org.assertj.core.api.Assertions.*;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 
 import javax.xml.namespace.QName;
@@ -67,7 +68,7 @@ public class ResponseCreatorsTest {
 	public void withPayloadResource() throws Exception {
 
 		String payload = "<payload xmlns='http://springframework.org'/>";
-		ResponseCreator responseCreator = ResponseCreators.withPayload(new ByteArrayResource(payload.getBytes("UTF-8")));
+		ResponseCreator responseCreator = ResponseCreators.withPayload(new ByteArrayResource(payload.getBytes(StandardCharsets.UTF_8)));
 
 		WebServiceMessage response = responseCreator.createResponse(null, null, messageFactory);
 
@@ -101,7 +102,7 @@ public class ResponseCreatorsTest {
 		xmlBuilder.append("</soap:Envelope>");
 		String envelope = xmlBuilder.toString();
 		ResponseCreator responseCreator = ResponseCreators
-				.withSoapEnvelope(new ByteArrayResource(envelope.getBytes("UTF-8")));
+				.withSoapEnvelope(new ByteArrayResource(envelope.getBytes(StandardCharsets.UTF_8)));
 		WebServiceMessage response = responseCreator.createResponse(null, null, messageFactory);
 
 		XmlAssert.assertThat(getSoapEnvelopeAsString((SoapMessage) response)).and(envelope).ignoreWhitespace().areSimilar();


### PR DESCRIPTION
Since Java 1.7 `StandardCharsets` can be used. It prevent the unnecessary lookup of a charset from String. Also it is easier to read.