### PR TITLE
 Apache HttpClient 5.0 followup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -274,7 +274,11 @@
                     </argLine>
                 </configuration>
             </plugin>
-
+            <plugin>
+                <groupId>io.spring.javaformat</groupId>
+                <artifactId>spring-javaformat-maven-plugin</artifactId>
+                <version>0.0.38</version>
+            </plugin>
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -274,11 +274,9 @@
                     </argLine>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>io.spring.javaformat</groupId>
-                <artifactId>spring-javaformat-maven-plugin</artifactId>
-                <version>0.0.38</version>
-            </plugin>
+
+
+
         </plugins>
     </build>
 

--- a/spring-ws-core/src/main/java/org/springframework/ws/transport/http/HttpComponents5ClientFactory.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/transport/http/HttpComponents5ClientFactory.java
@@ -33,6 +33,7 @@ import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuil
 import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.util.Timeout;
 import org.springframework.beans.factory.FactoryBean;
+import org.springframework.ws.client.support.interceptor.ClientInterceptor;
 
 /**
  * {@link FactoryBean} to set up a {@link CloseableHttpClient} using HttpComponents HttpClient 5.
@@ -45,6 +46,11 @@ public class HttpComponents5ClientFactory implements FactoryBean<CloseableHttpCl
 
 	/**
 	 * AuthScope to match any Host.
+	 * <p>
+	 * <b>HEADS-UP</b>: ANY has been removed from {@link AuthScope} since httpcomponents version 5.x. It has been
+	 * redefined here to ease migration from httpcomponents 4. The associated functionality might be removed in a future
+	 * version of apache httpcomponents. Consider using a {@link ClientInterceptor} to implement http client agnostic
+	 * preemptive basic auth.
 	 *
 	 * @see AuthScope#AuthScope(String, String, int, String, String)
 	 */

--- a/spring-ws-core/src/main/java/org/springframework/ws/transport/http/HttpComponents5ClientFactory.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/transport/http/HttpComponents5ClientFactory.java
@@ -32,6 +32,7 @@ import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
 import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.util.Timeout;
