### PR TITLE
Remove duplicate dependency declaration for httpclient

### DIFF
--- a/spring-ws-core/pom.xml
+++ b/spring-ws-core/pom.xml
@@ -166,18 +166,6 @@
             <version>${httpclient5.version}</version>
             <optional>true</optional>
         </dependency>
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>${httpclient.version}</version>
-            <optional>true</optional>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-logging</groupId>
-                    <artifactId>commons-logging</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
 
         <dependency>
             <groupId>org.eclipse.jetty</groupId>


### PR DESCRIPTION
### Remove duplicate dependency declaration for httpclient

`org.apache.httpcomponents:httpclient` has beed declared twice.