### PR TITLE
Fix integration between Logbook and HttpClient5

### DIFF
--- a/spring-ws-core/src/main/java/org/springframework/ws/transport/http/HttpComponents5Connection.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/transport/http/HttpComponents5Connection.java
@@ -27,10 +27,7 @@ import java.util.Iterator;
 
 import org.apache.hc.client5.http.classic.HttpClient;
 import org.apache.hc.client5.http.classic.methods.HttpPost;
-import org.apache.hc.core5.http.ClassicHttpResponse;
-import org.apache.hc.core5.http.HttpEntity;
-import org.apache.hc.core5.http.HttpResponse;
-import org.apache.hc.core5.http.NameValuePair;
+import org.apache.hc.core5.http.*;
 import org.apache.hc.core5.http.io.entity.ByteArrayEntity;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.apache.hc.core5.http.protocol.HttpContext;
@@ -119,8 +116,8 @@ public class HttpComponents5Connection extends AbstractHttpSenderConnection {
 
 	@Override
 	protected void onSendAfterWrite(WebServiceMessage message) throws IOException {
-
-		httpPost.setEntity(new ByteArrayEntity(requestBuffer.toByteArray(), null));
+		var contentType = ContentType.parse(httpPost.getFirstHeader(HttpHeaders.CONTENT_TYPE).getValue());
+		httpPost.setEntity(new ByteArrayEntity(requestBuffer.toByteArray(), contentType));
 		requestBuffer = null;
 
 		if (httpContext != null) {


### PR DESCRIPTION
# Background information
I recently migrated a project I am working on from Spring Boot 2 to 3.
After it, I noticed that [Logbook](https://github.com/zalando/logbook) stopped logging formatted XML.

After debugging, the main issue I found is the integration between Apache HttpClient5, Zalando Logbook and Spring-WS.

Logbook works well with JSON (Spring-Web) and does not have this issue.

# Root cause of the issue
Logbook expects to find a non-blank Content Type from `HttpEntity` during his execution of `org.zalando.logbook.BodyFilter` chain.

# Solution
I did, basically, the same what is already written for JSON in Spring-Web:
https://github.com/spring-projects/spring-framework/blob/v6.0.8/spring-web/src/main/java/org/springframework/http/client/HttpComponentsClientHttpRequest.java#L90

I copied the code from version 6.0.8 because that's what I had in my classpath. While I was creating this pull request I noticed that Spring team already refactored the above mentioned class: https://github.com/spring-projects/spring-framework/blob/main/spring-web/src/main/java/org/springframework/http/client/HttpComponentsClientHttpRequest.java#L141