+
 import org.springframework.beans.factory.FactoryBean;
 
 /**
@@ -66,10 +67,12 @@ public class HttpComponents5ClientFactory implements FactoryBean<CloseableHttpCl
 	private PoolingHttpClientConnectionManagerBuilderCustomizer connectionManagerBuilderCustomizer;
 
 	/**
-	 * Sets the credentials to be used. If not set, no authentication is done.
+	 * Sets the credentials to be used. If not set, no authentication is done. Only used
+	 * when the {@code authScope} property has been set.
 	 *
 	 * @see org.apache.hc.client5.http.auth.UsernamePasswordCredentials
 	 * @see org.apache.hc.client5.http.auth.NTCredentials
+	 * @see #setAuthScope(AuthScope)
 	 */
 	public void setCredentials(Credentials credentials) {
 		this.credentials = credentials;
@@ -78,7 +81,6 @@ public class HttpComponents5ClientFactory implements FactoryBean<CloseableHttpCl
 	/**
 	 * Sets the authentication scope to be used. Only used when the {@code credentials} property has been set.
 	 * <p>
-	 * By default, the {@link AuthScope#ANY} is used.
 	 *
 	 * @see #setCredentials(Credentials)
 	 */

--- a/spring-ws-core/src/main/java/org/springframework/ws/transport/http/HttpComponents5ClientFactory.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/transport/http/HttpComponents5ClientFactory.java
@@ -32,7 +32,6 @@ import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
 import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.util.Timeout;
-
 import org.springframework.beans.factory.FactoryBean;
 
 /**
@@ -67,12 +66,10 @@ public class HttpComponents5ClientFactory implements FactoryBean<CloseableHttpCl
 	private PoolingHttpClientConnectionManagerBuilderCustomizer connectionManagerBuilderCustomizer;
 
 	/**
-	 * Sets the credentials to be used. If not set, no authentication is done. Only used
-	 * when the {@code authScope} property has been set.
+	 * Sets the credentials to be used. If not set, no authentication is done.
 	 *
 	 * @see org.apache.hc.client5.http.auth.UsernamePasswordCredentials
 	 * @see org.apache.hc.client5.http.auth.NTCredentials
-	 * @see #setAuthScope(AuthScope)
 	 */
 	public void setCredentials(Credentials credentials) {
 		this.credentials = credentials;
@@ -81,6 +78,7 @@ public class HttpComponents5ClientFactory implements FactoryBean<CloseableHttpCl
 	/**
 	 * Sets the authentication scope to be used. Only used when the {@code credentials} property has been set.
 	 * <p>
+	 * By default, the {@link AuthScope#ANY} is used.
 	 *
 	 * @see #setCredentials(Credentials)
 	 */

--- a/spring-ws-core/src/main/java/org/springframework/ws/transport/http/HttpComponents5ClientFactory.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/transport/http/HttpComponents5ClientFactory.java
@@ -43,6 +43,13 @@ import org.springframework.beans.factory.FactoryBean;
  */
 public class HttpComponents5ClientFactory implements FactoryBean<CloseableHttpClient> {
 
+	/**
+	 * AuthScope to match any Host.
+	 *
+	 * @see AuthScope#AuthScope(String, String, int, String, String)
+	 */
+	public static final AuthScope ANY = new AuthScope(null, null, -1, null, null);
+
 	private static final Duration DEFAULT_CONNECTION_TIMEOUT = Duration.ofSeconds(60);
 
 	private static final Duration DEFAULT_READ_TIMEOUT = Duration.ofSeconds(60);
@@ -53,7 +60,7 @@ public class HttpComponents5ClientFactory implements FactoryBean<CloseableHttpCl
 
 	private int maxTotalConnections = -1;
 
-	private AuthScope authScope = null;
+	private AuthScope authScope = ANY;
 
 	private Credentials credentials = null;
 
@@ -78,7 +85,7 @@ public class HttpComponents5ClientFactory implements FactoryBean<CloseableHttpCl
 	/**
 	 * Sets the authentication scope to be used. Only used when the {@code credentials} property has been set.
 	 * <p>
-	 * By default, the {@link AuthScope#ANY} is used.
+	 * By default, the {@link #ANY} is used.
 	 *
 	 * @see #setCredentials(Credentials)
 	 */

--- a/spring-ws-core/src/main/java/org/springframework/ws/transport/http/HttpComponents5MessageSender.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/transport/http/HttpComponents5MessageSender.java
@@ -40,11 +40,13 @@ import org.springframework.util.Assert;
 import org.springframework.ws.transport.WebServiceConnection;
 
 /**
- * {@code WebServiceMessageSender} implementation that uses <a href="http://hc.apache.org/httpcomponents-client">Apache
- * HttpClient</a> to execute POST requests.
+ * {@code WebServiceMessageSender} implementation that uses
+ * <a href="http://hc.apache.org/httpcomponents-client">Apache HttpClient</a> to execute
+ * POST requests.
  * <p>
- * Allows to use a pre-configured HttpClient instance, potentially with authentication, HTTP connection pooling, etc.
- * Authentication can also be set by injecting a {@link Credentials} instance (such as the
+ * Allows to use a pre-configured HttpClient instance, potentially with authentication,
+ * HTTP connection pooling, etc. Authentication can also be set by injecting a
+ * {@link Credentials} instance (such as the
  * {@link org.apache.hc.client5.http.auth.UsernamePasswordCredentials}).
  *
  * @author Alan Stewart
@@ -65,8 +67,8 @@ public class HttpComponents5MessageSender extends AbstractHttpWebServiceMessageS
 	private HttpComponents5ClientFactory clientFactory;
 
 	/**
-	 * Create a new instance of the {@code HttpClientMessageSender} with a default {@link HttpClient} that uses a default
-	 * {@link PoolingHttpClientConnectionManager}.
+	 * Create a new instance of the {@code HttpClientMessageSender} with a default
+	 * {@link HttpClient} that uses a default {@link PoolingHttpClientConnectionManager}.
 	 */
 	public HttpComponents5MessageSender() {
 
@@ -76,12 +78,13 @@ public class HttpComponents5MessageSender extends AbstractHttpWebServiceMessageS
 	}
 
 	/**
-	 * Create a new instance of the {@link HttpComponents5MessageSender} with the given {@link HttpClient} instance.
+	 * Create a new instance of the {@link HttpComponents5MessageSender} with the given
+	 * {@link HttpClient} instance.
 	 * <p>
-	 * This constructor does not change the given {@code HttpClient} in any way. As such, it does not set timeouts, nor
-	 * does it {@linkplain HttpClientBuilder#addRequestInterceptorFirst(HttpRequestInterceptor) add} the
-	 * {@link RemoveSoapHeadersInterceptor}.
-	 *
+	 * This constructor does not change the given {@code HttpClient} in any way. As such,
+	 * it does not set timeouts, nor does it
+	 * {@linkplain HttpClientBuilder#addRequestInterceptorFirst(HttpRequestInterceptor)
+	 * add} the {@link RemoveSoapHeadersInterceptor}.
 	 * @param httpClient the HttpClient instance to use for this sender
 	 */
 	public HttpComponents5MessageSender(HttpClient httpClient) {
@@ -187,7 +190,8 @@ public class HttpComponents5MessageSender extends AbstractHttpWebServiceMessageS
 		HttpPost httpPost = new HttpPost(uri);
 
 		if (isAcceptGzipEncoding()) {
-			httpPost.addHeader(HttpTransportConstants.HEADER_ACCEPT_ENCODING, HttpTransportConstants.CONTENT_ENCODING_GZIP);
+			httpPost.addHeader(HttpTransportConstants.HEADER_ACCEPT_ENCODING,
+					HttpTransportConstants.CONTENT_ENCODING_GZIP);
 		}
 
 		HttpContext httpContext = createContext(uri);
@@ -196,9 +200,8 @@ public class HttpComponents5MessageSender extends AbstractHttpWebServiceMessageS
 	}
 
 	/**
-	 * Template method that allows for creation of an {@link HttpContext} for the given uri. Default implementation returns
-	 * {@code null}.
-	 *
+	 * Template method that allows for creation of an {@link HttpContext} for the given
+	 * uri. Default implementation returns {@code null}.
 	 * @param uri the URI to create the context for
 	 * @return the context, or {@code null}
 	 */
@@ -209,15 +212,16 @@ public class HttpComponents5MessageSender extends AbstractHttpWebServiceMessageS
 	@Override
 	public void destroy() throws Exception {
 
-		if (getHttpClient()instanceof CloseableHttpClient client) {
+		if (getHttpClient() instanceof CloseableHttpClient client) {
 			client.close();
 		}
 	}
 
 	/**
-	 * HttpClient {@link HttpRequestInterceptor} implementation that removes {@code Content-Length} and
-	 * {@code Transfer-Encoding} headers from the request. Necessary, because some SAAJ and other SOAP implementations set
-	 * these headers themselves, and HttpClient throws an exception if they have been set.
+	 * HttpClient {@link HttpRequestInterceptor} implementation that removes
+	 * {@code Content-Length} and {@code Transfer-Encoding} headers from the request.
+	 * Necessary, because some SAAJ and other SOAP implementations set these headers
+	 * themselves, and HttpClient throws an exception if they have been set.
 	 */
 	public static class RemoveSoapHeadersInterceptor implements HttpRequestInterceptor {
 
@@ -233,5 +237,7 @@ public class HttpComponents5MessageSender extends AbstractHttpWebServiceMessageS
 				request.removeHeaders(HttpHeaders.CONTENT_LENGTH);
 			}
 		}
+
 	}
+
 }

--- a/spring-ws-core/src/main/java/org/springframework/ws/transport/http/HttpComponents5MessageSender.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/transport/http/HttpComponents5MessageSender.java
@@ -180,7 +180,7 @@ public class HttpComponents5MessageSender extends AbstractHttpWebServiceMessageS
 	@Override
 	public void afterPropertiesSet() throws Exception {
 
-		if (null != this.clientFactory) {
+		if (this.clientFactory != null) {
 			this.httpClient = clientFactory.getObject();
 		}
 	}

--- a/spring-ws-core/src/main/java/org/springframework/ws/transport/http/HttpComponents5MessageSender.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/transport/http/HttpComponents5MessageSender.java
@@ -41,13 +41,11 @@ import org.springframework.util.Assert;
 import org.springframework.ws.transport.WebServiceConnection;
 
 /**
- * {@code WebServiceMessageSender} implementation that uses
- * <a href="http://hc.apache.org/httpcomponents-client">Apache HttpClient</a> to execute
- * POST requests.
+ * {@code WebServiceMessageSender} implementation that uses <a href="http://hc.apache.org/httpcomponents-client">Apache
+ * HttpClient</a> to execute POST requests.
  * <p>
- * Allows to use a pre-configured HttpClient instance, potentially with authentication,
- * HTTP connection pooling, etc. Authentication can also be set by injecting a
- * {@link Credentials} instance (such as the
+ * Allows to use a pre-configured HttpClient instance, potentially with authentication, HTTP connection pooling, etc.
+ * Authentication can also be set by injecting a {@link Credentials} instance (such as the
  * {@link org.apache.hc.client5.http.auth.UsernamePasswordCredentials}).
  *
  * @author Alan Stewart
@@ -68,8 +66,8 @@ public class HttpComponents5MessageSender extends AbstractHttpWebServiceMessageS
 	private HttpComponents5ClientFactory clientFactory;
 
 	/**
-	 * Create a new instance of the {@code HttpClientMessageSender} with a default
-	 * {@link HttpClient} that uses a default {@link PoolingHttpClientConnectionManager}.
+	 * Create a new instance of the {@code HttpClientMessageSender} with a default {@link HttpClient} that uses a default
+	 * {@link PoolingHttpClientConnectionManager}.
 	 */
 	public HttpComponents5MessageSender() {
 
@@ -79,13 +77,12 @@ public class HttpComponents5MessageSender extends AbstractHttpWebServiceMessageS
 	}
 
 	/**
-	 * Create a new instance of the {@link HttpComponents5MessageSender} with the given
-	 * {@link HttpClient} instance.
+	 * Create a new instance of the {@link HttpComponents5MessageSender} with the given {@link HttpClient} instance.
 	 * <p>
-	 * This constructor does not change the given {@code HttpClient} in any way. As such,
-	 * it does not set timeouts, nor does it
-	 * {@linkplain HttpClientBuilder#addRequestInterceptorFirst(HttpRequestInterceptor)
-	 * add} the {@link RemoveSoapHeadersInterceptor}.
+	 * This constructor does not change the given {@code HttpClient} in any way. As such, it does not set timeouts, nor
+	 * does it {@linkplain HttpClientBuilder#addRequestInterceptorFirst(HttpRequestInterceptor) add} the
+	 * {@link RemoveSoapHeadersInterceptor}.
+	 *
 	 * @param httpClient the HttpClient instance to use for this sender
 	 */
 	public HttpComponents5MessageSender(HttpClient httpClient) {
@@ -194,8 +191,7 @@ public class HttpComponents5MessageSender extends AbstractHttpWebServiceMessageS
 		HttpPost httpPost = new HttpPost(uri);
 
 		if (isAcceptGzipEncoding()) {
-			httpPost.addHeader(HttpTransportConstants.HEADER_ACCEPT_ENCODING,
-					HttpTransportConstants.CONTENT_ENCODING_GZIP);
+			httpPost.addHeader(HttpTransportConstants.HEADER_ACCEPT_ENCODING, HttpTransportConstants.CONTENT_ENCODING_GZIP);
 		}
 
 		HttpContext httpContext = createContext(uri);
@@ -204,8 +200,9 @@ public class HttpComponents5MessageSender extends AbstractHttpWebServiceMessageS
 	}
 
 	/**
-	 * Template method that allows for creation of an {@link HttpContext} for the given
-	 * uri. Default implementation returns {@code null}.
+	 * Template method that allows for creation of an {@link HttpContext} for the given uri. Default implementation returns
+	 * {@code null}.
+	 *
 	 * @param uri the URI to create the context for
 	 * @return the context, or {@code null}
 	 */
@@ -216,16 +213,15 @@ public class HttpComponents5MessageSender extends AbstractHttpWebServiceMessageS
 	@Override
 	public void destroy() throws Exception {
 
-		if (getHttpClient() instanceof CloseableHttpClient client) {
+		if (getHttpClient()instanceof CloseableHttpClient client) {
 			client.close();
 		}
 	}
 
 	/**
-	 * HttpClient {@link HttpRequestInterceptor} implementation that removes
-	 * {@code Content-Length} and {@code Transfer-Encoding} headers from the request.
-	 * Necessary, because some SAAJ and other SOAP implementations set these headers
-	 * themselves, and HttpClient throws an exception if they have been set.
+	 * HttpClient {@link HttpRequestInterceptor} implementation that removes {@code Content-Length} and
+	 * {@code Transfer-Encoding} headers from the request. Necessary, because some SAAJ and other SOAP implementations set
+	 * these headers themselves, and HttpClient throws an exception if they have been set.
 	 */
 	public static class RemoveSoapHeadersInterceptor implements HttpRequestInterceptor {
 
@@ -241,7 +237,5 @@ public class HttpComponents5MessageSender extends AbstractHttpWebServiceMessageS
 				request.removeHeaders(HttpHeaders.CONTENT_LENGTH);
 			}
 		}
-
 	}
-
 }

