### PR TITLE
Use bulk operation addAll instead of iteration.

### DIFF
--- a/spring-xml/src/main/java/org/springframework/xml/xsd/commons/CommonsXsdSchemaCollection.java
+++ b/spring-xml/src/main/java/org/springframework/xml/xsd/commons/CommonsXsdSchemaCollection.java
@@ -189,10 +189,7 @@ public class CommonsXsdSchemaCollection implements XsdSchemaCollection, Initiali
 				if (!processedIncludes.contains(includedSchema)) {
 					inlineIncludes(includedSchema, processedIncludes, processedImports);
 					findImports(includedSchema, processedImports, processedIncludes);
-					List<XmlSchemaObject> includeItems = includedSchema.getItems();
-					for (XmlSchemaObject includedItem : includeItems) {
-						schemaItems.add(includedItem);
-					}
+					schemaItems.addAll(includedSchema.getItems());
 				}
 				// remove the <include/>
 				schemaItems.remove(i);


### PR DESCRIPTION
Using `addAll()` makes the code easier to read and could provide a small speedup. So it should be used instead of an iteration.