### PR TITLE
generify ClientHttpRequestMessageSenderIntegrationTest

### DIFF
--- a/spring-ws-core/src/test/java/org/springframework/ws/transport/http/ClientHttpRequestMessageSenderIntegrationTest.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/transport/http/ClientHttpRequestMessageSenderIntegrationTest.java
@@ -17,10 +17,10 @@
 package org.springframework.ws.transport.http;
 
 public class ClientHttpRequestMessageSenderIntegrationTest
-		extends AbstractHttpWebServiceMessageSenderIntegrationTestCase {
+		extends AbstractHttpWebServiceMessageSenderIntegrationTestCase<ClientHttpRequestMessageSender> {
 
 	@Override
-	protected AbstractHttpWebServiceMessageSender createMessageSender() {
+	protected ClientHttpRequestMessageSender createMessageSender() {
 		return new ClientHttpRequestMessageSender();
 	}
 }


### PR DESCRIPTION
I added the missing generic type to `ClientHttpRequestMessageSenderIntegrationTest`.