--- a/spring-ws-core/src/main/java/org/springframework/ws/transport/http/HttpComponents5MessageSender.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/transport/http/HttpComponents5MessageSender.java
@@ -34,6 +34,7 @@ import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.HttpRequest;
 import org.apache.hc.core5.http.HttpRequestInterceptor;
 import org.apache.hc.core5.http.protocol.HttpContext;
+
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.util.Assert;
@@ -181,7 +182,10 @@ public class HttpComponents5MessageSender extends AbstractHttpWebServiceMessageS
 
 	@Override
 	public void afterPropertiesSet() throws Exception {
-		this.httpClient = clientFactory.getObject();
+
+		if (null != this.clientFactory) {
+			this.httpClient = clientFactory.getObject();
+		}
 	}
 
 	@Override

--- a/spring-ws-core/src/test/java/org/springframework/ws/transport/http/HttpComponents5MessageSenderTest.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/transport/http/HttpComponents5MessageSenderTest.java
@@ -1,0 +1,33 @@
+package org.springframework.ws.transport.http;
+
+import java.time.Duration;
+
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
+
+class HttpComponents5MessageSenderTest {
+
+	@Test
+	void afterPropertiesSet_createHttpClient() throws Exception {
+		HttpComponents5MessageSender messageSender = new HttpComponents5MessageSender();
+		assertThat(messageSender.getHttpClient()).isNull();
+		Duration timeout = Duration.ofSeconds(1);
+		assertThatCode(() -> messageSender.setConnectionTimeout(timeout)).doesNotThrowAnyException();
+		messageSender.afterPropertiesSet();
+		assertThat(messageSender.getHttpClient()).isNotNull();
+	}
+
+	@Test
+	void afterPropertiesSet_httpClientAlreadySet() throws Exception {
+		CloseableHttpClient httpClient = HttpClientBuilder.create().build();
+		HttpComponents5MessageSender messageSender = new HttpComponents5MessageSender(httpClient);
+		Duration timeout = Duration.ofSeconds(1);
+		assertThatCode(() -> messageSender.setConnectionTimeout(timeout)).isInstanceOf(IllegalStateException.class);
+		messageSender.afterPropertiesSet();
+		assertThat(messageSender.getHttpClient()).isSameAs(httpClient);
+	}
+
+}


### PR DESCRIPTION
@gregturn Thanks for the quick merge of  #1356. There are some issued we need to address. I already spotted a Bug in `HttpComponents5MessageSender#afterPropertiesSet`. This is fixed in this MR.

In my original MR I noted  incompatibilities in the HttpClient Api regarding configuring Authentication on the HttpClient. 
Previously, AuthScope has been `AuthScope.ANY` which is removed in httpclient 5.x. So basically this way to configure preemptive http authentication will no longer work as before (or at all, not sure). At least I updated the Javadoc to reflect the change.

Another Idea would be to remove credentials and authScope altogether and guide users to handle authentication in a client interceptor. WDYT?
