### PR TITLE
Use instanceof pattern variable

### DIFF
--- a/spring-ws-core/src/main/java/org/springframework/ws/client/core/SimpleFaultMessageResolver.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/client/core/SimpleFaultMessageResolver.java
@@ -32,8 +32,8 @@ public class SimpleFaultMessageResolver implements FaultMessageResolver {
 	/** Throws a new {@code WebServiceFaultException}. */
 	@Override
 	public void resolveFault(WebServiceMessage message) {
-		if (message instanceof FaultAwareWebServiceMessage) {
-			throw new WebServiceFaultException((FaultAwareWebServiceMessage) message);
+		if (message instanceof FaultAwareWebServiceMessage faultAwareWebServiceMessage) {
+			throw new WebServiceFaultException(faultAwareWebServiceMessage);
 		} else {
 			throw new WebServiceFaultException("Message has unknown fault: " + message);
 		}

--- a/spring-ws-core/src/main/java/org/springframework/ws/client/core/WebServiceTemplate.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/client/core/WebServiceTemplate.java
@@ -161,13 +161,13 @@ public class WebServiceTemplate extends WebServiceAccessor implements WebService
 	 */
 	public WebServiceTemplate(Marshaller marshaller) {
 		Assert.notNull(marshaller, "marshaller must not be null");
-		if (!(marshaller instanceof Unmarshaller)) {
+		if (!(marshaller instanceof Unmarshaller unmarshallerInstance)) {
 			throw new IllegalArgumentException("Marshaller [" + marshaller + "] does not implement the Unmarshaller "
 					+ "interface. Please set an Unmarshaller explicitly by using the "
 					+ "WebServiceTemplate(Marshaller, Unmarshaller) constructor.");
 		} else {
 			this.setMarshaller(marshaller);
-			this.setUnmarshaller((Unmarshaller) marshaller);
+			this.setUnmarshaller(unmarshallerInstance);
 		}
 		initDefaultStrategies();
 	}
@@ -641,9 +641,8 @@ public class WebServiceTemplate extends WebServiceAccessor implements WebService
 	protected boolean hasError(WebServiceConnection connection, WebServiceMessage request) throws IOException {
 		if (checkConnectionForError && connection.hasError()) {
 			// could be a fault
-			if (checkConnectionForFault && connection instanceof FaultAwareWebServiceConnection) {
-				FaultAwareWebServiceConnection faultConnection = (FaultAwareWebServiceConnection) connection;
-				return !(faultConnection.hasFault() && request instanceof FaultAwareWebServiceMessage);
+			if (checkConnectionForFault && connection instanceof FaultAwareWebServiceConnection faultConnection) {
+                return !(faultConnection.hasFault() && request instanceof FaultAwareWebServiceMessage);
 			} else {
 				return true;
 			}
@@ -699,17 +698,15 @@ public class WebServiceTemplate extends WebServiceAccessor implements WebService
 	 * @throws IOException in case of I/O errors
 	 */
 	protected boolean hasFault(WebServiceConnection connection, WebServiceMessage response) throws IOException {
-		if (checkConnectionForFault && connection instanceof FaultAwareWebServiceConnection) {
+		if (checkConnectionForFault && connection instanceof FaultAwareWebServiceConnection faultConnection) {
 			// check whether the connection has a fault (i.e. status code 500 in HTTP)
-			FaultAwareWebServiceConnection faultConnection = (FaultAwareWebServiceConnection) connection;
-			if (!faultConnection.hasFault()) {
+            if (!faultConnection.hasFault()) {
 				return false;
 			}
 		}
-		if (response instanceof FaultAwareWebServiceMessage) {
+		if (response instanceof FaultAwareWebServiceMessage faultMessage) {
 			// either the connection has a fault, or checkConnectionForFault is false: let's verify the fault
-			FaultAwareWebServiceMessage faultMessage = (FaultAwareWebServiceMessage) response;
-			return faultMessage.hasFault();
+            return faultMessage.hasFault();
 		}
 		return false;
 	}

--- a/spring-ws-core/src/main/java/org/springframework/ws/mime/AbstractMimeMessage.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/mime/AbstractMimeMessage.java
@@ -49,7 +49,7 @@ public abstract class AbstractMimeMessage implements MimeMessage {
 	public final Attachment addAttachment(String contentId, InputStreamSource inputStreamSource, String contentType) {
 		Assert.hasLength(contentId, "contentId must not be empty");
 		Assert.notNull(inputStreamSource, "InputStreamSource must not be null");
-		if (inputStreamSource instanceof Resource && ((Resource) inputStreamSource).isOpen()) {
+		if (inputStreamSource instanceof Resource resource && resource.isOpen()) {
 			throw new IllegalArgumentException("Passed-in Resource contains an open stream: invalid argument. "
 					+ "MIME requires an InputStreamSource that creates a fresh stream for every call.");
 		}
@@ -91,9 +91,8 @@ public abstract class AbstractMimeMessage implements MimeMessage {
 
 		@Override
 		public String getName() {
-			if (inputStreamSource instanceof Resource) {
-				Resource resource = (Resource) inputStreamSource;
-				return resource.getFilename();
+			if (inputStreamSource instanceof Resource resource) {
+                return resource.getFilename();
 			} else {
 				throw new UnsupportedOperationException("DataSource name not available");
 			}

--- a/spring-ws-core/src/main/java/org/springframework/ws/pox/dom/DomPoxMessage.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/pox/dom/DomPoxMessage.java
@@ -105,9 +105,8 @@ public class DomPoxMessage implements PoxMessage {
 	@Override
 	public void writeTo(OutputStream outputStream) throws IOException {
 		try {
-			if (outputStream instanceof TransportOutputStream) {
-				TransportOutputStream transportOutputStream = (TransportOutputStream) outputStream;
-				transportOutputStream.addHeader(TransportConstants.HEADER_CONTENT_TYPE, contentType);
+			if (outputStream instanceof TransportOutputStream transportOutputStream) {
+                transportOutputStream.addHeader(TransportConstants.HEADER_CONTENT_TYPE, contentType);
 			}
 			transformer.transform(getPayloadSource(), new StreamResult(outputStream));
 		} catch (TransformerException ex) {

--- a/spring-ws-core/src/main/java/org/springframework/ws/server/MessageDispatcher.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/server/MessageDispatcher.java
@@ -348,8 +348,8 @@ public class MessageDispatcher implements WebServiceMessageReceiver, BeanNameAwa
 				&& !ObjectUtils.isEmpty(mappedEndpoint.getInterceptors())) {
 			boolean hasFault = false;
 			WebServiceMessage response = messageContext.getResponse();
-			if (response instanceof FaultAwareWebServiceMessage) {
-				hasFault = ((FaultAwareWebServiceMessage) response).hasFault();
+			if (response instanceof FaultAwareWebServiceMessage faultAwareWebServiceMessage) {
+				hasFault = faultAwareWebServiceMessage.hasFault();
 			}
 			boolean resume = true;
 			for (int i = interceptorIndex; resume && i >= 0; i--) {

--- a/spring-ws-core/src/main/java/org/springframework/ws/server/endpoint/AbstractDom4jPayloadEndpoint.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/server/endpoint/AbstractDom4jPayloadEndpoint.java
@@ -85,8 +85,8 @@ public abstract class AbstractDom4jPayloadEndpoint extends TransformerObjectSupp
 		if (source == null) {
 			return null;
 		}
-		if (!alwaysTransform && source instanceof DOMSource) {
-			Node node = ((DOMSource) source).getNode();
+		if (!alwaysTransform && source instanceof DOMSource domSource) {
+			Node node = domSource.getNode();
 			if (node.getNodeType() == Node.DOCUMENT_NODE) {
 				DOMReader domReader = new DOMReader();
 				Document document = domReader.read((org.w3c.dom.Document) node);

--- a/spring-ws-core/src/main/java/org/springframework/ws/server/endpoint/AbstractDomPayloadEndpoint.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/server/endpoint/AbstractDomPayloadEndpoint.java
@@ -141,8 +141,8 @@ public abstract class AbstractDomPayloadEndpoint extends TransformerObjectSuppor
 		if (source == null) {
 			return null;
 		}
-		if (!alwaysTransform && source instanceof DOMSource) {
-			Node node = ((DOMSource) source).getNode();
+		if (!alwaysTransform && source instanceof DOMSource domSource) {
+			Node node = domSource.getNode();
 			if (node.getNodeType() == Node.ELEMENT_NODE) {
 				return (Element) node;
 			} else if (node.getNodeType() == Node.DOCUMENT_NODE) {

--- a/spring-ws-core/src/main/java/org/springframework/ws/server/endpoint/AbstractEndpointExceptionResolver.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/server/endpoint/AbstractEndpointExceptionResolver.java
@@ -96,7 +96,7 @@ public abstract class AbstractEndpointExceptionResolver implements EndpointExcep
 	 */
 	@Override
 	public final boolean resolveException(MessageContext messageContext, Object endpoint, Exception ex) {
-		Object mappedEndpoint = endpoint instanceof MethodEndpoint ? ((MethodEndpoint) endpoint).getBean() : endpoint;
+		Object mappedEndpoint = endpoint instanceof MethodEndpoint methodEndpoint ? methodEndpoint.getBean() : endpoint;
 		if (mappedEndpoints != null && !mappedEndpoints.contains(mappedEndpoint)) {
 			return false;
 		}

--- a/spring-ws-core/src/main/java/org/springframework/ws/server/endpoint/AbstractJDomPayloadEndpoint.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/server/endpoint/AbstractJDomPayloadEndpoint.java
@@ -76,8 +76,8 @@ public abstract class AbstractJDomPayloadEndpoint extends TransformerObjectSuppo
 		if (source == null) {
 			return null;
 		}
-		if (!alwaysTransform && source instanceof DOMSource) {
-			Node node = ((DOMSource) source).getNode();
+		if (!alwaysTransform && source instanceof DOMSource domSource) {
+			Node node = domSource.getNode();
 			DOMBuilder domBuilder = new DOMBuilder();
 			if (node.getNodeType() == Node.ELEMENT_NODE) {
 				return domBuilder.build((org.w3c.dom.Element) node);

--- a/spring-ws-core/src/main/java/org/springframework/ws/server/endpoint/AbstractMarshallingPayloadEndpoint.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/server/endpoint/AbstractMarshallingPayloadEndpoint.java
@@ -75,13 +75,13 @@ public abstract class AbstractMarshallingPayloadEndpoint implements MessageEndpo
 	 */
 	protected AbstractMarshallingPayloadEndpoint(Marshaller marshaller) {
 		Assert.notNull(marshaller, "marshaller must not be null");
-		if (!(marshaller instanceof Unmarshaller)) {
+		if (!(marshaller instanceof Unmarshaller unmarshallerInstance)) {
 			throw new IllegalArgumentException("Marshaller [" + marshaller + "] does not implement the Unmarshaller "
 					+ "interface. Please set an Unmarshaller explicitly by using the "
 					+ "AbstractMarshallingPayloadEndpoint(Marshaller, Unmarshaller) constructor.");
 		} else {
 			setMarshaller(marshaller);
-			setUnmarshaller((Unmarshaller) marshaller);
+			setUnmarshaller(unmarshallerInstance);
 		}
 	}
 

--- a/spring-ws-core/src/main/java/org/springframework/ws/server/endpoint/MethodEndpoint.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/server/endpoint/MethodEndpoint.java
@@ -91,9 +91,8 @@ public final class MethodEndpoint {
 
 	/** Returns the object bean for this method endpoint. */
 	public Object getBean() {
-		if (beanFactory != null && bean instanceof String) {
-			String beanName = (String) bean;
-			return beanFactory.getBean(beanName);
+		if (beanFactory != null && bean instanceof String beanName) {
+            return beanFactory.getBean(beanName);
 		} else {
 			return bean;
 		}
@@ -140,14 +139,14 @@ public final class MethodEndpoint {
 
 	private void handleInvocationTargetException(InvocationTargetException ex) throws Exception {
 		Throwable targetException = ex.getTargetException();
-		if (targetException instanceof RuntimeException) {
-			throw (RuntimeException) targetException;
+		if (targetException instanceof RuntimeException runtimeException) {
+			throw runtimeException;
 		}
-		if (targetException instanceof Error) {
-			throw (Error) targetException;
+		if (targetException instanceof Error error) {
+			throw error;
 		}
-		if (targetException instanceof Exception) {
-			throw (Exception) targetException;
+		if (targetException instanceof Exception exception) {
+			throw exception;
 		}
 
 	}

--- a/spring-ws-core/src/main/java/org/springframework/ws/server/endpoint/adapter/AbstractMethodEndpointAdapter.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/server/endpoint/adapter/AbstractMethodEndpointAdapter.java
@@ -38,7 +38,7 @@ public abstract class AbstractMethodEndpointAdapter extends TransformerObjectSup
 	 */
 	@Override
 	public final boolean supports(Object endpoint) {
-		return endpoint instanceof MethodEndpoint && supportsInternal((MethodEndpoint) endpoint);
+		return endpoint instanceof MethodEndpoint methodEndpoint && supportsInternal(methodEndpoint);
 	}
 
 	/**

--- a/spring-ws-core/src/main/java/org/springframework/ws/server/endpoint/adapter/GenericMarshallingMethodEndpointAdapter.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/server/endpoint/adapter/GenericMarshallingMethodEndpointAdapter.java
@@ -86,8 +86,8 @@ public class GenericMarshallingMethodEndpointAdapter extends MarshallingMethodEn
 		if (Void.TYPE.equals(method.getReturnType())) {
 			return true;
 		} else {
-			if (getMarshaller() instanceof GenericMarshaller) {
-				return ((GenericMarshaller) getMarshaller()).supports(method.getGenericReturnType());
+			if (getMarshaller() instanceof GenericMarshaller genericMarshaller) {
+				return genericMarshaller.supports(method.getGenericReturnType());
 			} else {
 				return getMarshaller().supports(method.getReturnType());
 			}
@@ -97,9 +97,8 @@ public class GenericMarshallingMethodEndpointAdapter extends MarshallingMethodEn
 	private boolean supportsParameters(Method method) {
 		if (method.getParameterTypes().length != 1) {
 			return false;
-		} else if (getUnmarshaller() instanceof GenericUnmarshaller) {
-			GenericUnmarshaller genericUnmarshaller = (GenericUnmarshaller) getUnmarshaller();
-			return genericUnmarshaller.supports(method.getGenericParameterTypes()[0]);
+		} else if (getUnmarshaller() instanceof GenericUnmarshaller genericUnmarshaller) {
+            return genericUnmarshaller.supports(method.getGenericParameterTypes()[0]);
 		} else {
 			return getUnmarshaller().supports(method.getParameterTypes()[0]);
 		}

--- a/spring-ws-core/src/main/java/org/springframework/ws/server/endpoint/adapter/MarshallingMethodEndpointAdapter.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/server/endpoint/adapter/MarshallingMethodEndpointAdapter.java
@@ -85,13 +85,13 @@ public class MarshallingMethodEndpointAdapter extends AbstractMethodEndpointAdap
 	 */
 	public MarshallingMethodEndpointAdapter(Marshaller marshaller) {
 		Assert.notNull(marshaller, "marshaller must not be null");
-		if (!(marshaller instanceof Unmarshaller)) {
+		if (!(marshaller instanceof Unmarshaller unmarshallerInstance)) {
 			throw new IllegalArgumentException("Marshaller [" + marshaller + "] does not implement the Unmarshaller "
 					+ "interface. Please set an Unmarshaller explicitly by using the "
 					+ "MarshallingMethodEndpointAdapter(Marshaller, Unmarshaller) constructor.");
 		} else {
 			this.setMarshaller(marshaller);
-			this.setUnmarshaller((Unmarshaller) marshaller);
+			this.setUnmarshaller(unmarshallerInstance);
 		}
 	}
 

--- a/spring-ws-core/src/main/java/org/springframework/ws/server/endpoint/adapter/method/MarshallingPayloadMethodProcessor.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/server/endpoint/adapter/method/MarshallingPayloadMethodProcessor.java
@@ -112,8 +112,8 @@ public class MarshallingPayloadMethodProcessor extends AbstractPayloadMethodProc
 		Unmarshaller unmarshaller = getUnmarshaller();
 		if (unmarshaller == null) {
 			return false;
-		} else if (unmarshaller instanceof GenericUnmarshaller) {
-			return ((GenericUnmarshaller) unmarshaller).supports(parameter.getGenericParameterType());
+		} else if (unmarshaller instanceof GenericUnmarshaller genericUnmarshaller) {
+			return genericUnmarshaller.supports(parameter.getGenericParameterType());
 		} else {
 			return unmarshaller.supports(parameter.getParameterType());
 		}
@@ -137,9 +137,8 @@ public class MarshallingPayloadMethodProcessor extends AbstractPayloadMethodProc
 		Marshaller marshaller = getMarshaller();
 		if (marshaller == null) {
 			return false;
-		} else if (marshaller instanceof GenericMarshaller) {
-			GenericMarshaller genericMarshaller = (GenericMarshaller) marshaller;
-			return genericMarshaller.supports(returnType.getGenericParameterType());
+		} else if (marshaller instanceof GenericMarshaller genericMarshaller) {
+            return genericMarshaller.supports(returnType.getGenericParameterType());
 		} else {
 			return marshaller.supports(returnType.getParameterType());
 		}

--- a/spring-ws-core/src/main/java/org/springframework/ws/server/endpoint/adapter/method/dom/Dom4jPayloadMethodProcessor.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/server/endpoint/adapter/method/dom/Dom4jPayloadMethodProcessor.java
@@ -46,8 +46,8 @@ public class Dom4jPayloadMethodProcessor extends AbstractPayloadSourceMethodProc
 	@Override
 	protected Element resolveRequestPayloadArgument(MethodParameter parameter, Source requestPayload)
 			throws TransformerException {
-		if (requestPayload instanceof DOMSource) {
-			org.w3c.dom.Node node = ((DOMSource) requestPayload).getNode();
+		if (requestPayload instanceof DOMSource domSource) {
+			org.w3c.dom.Node node = domSource.getNode();
 			if (node.getNodeType() == org.w3c.dom.Node.DOCUMENT_NODE) {
 				DOMReader domReader = new DOMReader();
 				Document document = domReader.read((org.w3c.dom.Document) node);

--- a/spring-ws-core/src/main/java/org/springframework/ws/server/endpoint/adapter/method/dom/DomPayloadMethodProcessor.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/server/endpoint/adapter/method/dom/DomPayloadMethodProcessor.java
@@ -45,8 +45,8 @@ public class DomPayloadMethodProcessor extends AbstractPayloadSourceMethodProces
 
 	@Override
 	protected Node resolveRequestPayloadArgument(MethodParameter parameter, Source requestPayload) throws Exception {
-		if (requestPayload instanceof DOMSource) {
-			return resolveArgumentDomSource(parameter, (DOMSource) requestPayload);
+		if (requestPayload instanceof DOMSource domSource) {
+			return resolveArgumentDomSource(parameter, domSource);
 		} else {
 			DOMResult domResult = new DOMResult();
 			transform(requestPayload, domResult);
@@ -60,9 +60,8 @@ public class DomPayloadMethodProcessor extends AbstractPayloadSourceMethodProces
 		Node requestNode = requestSource.getNode();
 		if (parameterType.isAssignableFrom(requestNode.getClass())) {
 			return requestNode;
-		} else if (Element.class.equals(parameterType) && requestNode instanceof Document) {
-			Document document = (Document) requestNode;
-			return document.getDocumentElement();
+		} else if (Element.class.equals(parameterType) && requestNode instanceof Document document) {
+            return document.getDocumentElement();
 		}
 		// should not happen
 		throw new UnsupportedOperationException();

--- a/spring-ws-core/src/main/java/org/springframework/ws/server/endpoint/adapter/method/dom/JDomPayloadMethodProcessor.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/server/endpoint/adapter/method/dom/JDomPayloadMethodProcessor.java
@@ -45,8 +45,8 @@ public class JDomPayloadMethodProcessor extends AbstractPayloadSourceMethodProce
 
 	@Override
 	protected Element resolveRequestPayloadArgument(MethodParameter parameter, Source requestPayload) throws Exception {
-		if (requestPayload instanceof DOMSource) {
-			Node node = ((DOMSource) requestPayload).getNode();
+		if (requestPayload instanceof DOMSource domSource) {
+			Node node = domSource.getNode();
 			DOMBuilder domBuilder = new DOMBuilder();
 			if (node.getNodeType() == Node.ELEMENT_NODE) {
 				return domBuilder.build((org.w3c.dom.Element) node);

--- a/spring-ws-core/src/main/java/org/springframework/ws/server/endpoint/adapter/method/dom/XomPayloadMethodProcessor.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/server/endpoint/adapter/method/dom/XomPayloadMethodProcessor.java
@@ -57,8 +57,8 @@ public class XomPayloadMethodProcessor extends AbstractPayloadSourceMethodProces
 	@Override
 	protected Element resolveRequestPayloadArgument(MethodParameter parameter, Source requestPayload)
 			throws TransformerException, IOException, ParsingException {
-		if (requestPayload instanceof DOMSource) {
-			org.w3c.dom.Node node = ((DOMSource) requestPayload).getNode();
+		if (requestPayload instanceof DOMSource domSource) {
+			org.w3c.dom.Node node = domSource.getNode();
 			if (node.getNodeType() == org.w3c.dom.Node.ELEMENT_NODE) {
 				return DOMConverter.convert((org.w3c.dom.Element) node);
 			} else if (node.getNodeType() == org.w3c.dom.Node.DOCUMENT_NODE) {

--- a/spring-ws-core/src/main/java/org/springframework/ws/server/endpoint/adapter/method/jaxb/AbstractJaxb2PayloadMethodProcessor.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/server/endpoint/adapter/method/jaxb/AbstractJaxb2PayloadMethodProcessor.java
@@ -102,10 +102,8 @@ public abstract class AbstractJaxb2PayloadMethodProcessor extends AbstractPayloa
 			logger.debug("Marshalling [" + jaxbElement + "] to response payload");
 		}
 		WebServiceMessage response = messageContext.getResponse();
-		if (response instanceof StreamingWebServiceMessage) {
-			StreamingWebServiceMessage streamingResponse = (StreamingWebServiceMessage) response;
-
-			StreamingPayload payload = new JaxbStreamingPayload(clazz, jaxbElement);
+		if (response instanceof StreamingWebServiceMessage streamingResponse) {
+            StreamingPayload payload = new JaxbStreamingPayload(clazz, jaxbElement);
 			streamingResponse.setStreamingPayload(payload);
 		} else {
 			Result responsePayload = response.getPayloadResult();
@@ -176,8 +174,8 @@ public abstract class AbstractJaxb2PayloadMethodProcessor extends AbstractPayloa
 	}
 
 	private JAXBException convertToJaxbException(Exception ex) {
-		if (ex instanceof JAXBException) {
-			return (JAXBException) ex;
+		if (ex instanceof JAXBException jaxbException) {
+			return jaxbException;
 		} else {
 			return new JAXBException(ex);
 		}

--- a/spring-ws-core/src/main/java/org/springframework/ws/server/endpoint/mapping/AbstractEndpointMapping.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/server/endpoint/mapping/AbstractEndpointMapping.java
@@ -123,9 +123,8 @@ public abstract class AbstractEndpointMapping extends ApplicationObjectSupport i
 		if (endpoint == null) {
 			return null;
 		}
-		if (endpoint instanceof String) {
-			String endpointName = (String) endpoint;
-			endpoint = resolveStringEndpoint(endpointName);
+		if (endpoint instanceof String endpointName) {
+            endpoint = resolveStringEndpoint(endpointName);
 			if (endpoint == null) {
 				return null;
 			}

--- a/spring-ws-core/src/main/java/org/springframework/ws/server/endpoint/mapping/AbstractMapBasedEndpointMapping.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/server/endpoint/mapping/AbstractMapBasedEndpointMapping.java
@@ -83,8 +83,8 @@ public abstract class AbstractMapBasedEndpointMapping extends AbstractEndpointMa
 	 */
 	public void setMappings(Properties mappings) {
 		for (Map.Entry<Object, Object> entry : mappings.entrySet()) {
-			if (entry.getKey() instanceof String) {
-				temporaryEndpointMap.put((String) entry.getKey(), entry.getValue());
+			if (entry.getKey() instanceof String key) {
+				temporaryEndpointMap.put(key, entry.getValue());
 			}
 		}
 	}
@@ -139,9 +139,8 @@ public abstract class AbstractMapBasedEndpointMapping extends AbstractEndpointMa
 			throw new ApplicationContextException("Cannot map endpoint [" + endpoint + "] on registration key [" + key
 					+ "]: there's already endpoint [" + mappedEndpoint + "] mapped");
 		}
-		if (!lazyInitEndpoints && endpoint instanceof String) {
-			String endpointName = (String) endpoint;
-			endpoint = resolveStringEndpoint(endpointName);
+		if (!lazyInitEndpoints && endpoint instanceof String endpointName) {
+            endpoint = resolveStringEndpoint(endpointName);
 		}
 		if (endpoint == null) {
 			throw new ApplicationContextException("Could not find endpoint for key [" + key + "]");

--- a/spring-ws-core/src/main/java/org/springframework/ws/soap/addressing/server/AbstractActionEndpointMapping.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/soap/addressing/server/AbstractActionEndpointMapping.java
@@ -130,9 +130,8 @@ public abstract class AbstractActionEndpointMapping extends AbstractAddressingEn
 		Assert.notNull(endpoint, "Endpoint object must not be null");
 		Object resolvedEndpoint = endpoint;
 
-		if (endpoint instanceof String) {
-			String endpointName = (String) endpoint;
-			if (getApplicationContext().isSingleton(endpointName)) {
+		if (endpoint instanceof String endpointName) {
+            if (getApplicationContext().isSingleton(endpointName)) {
 				resolvedEndpoint = getApplicationContext().getBean(endpointName);
 			}
 		}

--- a/spring-ws-core/src/main/java/org/springframework/ws/soap/addressing/server/SimpleActionEndpointMapping.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/soap/addressing/server/SimpleActionEndpointMapping.java
@@ -77,10 +77,10 @@ public class SimpleActionEndpointMapping extends AbstractActionEndpointMapping {
 	public void setActionMap(Map<?, Object> actionMap) throws URISyntaxException {
 		for (Map.Entry<?, Object> entry : actionMap.entrySet()) {
 			URI action;
-			if (entry.getKey() instanceof String) {
-				action = new URI((String) entry.getKey());
-			} else if (entry.getKey() instanceof URI) {
-				action = (URI) entry.getKey();
+			if (entry.getKey() instanceof String key) {
+				action = new URI(key);
+			} else if (entry.getKey() instanceof URI uri) {
+				action = uri;
 			} else {
 				throw new IllegalArgumentException("Invalid key [" + entry.getKey() + "]; expected String or URI");
 			}
@@ -120,8 +120,8 @@ public class SimpleActionEndpointMapping extends AbstractActionEndpointMapping {
 				URI action = entry.getKey();
 				Object endpoint = entry.getValue();
 				// Remove whitespace from endpoint bean name.
-				if (endpoint instanceof String) {
-					endpoint = ((String) endpoint).trim();
+				if (endpoint instanceof String endpointString) {
+					endpoint = endpointString.trim();
 				}
 				registerEndpoint(action, endpoint);
 			}

--- a/spring-ws-core/src/main/java/org/springframework/ws/soap/addressing/version/AbstractAddressingVersion.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/soap/addressing/version/AbstractAddressingVersion.java
@@ -155,9 +155,8 @@ public abstract class AbstractAddressingVersion extends TransformerObjectSupport
 
 	private Element getSoapHeaderElement(SoapMessage message) {
 		Source source = message.getSoapHeader().getSource();
-		if (source instanceof DOMSource) {
-			DOMSource domSource = (DOMSource) source;
-			if (domSource.getNode() != null && domSource.getNode().getNodeType() == Node.ELEMENT_NODE) {
+		if (source instanceof DOMSource domSource) {
+            if (domSource.getNode() != null && domSource.getNode().getNodeType() == Node.ELEMENT_NODE) {
 				return (Element) domSource.getNode();
 			}
 		}
@@ -289,12 +288,10 @@ public abstract class AbstractAddressingVersion extends TransformerObjectSupport
 	}
 
 	private SoapFault addAddressingFault(SoapMessage message, QName subcode, String reason) {
-		if (message.getSoapBody() instanceof Soap11Body) {
-			Soap11Body soapBody = (Soap11Body) message.getSoapBody();
-			return soapBody.addFault(subcode, reason, Locale.ENGLISH);
-		} else if (message.getSoapBody() instanceof Soap12Body) {
-			Soap12Body soapBody = (Soap12Body) message.getSoapBody();
-			Soap12Fault soapFault = soapBody.addClientOrSenderFault(reason, Locale.ENGLISH);
+		if (message.getSoapBody() instanceof Soap11Body soapBody) {
+            return soapBody.addFault(subcode, reason, Locale.ENGLISH);
+		} else if (message.getSoapBody() instanceof Soap12Body soapBody) {
+            Soap12Fault soapFault = soapBody.addClientOrSenderFault(reason, Locale.ENGLISH);
 			soapFault.addFaultSubcode(subcode);
 			return soapFault;
 		}

--- a/spring-ws-core/src/main/java/org/springframework/ws/soap/saaj/SaajSoapHeader.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/soap/saaj/SaajSoapHeader.java
@@ -112,8 +112,8 @@ abstract class SaajSoapHeader extends SaajSoapElement<SOAPHeader> implements Soa
 		@Override
 		public SoapHeaderElement next() {
 			Node saajHeaderElement = iterator.next();
-			if (saajHeaderElement instanceof SOAPHeaderElement) {
-				return new SaajSoapHeaderElement((SOAPHeaderElement) saajHeaderElement);
+			if (saajHeaderElement instanceof SOAPHeaderElement soapHeaderElement) {
+				return new SaajSoapHeaderElement(soapHeaderElement);
 			} else {
 				throw new RuntimeException("saajHeaderElement is not an instance of SOAPHeaderElement");
 			}

--- a/spring-ws-core/src/main/java/org/springframework/ws/soap/saaj/SaajSoapMessage.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/soap/saaj/SaajSoapMessage.java
@@ -225,9 +225,8 @@ public class SaajSoapMessage extends AbstractSoapMessage {
 		try {
 			SOAPMessage message = getSaajMessage();
 			message.saveChanges();
-			if (outputStream instanceof TransportOutputStream) {
-				TransportOutputStream transportOutputStream = (TransportOutputStream) outputStream;
-				// some SAAJ implementations (Axis 1) do not have a Content-Type header by default
+			if (outputStream instanceof TransportOutputStream transportOutputStream) {
+                // some SAAJ implementations (Axis 1) do not have a Content-Type header by default
 				MimeHeaders headers = message.getMimeHeaders();
 				if (ObjectUtils.isEmpty(headers.getHeader(TransportConstants.HEADER_CONTENT_TYPE))) {
 					SOAPEnvelope envelope1 = message.getSOAPPart().getEnvelope();

--- a/spring-ws-core/src/main/java/org/springframework/ws/soap/saaj/SaajSoapMessageFactory.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/soap/saaj/SaajSoapMessageFactory.java
@@ -207,8 +207,8 @@ public class SaajSoapMessageFactory implements SoapMessageFactory, InitializingB
 	}
 
 	private SAXParseException getSAXParseException(Throwable ex) {
-		if (ex instanceof SAXParseException) {
-			return (SAXParseException) ex;
+		if (ex instanceof SAXParseException saxParseException) {
+			return saxParseException;
 		} else if (ex.getCause() != null) {
 			return getSAXParseException(ex.getCause());
 		} else {
@@ -218,9 +218,8 @@ public class SaajSoapMessageFactory implements SoapMessageFactory, InitializingB
 
 	private MimeHeaders parseMimeHeaders(InputStream inputStream) throws IOException {
 		MimeHeaders mimeHeaders = new MimeHeaders();
-		if (inputStream instanceof TransportInputStream) {
-			TransportInputStream transportInputStream = (TransportInputStream) inputStream;
-			for (Iterator<String> headerNames = transportInputStream.getHeaderNames(); headerNames.hasNext();) {
+		if (inputStream instanceof TransportInputStream transportInputStream) {
+            for (Iterator<String> headerNames = transportInputStream.getHeaderNames(); headerNames.hasNext();) {
 				String headerName = headerNames.next();
 				for (Iterator<String> headerValues = transportInputStream.getHeaders(headerName); headerValues.hasNext();) {
 					String headerValue = headerValues.next();

--- a/spring-ws-core/src/main/java/org/springframework/ws/soap/saaj/support/SaajContentHandler.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/soap/saaj/support/SaajContentHandler.java
@@ -55,8 +55,8 @@ public class SaajContentHandler implements ContentHandler {
 	 */
 	public SaajContentHandler(SOAPElement element) {
 		Assert.notNull(element, "element must not be null");
-		if (element instanceof SOAPEnvelope) {
-			envelope = (SOAPEnvelope) element;
+		if (element instanceof SOAPEnvelope soapEnvelope) {
+			envelope = soapEnvelope;
 		} else {
 			envelope = SaajUtils.getEnvelope(element);
 		}

--- a/spring-ws-core/src/main/java/org/springframework/ws/soap/saaj/support/SaajUtils.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/soap/saaj/support/SaajUtils.java
@@ -184,8 +184,8 @@ public abstract class SaajUtils {
 	public static SOAPEnvelope getEnvelope(SOAPElement element) {
 		Assert.notNull(element, "Element should not be null");
 		do {
-			if (element instanceof SOAPEnvelope) {
-				return (SOAPEnvelope) element;
+			if (element instanceof SOAPEnvelope soapEnvelope) {
+				return soapEnvelope;
 			}
 			element = element.getParentElement();
 		} while (element != null);
@@ -198,8 +198,8 @@ public abstract class SaajUtils {
 	public static SOAPElement getFirstBodyElement(SOAPBody body) {
 		for (Iterator<?> iterator = body.getChildElements(); iterator.hasNext();) {
 			Object child = iterator.next();
-			if (child instanceof SOAPElement) {
-				return (SOAPElement) child;
+			if (child instanceof SOAPElement soapChild) {
+				return soapChild;
 			}
 		}
 		return null;

--- a/spring-ws-core/src/main/java/org/springframework/ws/soap/saaj/support/SaajXmlReader.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/soap/saaj/support/SaajXmlReader.java
@@ -121,11 +121,10 @@ public class SaajXmlReader extends AbstractXmlReader {
 	}
 
 	private void handleNode(Node node) throws SAXException {
-		if (node instanceof SOAPElement) {
-			handleElement((SOAPElement) node);
-		} else if (node instanceof Text) {
-			Text text = (Text) node;
-			handleText(text);
+		if (node instanceof SOAPElement soapElement) {
+			handleElement(soapElement);
+		} else if (node instanceof Text text) {
+            handleText(text);
 		}
 	}
 

--- a/spring-ws-core/src/main/java/org/springframework/ws/soap/server/SoapMessageDispatcher.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/soap/server/SoapMessageDispatcher.java
@@ -84,9 +84,8 @@ public class SoapMessageDispatcher extends MessageDispatcher {
 		if (messageContext.getRequest() instanceof SoapMessage) {
 			String[] actorsOrRoles = null;
 			boolean isUltimateReceiver = true;
-			if (mappedEndpoint instanceof SoapEndpointInvocationChain) {
-				SoapEndpointInvocationChain soapChain = (SoapEndpointInvocationChain) mappedEndpoint;
-				actorsOrRoles = soapChain.getActorsOrRoles();
+			if (mappedEndpoint instanceof SoapEndpointInvocationChain soapChain) {
+                actorsOrRoles = soapChain.getActorsOrRoles();
 				isUltimateReceiver = soapChain.isUltimateReceiver();
 			}
 			return handleHeaders(mappedEndpoint, messageContext, actorsOrRoles, isUltimateReceiver);
@@ -102,8 +101,8 @@ public class SoapMessageDispatcher extends MessageDispatcher {
 			return true;
 		}
 		Iterator<SoapHeaderElement> headerIterator;
-		if (soapHeader instanceof Soap11Header) {
-			headerIterator = ((Soap11Header) soapHeader).examineHeaderElementsToProcess(actorsOrRoles);
+		if (soapHeader instanceof Soap11Header soap11Header) {
+			headerIterator = soap11Header.examineHeaderElementsToProcess(actorsOrRoles);
 		} else {
 			headerIterator = ((Soap12Header) soapHeader).examineHeaderElementsToProcess(actorsOrRoles, isUltimateReceiver);
 		}
@@ -141,8 +140,8 @@ public class SoapMessageDispatcher extends MessageDispatcher {
 			return false;
 		}
 		for (EndpointInterceptor interceptor : interceptors) {
-			if (interceptor instanceof SoapEndpointInterceptor
-					&& ((SoapEndpointInterceptor) interceptor).understands(headerElement)) {
+			if (interceptor instanceof SoapEndpointInterceptor soapEndpointInterceptor
+					&& soapEndpointInterceptor.understands(headerElement)) {
 				return true;
 			}
 		}
@@ -161,9 +160,8 @@ public class SoapMessageDispatcher extends MessageDispatcher {
 			fault.setFaultActorOrRole(actorsOrRoles[0]);
 		}
 		SoapHeader header = soapResponse.getSoapHeader();
-		if (header instanceof Soap12Header) {
-			Soap12Header soap12Header = (Soap12Header) header;
-			for (QName headerName : notUnderstoodHeaderNames) {
+		if (header instanceof Soap12Header soap12Header) {
+            for (QName headerName : notUnderstoodHeaderNames) {
 				soap12Header.addNotUnderstoodHeaderElement(headerName);
 			}
 		}

--- a/spring-ws-core/src/main/java/org/springframework/ws/soap/server/endpoint/AbstractFaultCreatingValidatingMarshallingPayloadEndpoint.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/soap/server/endpoint/AbstractFaultCreatingValidatingMarshallingPayloadEndpoint.java
@@ -163,9 +163,8 @@ public abstract class AbstractFaultCreatingValidatingMarshallingPayloadEndpoint 
 			String msg = messageSource.getMessage(objectError, getFaultLocale());
 			logger.warn("Validation error on request object[" + requestObject + "]: " + msg);
 		}
-		if (messageContext.getResponse() instanceof SoapMessage) {
-			SoapMessage response = (SoapMessage) messageContext.getResponse();
-			SoapBody body = response.getSoapBody();
+		if (messageContext.getResponse() instanceof SoapMessage response) {
+            SoapBody body = response.getSoapBody();
 			SoapFault fault = body.addClientOrSenderFault(getFaultStringOrReason(), getFaultLocale());
 			if (getAddValidationErrorDetail()) {
 				SoapFaultDetail detail = fault.addFaultDetail();

--- a/spring-ws-core/src/main/java/org/springframework/ws/soap/server/endpoint/AbstractSoapFaultDefinitionExceptionResolver.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/soap/server/endpoint/AbstractSoapFaultDefinitionExceptionResolver.java
@@ -83,12 +83,10 @@ public abstract class AbstractSoapFaultDefinitionExceptionResolver extends Abstr
 				|| SoapFaultDefinition.SENDER.equals(definition.getFaultCode())) {
 			fault = soapBody.addClientOrSenderFault(faultStringOrReason, definition.getLocale());
 		} else {
-			if (soapBody instanceof Soap11Body) {
-				Soap11Body soap11Body = (Soap11Body) soapBody;
-				fault = soap11Body.addFault(definition.getFaultCode(), faultStringOrReason, definition.getLocale());
-			} else if (soapBody instanceof Soap12Body) {
-				Soap12Body soap12Body = (Soap12Body) soapBody;
-				Soap12Fault soap12Fault = soap12Body.addServerOrReceiverFault(faultStringOrReason, definition.getLocale());
+			if (soapBody instanceof Soap11Body soap11Body) {
+                fault = soap11Body.addFault(definition.getFaultCode(), faultStringOrReason, definition.getLocale());
+			} else if (soapBody instanceof Soap12Body soap12Body) {
+                Soap12Fault soap12Fault = soap12Body.addServerOrReceiverFault(faultStringOrReason, definition.getLocale());
 				soap12Fault.addFaultSubcode(definition.getFaultCode());
 				fault = soap12Fault;
 			} else {

--- a/spring-ws-core/src/main/java/org/springframework/ws/soap/server/endpoint/SoapFaultMappingExceptionResolver.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/soap/server/endpoint/SoapFaultMappingExceptionResolver.java
@@ -47,8 +47,8 @@ public class SoapFaultMappingExceptionResolver extends AbstractSoapFaultDefiniti
 	 */
 	public void setExceptionMappings(Properties mappings) {
 		for (Map.Entry<Object, Object> entry : mappings.entrySet()) {
-			if (entry.getKey() instanceof String && entry.getValue() instanceof String) {
-				exceptionMappings.put((String) entry.getKey(), (String) entry.getValue());
+			if (entry.getKey() instanceof String key && entry.getValue() instanceof String value) {
+				exceptionMappings.put(key, value);
 			}
 		}
 	}

--- a/spring-ws-core/src/main/java/org/springframework/ws/soap/server/endpoint/adapter/method/SoapHeaderElementMethodArgumentResolver.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/soap/server/endpoint/adapter/method/SoapHeaderElementMethodArgumentResolver.java
@@ -73,9 +73,8 @@ public class SoapHeaderElementMethodArgumentResolver implements MethodArgumentRe
 		// List<SoapHeaderElement> parameter
 		if (List.class.equals(parameterType)) {
 			Type genericType = parameter.getGenericParameterType();
-			if (genericType instanceof ParameterizedType) {
-				ParameterizedType parameterizedType = (ParameterizedType) genericType;
-				Type[] typeArguments = parameterizedType.getActualTypeArguments();
+			if (genericType instanceof ParameterizedType parameterizedType) {
+                Type[] typeArguments = parameterizedType.getActualTypeArguments();
 				if (typeArguments.length == 1 && SoapHeaderElement.class.equals(typeArguments[0])) {
 					return true;
 				}

--- a/spring-ws-core/src/main/java/org/springframework/ws/soap/server/endpoint/interceptor/AbstractFaultCreatingValidatingInterceptor.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/soap/server/endpoint/interceptor/AbstractFaultCreatingValidatingInterceptor.java
@@ -153,9 +153,8 @@ public abstract class AbstractFaultCreatingValidatingInterceptor extends Abstrac
 		for (SAXParseException error : errors) {
 			logger.warn("XML validation error on request: " + error.getMessage());
 		}
-		if (messageContext.getResponse() instanceof SoapMessage) {
-			SoapMessage response = (SoapMessage) messageContext.getResponse();
-			SoapBody body = response.getSoapBody();
+		if (messageContext.getResponse() instanceof SoapMessage response) {
+            SoapBody body = response.getSoapBody();
 			SoapFault fault = body.addClientOrSenderFault(getFaultStringOrReason(), getFaultStringOrReasonLocale());
 			if (getAddValidationErrorDetail()) {
 				SoapFaultDetail detail = fault.addFaultDetail();

--- a/spring-ws-core/src/main/java/org/springframework/ws/soap/server/endpoint/interceptor/DelegatingSmartSoapEndpointInterceptor.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/soap/server/endpoint/interceptor/DelegatingSmartSoapEndpointInterceptor.java
@@ -44,8 +44,8 @@ public class DelegatingSmartSoapEndpointInterceptor extends DelegatingSmartEndpo
 	@Override
 	public boolean understands(SoapHeaderElement header) {
 		EndpointInterceptor delegate = getDelegate();
-		if (delegate instanceof SoapEndpointInterceptor) {
-			return ((SoapEndpointInterceptor) delegate).understands(header);
+		if (delegate instanceof SoapEndpointInterceptor soapEndpointInterceptor) {
+			return soapEndpointInterceptor.understands(header);
 		} else {
 			return false;
 		}

--- a/spring-ws-core/src/main/java/org/springframework/ws/soap/server/endpoint/interceptor/SoapActionSmartEndpointInterceptor.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/soap/server/endpoint/interceptor/SoapActionSmartEndpointInterceptor.java
@@ -41,8 +41,8 @@ public class SoapActionSmartEndpointInterceptor extends DelegatingSmartSoapEndpo
 
 	@Override
 	protected boolean shouldIntercept(WebServiceMessage request, Object endpoint) {
-		if (request instanceof SoapMessage) {
-			String soapAction = ((SoapMessage) request).getSoapAction();
+		if (request instanceof SoapMessage soapMessage) {
+			String soapAction = soapMessage.getSoapAction();
 			if (StringUtils.hasLength(soapAction) && soapAction.charAt(0) == '"'
 					&& soapAction.charAt(soapAction.length() - 1) == '"') {
 				soapAction = soapAction.substring(1, soapAction.length() - 1);

--- a/spring-ws-core/src/main/java/org/springframework/ws/soap/server/endpoint/interceptor/SoapEnvelopeLoggingInterceptor.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/soap/server/endpoint/interceptor/SoapEnvelopeLoggingInterceptor.java
@@ -60,9 +60,8 @@ public class SoapEnvelopeLoggingInterceptor extends AbstractLoggingInterceptor i
 
 	@Override
 	protected Source getSource(WebServiceMessage message) {
-		if (message instanceof SoapMessage) {
-			SoapMessage soapMessage = (SoapMessage) message;
-			return soapMessage.getEnvelope().getSource();
+		if (message instanceof SoapMessage soapMessage) {
+            return soapMessage.getEnvelope().getSource();
 		} else {
 			return null;
 		}

--- a/spring-ws-core/src/main/java/org/springframework/ws/soap/server/endpoint/mapping/SoapActionAnnotationMethodEndpointMapping.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/soap/server/endpoint/mapping/SoapActionAnnotationMethodEndpointMapping.java
@@ -94,9 +94,8 @@ public class SoapActionAnnotationMethodEndpointMapping extends AbstractAnnotatio
 
 	@Override
 	protected String getLookupKeyForMessage(MessageContext messageContext) throws Exception {
-		if (messageContext.getRequest() instanceof SoapMessage) {
-			SoapMessage request = (SoapMessage) messageContext.getRequest();
-			String soapAction = request.getSoapAction();
+		if (messageContext.getRequest() instanceof SoapMessage request) {
+            String soapAction = request.getSoapAction();
 			if (StringUtils.hasLength(soapAction) && soapAction.charAt(0) == '"'
 					&& soapAction.charAt(soapAction.length() - 1) == '"') {
 				return soapAction.substring(1, soapAction.length() - 1);

--- a/spring-ws-core/src/main/java/org/springframework/ws/soap/server/endpoint/mapping/SoapActionEndpointMapping.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/soap/server/endpoint/mapping/SoapActionEndpointMapping.java
@@ -91,9 +91,8 @@ public class SoapActionEndpointMapping extends AbstractMapBasedEndpointMapping i
 
 	@Override
 	protected String getLookupKeyForMessage(MessageContext messageContext) throws Exception {
-		if (messageContext.getRequest() instanceof SoapMessage) {
-			SoapMessage request = (SoapMessage) messageContext.getRequest();
-			String soapAction = request.getSoapAction();
+		if (messageContext.getRequest() instanceof SoapMessage request) {
+            String soapAction = request.getSoapAction();
 			if (StringUtils.hasLength(soapAction) && soapAction.charAt(0) == '"'
 					&& soapAction.charAt(soapAction.length() - 1) == '"') {
 				return soapAction.substring(1, soapAction.length() - 1);

--- a/spring-ws-core/src/main/java/org/springframework/ws/support/DefaultStrategiesHelper.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/support/DefaultStrategiesHelper.java
@@ -145,38 +145,35 @@ public class DefaultStrategiesHelper {
 	/** Instantiates the given bean, simulating the standard bean life cycle. */
 	private <T> T instantiateBean(Class<T> clazz, ApplicationContext applicationContext) {
 		T strategy = BeanUtils.instantiateClass(clazz);
-		if (strategy instanceof BeanNameAware) {
-			BeanNameAware beanNameAware = (BeanNameAware) strategy;
-			beanNameAware.setBeanName(clazz.getName());
+		if (strategy instanceof BeanNameAware beanNameAware) {
+            beanNameAware.setBeanName(clazz.getName());
 		}
 		if (applicationContext != null) {
-			if (strategy instanceof BeanClassLoaderAware) {
-				((BeanClassLoaderAware) strategy).setBeanClassLoader(applicationContext.getClassLoader());
+			if (strategy instanceof BeanClassLoaderAware beanClassLoaderAware) {
+				beanClassLoaderAware.setBeanClassLoader(applicationContext.getClassLoader());
 			}
-			if (strategy instanceof BeanFactoryAware) {
-				((BeanFactoryAware) strategy).setBeanFactory(applicationContext);
+			if (strategy instanceof BeanFactoryAware beanFactoryAware) {
+				beanFactoryAware.setBeanFactory(applicationContext);
 			}
-			if (strategy instanceof ResourceLoaderAware) {
-				((ResourceLoaderAware) strategy).setResourceLoader(applicationContext);
+			if (strategy instanceof ResourceLoaderAware resourceLoaderAware) {
+				resourceLoaderAware.setResourceLoader(applicationContext);
 			}
-			if (strategy instanceof ApplicationEventPublisherAware) {
-				((ApplicationEventPublisherAware) strategy).setApplicationEventPublisher(applicationContext);
+			if (strategy instanceof ApplicationEventPublisherAware applicationEventPublisherAware) {
+				applicationEventPublisherAware.setApplicationEventPublisher(applicationContext);
 			}
-			if (strategy instanceof MessageSourceAware) {
-				((MessageSourceAware) strategy).setMessageSource(applicationContext);
+			if (strategy instanceof MessageSourceAware messageSourceAware) {
+				messageSourceAware.setMessageSource(applicationContext);
 			}
-			if (strategy instanceof ApplicationContextAware) {
-				ApplicationContextAware applicationContextAware = (ApplicationContextAware) strategy;
-				applicationContextAware.setApplicationContext(applicationContext);
+			if (strategy instanceof ApplicationContextAware applicationContextAware) {
+                applicationContextAware.setApplicationContext(applicationContext);
 			}
-			if (applicationContext instanceof WebApplicationContext && strategy instanceof ServletContextAware) {
-				ServletContext servletContext = ((WebApplicationContext) applicationContext).getServletContext();
-				((ServletContextAware) strategy).setServletContext(servletContext);
+			if (applicationContext instanceof WebApplicationContext webApplicationContext
+					&& strategy instanceof ServletContextAware servletContextAware) {
+                servletContextAware.setServletContext(webApplicationContext.getServletContext());
 			}
 		}
-		if (strategy instanceof InitializingBean) {
-			InitializingBean initializingBean = (InitializingBean) strategy;
-			try {
+		if (strategy instanceof InitializingBean initializingBean) {
+            try {
 				initializingBean.afterPropertiesSet();
 			} catch (Throwable ex) {
 				throw new BeanCreationException("Invocation of init method failed", ex);

--- a/spring-ws-core/src/main/java/org/springframework/ws/support/MarshallingUtils.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/support/MarshallingUtils.java
@@ -56,9 +56,9 @@ public abstract class MarshallingUtils {
 		Source payload = message.getPayloadSource();
 		if (payload == null) {
 			return null;
-		} else if (unmarshaller instanceof MimeUnmarshaller && message instanceof MimeMessage) {
-			MimeUnmarshaller mimeUnmarshaller = (MimeUnmarshaller) unmarshaller;
-			MimeMessageContainer container = new MimeMessageContainer((MimeMessage) message);
+		} else if (unmarshaller instanceof MimeUnmarshaller mimeUnmarshaller
+				&& message instanceof MimeMessage mimeMessage) {
+            MimeMessageContainer container = new MimeMessageContainer(mimeMessage);
 			return mimeUnmarshaller.unmarshal(payload, container);
 		} else {
 			return unmarshaller.unmarshal(payload);
@@ -74,9 +74,8 @@ public abstract class MarshallingUtils {
 	 * @throws IOException in case of I/O errors
 	 */
 	public static void marshal(Marshaller marshaller, Object graph, WebServiceMessage message) throws IOException {
-		if (marshaller instanceof MimeMarshaller && message instanceof MimeMessage) {
-			MimeMarshaller mimeMarshaller = (MimeMarshaller) marshaller;
-			MimeMessageContainer container = new MimeMessageContainer((MimeMessage) message);
+		if (marshaller instanceof MimeMarshaller mimeMarshaller && message instanceof MimeMessage mimeMessage) {
+            MimeMessageContainer container = new MimeMessageContainer(mimeMessage);
 			mimeMarshaller.marshal(graph, message.getPayloadResult(), container);
 		} else {
 			marshaller.marshal(graph, message.getPayloadResult());

--- a/spring-ws-core/src/main/java/org/springframework/ws/transport/http/CommonsHttpMessageSender.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/transport/http/CommonsHttpMessageSender.java
@@ -219,8 +219,8 @@ public class CommonsHttpMessageSender extends AbstractHttpWebServiceMessageSende
 	@Override
 	public void destroy() throws Exception {
 		HttpConnectionManager connectionManager = getHttpClient().getHttpConnectionManager();
-		if (connectionManager instanceof MultiThreadedHttpConnectionManager) {
-			((MultiThreadedHttpConnectionManager) connectionManager).shutdown();
+		if (connectionManager instanceof MultiThreadedHttpConnectionManager multiThreadedHttpConnectionManager) {
+			multiThreadedHttpConnectionManager.shutdown();
 		}
 	}
 

--- a/spring-ws-core/src/main/java/org/springframework/ws/transport/http/HttpComponentsMessageSender.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/transport/http/HttpComponentsMessageSender.java
@@ -158,12 +158,12 @@ public class HttpComponentsMessageSender extends AbstractHttpWebServiceMessageSe
 			throw new IllegalArgumentException("maxTotalConnections must be a positive value");
 		}
 		org.apache.http.conn.ClientConnectionManager connectionManager = getHttpClient().getConnectionManager();
-		if (!(connectionManager instanceof org.apache.http.impl.conn.PoolingClientConnectionManager)) {
+		if (!(connectionManager instanceof org.apache.http.impl.conn.PoolingClientConnectionManager poolingClientConnectionManager)) {
 			throw new IllegalArgumentException(
 					"maxTotalConnections is not supported on " + connectionManager.getClass().getName() + ". Use "
 							+ org.apache.http.impl.conn.PoolingClientConnectionManager.class.getName() + " instead");
 		}
-		((org.apache.http.impl.conn.PoolingClientConnectionManager) connectionManager).setMaxTotal(maxTotalConnections);
+		poolingClientConnectionManager.setMaxTotal(maxTotalConnections);
 	}
 
 	/**
@@ -183,14 +183,13 @@ public class HttpComponentsMessageSender extends AbstractHttpWebServiceMessageSe
 	 */
 	public void setMaxConnectionsPerHost(Map<String, String> maxConnectionsPerHost) throws URISyntaxException {
 		org.apache.http.conn.ClientConnectionManager connectionManager = getHttpClient().getConnectionManager();
-		if (!(connectionManager instanceof org.apache.http.impl.conn.PoolingClientConnectionManager)) {
+		if (!(connectionManager instanceof org.apache.http.impl.conn.PoolingClientConnectionManager poolingConnectionManager)) {
 			throw new IllegalArgumentException(
 					"maxConnectionsPerHost is not supported on " + connectionManager.getClass().getName() + ". Use "
 							+ org.apache.http.impl.conn.PoolingClientConnectionManager.class.getName() + " instead");
 		}
-		org.apache.http.impl.conn.PoolingClientConnectionManager poolingConnectionManager = (org.apache.http.impl.conn.PoolingClientConnectionManager) connectionManager;
 
-		for (Map.Entry<String, String> entry : maxConnectionsPerHost.entrySet()) {
+        for (Map.Entry<String, String> entry : maxConnectionsPerHost.entrySet()) {
 			URI uri = new URI(entry.getKey());
 			HttpHost host = new HttpHost(uri.getHost(), uri.getPort(), uri.getScheme());
 			final HttpRoute route;
@@ -220,9 +219,8 @@ public class HttpComponentsMessageSender extends AbstractHttpWebServiceMessageSe
 
 	@Override
 	public void afterPropertiesSet() throws Exception {
-		if (credentials != null && getHttpClient() instanceof org.apache.http.impl.client.DefaultHttpClient) {
-			((org.apache.http.impl.client.DefaultHttpClient) getHttpClient()).getCredentialsProvider()
-					.setCredentials(authScope, credentials);
+		if (credentials != null && getHttpClient() instanceof org.apache.http.impl.client.DefaultHttpClient defaultHttpClient) {
+			defaultHttpClient.getCredentialsProvider().setCredentials(authScope, credentials);
 		}
 	}
 

--- a/spring-ws-core/src/main/java/org/springframework/ws/transport/http/HttpUrlConnectionMessageSender.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/transport/http/HttpUrlConnectionMessageSender.java
@@ -68,11 +68,10 @@ public class HttpUrlConnectionMessageSender extends AbstractHttpWebServiceMessag
 	public WebServiceConnection createConnection(URI uri) throws IOException {
 		URL url = uri.toURL();
 		URLConnection connection = url.openConnection();
-		if (!(connection instanceof HttpURLConnection)) {
+		if (!(connection instanceof HttpURLConnection httpURLConnection)) {
 			throw new HttpTransportException("URI [" + uri + "] is not an HTTP URL");
 		} else {
-			HttpURLConnection httpURLConnection = (HttpURLConnection) connection;
-			prepareConnection(httpURLConnection);
+            prepareConnection(httpURLConnection);
 			return new HttpUrlConnection(httpURLConnection);
 		}
 	}

--- a/spring-ws-core/src/main/java/org/springframework/ws/transport/http/LastModifiedHelper.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/transport/http/LastModifiedHelper.java
@@ -44,8 +44,8 @@ class LastModifiedHelper {
 	 * @return the last modified date, as a long
 	 */
 	static long getLastModified(Source source) {
-		if (source instanceof DOMSource) {
-			Document document = TraxUtils.getDocument((DOMSource) source);
+		if (source instanceof DOMSource domSource) {
+			Document document = TraxUtils.getDocument(domSource);
 			return document != null ? getLastModified(document.getDocumentURI()) : -1;
 		} else {
 			return getLastModified(source.getSystemId());

--- a/spring-ws-core/src/main/java/org/springframework/ws/transport/http/LocationTransformerObjectSupport.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/transport/http/LocationTransformerObjectSupport.java
@@ -57,9 +57,8 @@ public abstract class LocationTransformerObjectSupport extends TransformerObject
 
 		List<Node> locationNodes = xPathExpression.evaluateAsNodeList(definitionDocument);
 		for (Node locationNode : locationNodes) {
-			if (locationNode instanceof Attr) {
-				Attr location = (Attr) locationNode;
-				if (StringUtils.hasLength(location.getValue())) {
+			if (locationNode instanceof Attr location) {
+                if (StringUtils.hasLength(location.getValue())) {
 					String newLocation = transformLocation(location.getValue(), request);
 					if (logger.isDebugEnabled()) {
 						logger.debug("Transforming [" + location.getValue() + "] to [" + newLocation + "]");

--- a/spring-ws-core/src/main/java/org/springframework/ws/transport/http/MessageDispatcherServlet.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/transport/http/MessageDispatcherServlet.java
@@ -431,8 +431,8 @@ public class MessageDispatcherServlet extends FrameworkServlet {
 			messageReceiver = context.getBean(getMessageReceiverBeanName(), WebServiceMessageReceiver.class);
 		} catch (NoSuchBeanDefinitionException ex) {
 			messageReceiver = defaultStrategiesHelper.getDefaultStrategy(WebServiceMessageReceiver.class, context);
-			if (messageReceiver instanceof BeanNameAware) {
-				((BeanNameAware) messageReceiver).setBeanName(getServletName());
+			if (messageReceiver instanceof BeanNameAware beanNameAware) {
+				beanNameAware.setBeanName(getServletName());
 			}
 			if (logger.isDebugEnabled()) {
 				logger.debug("No MessageDispatcher found in servlet '" + getServletName() + "': using default");

--- a/spring-ws-core/src/main/java/org/springframework/ws/transport/support/WebServiceMessageReceiverObjectSupport.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/transport/support/WebServiceMessageReceiverObjectSupport.java
@@ -88,10 +88,9 @@ public abstract class WebServiceMessageReceiverObjectSupport implements Initiali
 			receiver.receive(messageContext);
 			if (messageContext.hasResponse()) {
 				WebServiceMessage response = messageContext.getResponse();
-				if (response instanceof FaultAwareWebServiceMessage && connection instanceof FaultAwareWebServiceConnection) {
-					FaultAwareWebServiceMessage faultResponse = (FaultAwareWebServiceMessage) response;
-					FaultAwareWebServiceConnection faultConnection = (FaultAwareWebServiceConnection) connection;
-					faultConnection.setFaultCode(faultResponse.getFaultCode());
+				if (response instanceof FaultAwareWebServiceMessage faultResponse
+						&& connection instanceof FaultAwareWebServiceConnection faultConnection) {
+                    faultConnection.setFaultCode(faultResponse.getFaultCode());
 				}
 				connection.send(messageContext.getResponse());
 			}
@@ -116,8 +115,8 @@ public abstract class WebServiceMessageReceiverObjectSupport implements Initiali
 	 */
 	protected void handleNoEndpointFoundException(NoEndpointFoundException ex, WebServiceConnection connection,
 			WebServiceMessageReceiver receiver) throws Exception {
-		if (connection instanceof EndpointAwareWebServiceConnection) {
-			((EndpointAwareWebServiceConnection) connection).endpointNotFound();
+		if (connection instanceof EndpointAwareWebServiceConnection endpointAwareWebServiceConnection) {
+			endpointAwareWebServiceConnection.endpointNotFound();
 		}
 	}
 

--- a/spring-ws-core/src/main/java/org/springframework/ws/wsdl/wsdl11/provider/DefaultMessagesProvider.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/wsdl/wsdl11/provider/DefaultMessagesProvider.java
@@ -51,9 +51,8 @@ public class DefaultMessagesProvider implements MessagesProvider {
 		Assert.notNull(types, "No types element present in definition");
 		for (Object element : types.getExtensibilityElements()) {
 			ExtensibilityElement extensibilityElement = (ExtensibilityElement) element;
-			if (extensibilityElement instanceof Schema) {
-				Schema schema = (Schema) extensibilityElement;
-				if (schema.getElement() != null) {
+			if (extensibilityElement instanceof Schema schema) {
+                if (schema.getElement() != null) {
 					createMessages(definition, schema.getElement());
 				}
 			}

--- a/spring-ws-core/src/test/java/org/springframework/ws/soap/AbstractSoapMessageTestCase.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/soap/AbstractSoapMessageTestCase.java
@@ -106,13 +106,11 @@ public abstract class AbstractSoapMessageTestCase extends AbstractMimeMessageTes
 	@Test
 	public void testSetStreamingPayload() throws Exception {
 
-		if (!(soapMessage instanceof StreamingWebServiceMessage)) {
+		if (!(soapMessage instanceof StreamingWebServiceMessage streamingMessage)) {
 			return;
 		}
 
-		StreamingWebServiceMessage streamingMessage = (StreamingWebServiceMessage) soapMessage;
-
-		final QName name = new QName("http://springframework.org", "root", "");
+        final QName name = new QName("http://springframework.org", "root", "");
 
 		streamingMessage.setStreamingPayload(new StreamingPayload() {
 			public QName getName() {

--- a/spring-ws-core/src/test/java/org/springframework/ws/transport/http/AbstractHttpWebServiceMessageSenderIntegrationTestCase.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/transport/http/AbstractHttpWebServiceMessageSenderIntegrationTestCase.java
@@ -106,8 +106,8 @@ public abstract class AbstractHttpWebServiceMessageSenderIntegrationTestCase<T e
 
 		messageSender = createMessageSender();
 
-		if (messageSender instanceof InitializingBean) {
-			((InitializingBean) messageSender).afterPropertiesSet();
+		if (messageSender instanceof InitializingBean initializingBean) {
+			initializingBean.afterPropertiesSet();
 		}
 
 		saajMessageFactory = MessageFactory.newInstance(SOAPConstants.SOAP_1_1_PROTOCOL);

--- a/spring-ws-security/src/main/java/org/springframework/ws/soap/security/AbstractWsSecurityInterceptor.java
+++ b/spring-ws-security/src/main/java/org/springframework/ws/soap/security/AbstractWsSecurityInterceptor.java
@@ -310,8 +310,8 @@ public abstract class AbstractWsSecurityInterceptor implements SoapEndpointInter
 		}
 		SoapBody response = ((SoapMessage) messageContext.getResponse()).getSoapBody();
 		SoapFault fault;
-		if (response instanceof Soap11Body) {
-			fault = ((Soap11Body) response).addFault(ex.getFaultCode(), ex.getFaultString(), Locale.ENGLISH);
+		if (response instanceof Soap11Body soap11Body) {
+			fault = soap11Body.addFault(ex.getFaultCode(), ex.getFaultString(), Locale.ENGLISH);
 		} else {
 			fault = response.addClientOrSenderFault(ex.getFaultString(), Locale.ENGLISH);
 		}

--- a/spring-ws-security/src/main/java/org/springframework/ws/soap/security/wss4j2/callback/AbstractWsPasswordCallbackHandler.java
+++ b/spring-ws-security/src/main/java/org/springframework/ws/soap/security/wss4j2/callback/AbstractWsPasswordCallbackHandler.java
@@ -45,9 +45,8 @@ public abstract class AbstractWsPasswordCallbackHandler extends AbstractCallback
 	 */
 	@Override
 	protected final void handleInternal(Callback callback) throws IOException, UnsupportedCallbackException {
-		if (callback instanceof WSPasswordCallback) {
-			WSPasswordCallback passwordCallback = (WSPasswordCallback) callback;
-			switch (passwordCallback.getUsage()) {
+		if (callback instanceof WSPasswordCallback passwordCallback) {
+            switch (passwordCallback.getUsage()) {
 				case WSPasswordCallback.DECRYPT:
 					handleDecrypt(passwordCallback);
 					break;
@@ -69,10 +68,10 @@ public abstract class AbstractWsPasswordCallbackHandler extends AbstractCallback
 				default:
 					throw new UnsupportedCallbackException(callback, "Unknown usage [" + passwordCallback.getUsage() + "]");
 			}
-		} else if (callback instanceof CleanupCallback) {
-			handleCleanup((CleanupCallback) callback);
-		} else if (callback instanceof UsernameTokenPrincipalCallback) {
-			handleUsernameTokenPrincipal((UsernameTokenPrincipalCallback) callback);
+		} else if (callback instanceof CleanupCallback cleanupCallback) {
+			handleCleanup(cleanupCallback);
+		} else if (callback instanceof UsernameTokenPrincipalCallback usernameTokenPrincipalCallback) {
+			handleUsernameTokenPrincipal(usernameTokenPrincipalCallback);
 		} else {
 			throw new UnsupportedCallbackException(callback);
 		}

--- a/spring-ws-security/src/main/java/org/springframework/ws/soap/security/wss4j2/callback/SimplePasswordValidationCallbackHandler.java
+++ b/spring-ws-security/src/main/java/org/springframework/ws/soap/security/wss4j2/callback/SimplePasswordValidationCallbackHandler.java
@@ -45,8 +45,8 @@ public class SimplePasswordValidationCallbackHandler extends AbstractWsPasswordC
 	/** Sets the users to validate against. Property names are usernames, property values are passwords. */
 	public void setUsers(Properties users) {
 		for (Map.Entry<Object, Object> entry : users.entrySet()) {
-			if (entry.getKey() instanceof String && entry.getValue() instanceof String) {
-				this.users.put((String) entry.getKey(), (String) entry.getValue());
+			if (entry.getKey() instanceof String key && entry.getValue() instanceof String value) {
+				this.users.put(key, value);
 			}
 		}
 	}

--- a/spring-ws-security/src/main/java/org/springframework/ws/soap/security/wss4j2/support/CryptoFactoryBean.java
+++ b/spring-ws-security/src/main/java/org/springframework/ws/soap/security/wss4j2/support/CryptoFactoryBean.java
@@ -90,9 +90,8 @@ public class CryptoFactoryBean implements FactoryBean<Crypto>, InitializingBean 
 		try {
 			return resource.getFile().getAbsolutePath();
 		} catch (IOException ex) {
-			if (resource instanceof ClassPathResource) {
-				ClassPathResource classPathResource = (ClassPathResource) resource;
-				return classPathResource.getPath();
+			if (resource instanceof ClassPathResource classPathResource) {
+                return classPathResource.getPath();
 			} else {
 				throw ex;
 			}

--- a/spring-ws-security/src/test/java/org/springframework/ws/soap/security/wss4j2/Wss4jMessageInterceptorSamlTestCase.java
+++ b/spring-ws-security/src/test/java/org/springframework/ws/soap/security/wss4j2/Wss4jMessageInterceptorSamlTestCase.java
@@ -86,10 +86,8 @@ public abstract class Wss4jMessageInterceptorSamlTestCase extends Wss4jTestCase 
 		public void handle(Callback[] callbacks) {
 
 			for (Callback value : callbacks) {
-				if (value instanceof SAMLCallback) {
-
-					SAMLCallback callback = (SAMLCallback) value;
-					callback.setSamlVersion(Version.SAML_20);
+				if (value instanceof SAMLCallback callback) {
+                    callback.setSamlVersion(Version.SAML_20);
 					callback.setIssuerCrypto(crypto);
 					callback.setIssuerKeyName("rsaKey");
 					callback.setIssuerKeyPassword("123456");

--- a/spring-ws-security/src/test/java/org/springframework/ws/soap/security/wss4j2/Wss4jTestCase.java
+++ b/spring-ws-security/src/test/java/org/springframework/ws/soap/security/wss4j2/Wss4jTestCase.java
@@ -144,8 +144,8 @@ public abstract class Wss4jTestCase {
 
 	protected Object getMessage(SoapMessage soapMessage) {
 
-		if (soapMessage instanceof SaajSoapMessage) {
-			return ((SaajSoapMessage) soapMessage).getSaajMessage();
+		if (soapMessage instanceof SaajSoapMessage saajSoapMessage) {
+			return saajSoapMessage.getSaajMessage();
 		}
 
 		throw new IllegalArgumentException("Illegal message: " + soapMessage);
@@ -153,8 +153,8 @@ public abstract class Wss4jTestCase {
 
 	protected void setMessage(SoapMessage soapMessage, Object message) {
 
-		if (soapMessage instanceof SaajSoapMessage) {
-			((SaajSoapMessage) soapMessage).setSaajMessage((SOAPMessage) message);
+		if (soapMessage instanceof SaajSoapMessage saajSoapMessage) {
+			saajSoapMessage.setSaajMessage((SOAPMessage) message);
 			return;
 		}
 

--- a/spring-ws-support/src/main/java/org/springframework/ws/transport/http/HttpsUrlConnectionMessageSender.java
+++ b/spring-ws-support/src/main/java/org/springframework/ws/transport/http/HttpsUrlConnectionMessageSender.java
@@ -134,9 +134,8 @@ public class HttpsUrlConnectionMessageSender extends HttpUrlConnectionMessageSen
 	@Override
 	protected void prepareConnection(HttpURLConnection connection) throws IOException {
 		super.prepareConnection(connection);
-		if (connection instanceof HttpsURLConnection) {
-			HttpsURLConnection httpsConnection = (HttpsURLConnection) connection;
-			httpsConnection.setSSLSocketFactory(createSslSocketFactory());
+		if (connection instanceof HttpsURLConnection httpsConnection) {
+            httpsConnection.setSSLSocketFactory(createSslSocketFactory());
 
 			if (hostnameVerifier != null) {
 				httpsConnection.setHostnameVerifier(hostnameVerifier);

--- a/spring-ws-support/src/main/java/org/springframework/ws/transport/jms/JmsMessageReceiver.java
+++ b/spring-ws-support/src/main/java/org/springframework/ws/transport/jms/JmsMessageReceiver.java
@@ -67,10 +67,10 @@ public class JmsMessageReceiver extends SimpleWebServiceMessageReceiverObjectSup
 	 */
 	protected final void handleMessage(Message request, Session session) throws Exception {
 		JmsReceiverConnection connection;
-		if (request instanceof BytesMessage) {
-			connection = new JmsReceiverConnection((BytesMessage) request, session);
-		} else if (request instanceof TextMessage) {
-			connection = new JmsReceiverConnection((TextMessage) request, textMessageEncoding, session);
+		if (request instanceof BytesMessage bytesMessage) {
+			connection = new JmsReceiverConnection(bytesMessage, session);
+		} else if (request instanceof TextMessage textMessage) {
+			connection = new JmsReceiverConnection(textMessage, textMessageEncoding, session);
 		} else {
 			throw new IllegalArgumentException(
 					"Wrong message type: [" + request.getClass() + "]. Only BytesMessages or TextMessages can be handled.");

--- a/spring-ws-support/src/main/java/org/springframework/ws/transport/jms/JmsReceiverConnection.java
+++ b/spring-ws-support/src/main/java/org/springframework/ws/transport/jms/JmsReceiverConnection.java
@@ -159,10 +159,10 @@ public class JmsReceiverConnection extends AbstractReceiverConnection {
 
 	@Override
 	protected InputStream getRequestInputStream() throws IOException {
-		if (requestMessage instanceof BytesMessage) {
-			return new BytesMessageInputStream((BytesMessage) requestMessage);
-		} else if (requestMessage instanceof TextMessage) {
-			return new TextMessageInputStream((TextMessage) requestMessage, textMessageEncoding);
+		if (requestMessage instanceof BytesMessage bytesMessage) {
+			return new BytesMessageInputStream(bytesMessage);
+		} else if (requestMessage instanceof TextMessage textMessage) {
+			return new TextMessageInputStream(textMessage, textMessageEncoding);
 		} else {
 			throw new IllegalStateException("Unknown request message type [" + requestMessage + "]");
 		}
@@ -203,10 +203,10 @@ public class JmsReceiverConnection extends AbstractReceiverConnection {
 
 	@Override
 	protected OutputStream getResponseOutputStream() throws IOException {
-		if (responseMessage instanceof BytesMessage) {
-			return new BytesMessageOutputStream((BytesMessage) responseMessage);
-		} else if (responseMessage instanceof TextMessage) {
-			return new TextMessageOutputStream((TextMessage) responseMessage, textMessageEncoding);
+		if (responseMessage instanceof BytesMessage bytesMessage) {
+			return new BytesMessageOutputStream(bytesMessage);
+		} else if (responseMessage instanceof TextMessage textMessage) {
+			return new TextMessageOutputStream(textMessage, textMessageEncoding);
 		} else {
 			throw new IllegalStateException("Unknown response message type [" + responseMessage + "]");
 		}

--- a/spring-ws-support/src/main/java/org/springframework/ws/transport/jms/JmsSenderConnection.java
+++ b/spring-ws-support/src/main/java/org/springframework/ws/transport/jms/JmsSenderConnection.java
@@ -183,10 +183,10 @@ public class JmsSenderConnection extends AbstractSenderConnection {
 
 	@Override
 	protected OutputStream getRequestOutputStream() throws IOException {
-		if (requestMessage instanceof BytesMessage) {
-			return new BytesMessageOutputStream((BytesMessage) requestMessage);
-		} else if (requestMessage instanceof TextMessage) {
-			return new TextMessageOutputStream((TextMessage) requestMessage, textMessageEncoding);
+		if (requestMessage instanceof BytesMessage bytesMessage) {
+			return new BytesMessageOutputStream(bytesMessage);
+		} else if (requestMessage instanceof TextMessage textMessage) {
+			return new TextMessageOutputStream(textMessage, textMessageEncoding);
 		} else {
 			throw new IllegalStateException("Unknown request message type [" + requestMessage + "]");
 		}
@@ -287,10 +287,10 @@ public class JmsSenderConnection extends AbstractSenderConnection {
 
 	@Override
 	protected InputStream getResponseInputStream() throws IOException {
-		if (responseMessage instanceof BytesMessage) {
-			return new BytesMessageInputStream((BytesMessage) responseMessage);
-		} else if (responseMessage instanceof TextMessage) {
-			return new TextMessageInputStream((TextMessage) responseMessage, textMessageEncoding);
+		if (responseMessage instanceof BytesMessage bytesMessage) {
+			return new BytesMessageInputStream(bytesMessage);
+		} else if (responseMessage instanceof TextMessage textMessage) {
+			return new TextMessageInputStream(textMessage, textMessageEncoding);
 		} else {
 			throw new IllegalStateException("Unknown response message type [" + responseMessage + "]");
 		}

--- a/spring-ws-support/src/main/java/org/springframework/ws/transport/jms/support/JmsTransportUtils.java
+++ b/spring-ws-support/src/main/java/org/springframework/ws/transport/jms/support/JmsTransportUtils.java
@@ -106,11 +106,10 @@ public abstract class JmsTransportUtils {
 			return null;
 		}
 		String destinationName;
-		if (destination instanceof Queue) {
-			destinationName = ((Queue) destination).getQueueName();
-		} else if (destination instanceof Topic) {
-			Topic topic = (Topic) destination;
-			destinationName = topic.getTopicName();
+		if (destination instanceof Queue queueDestination) {
+			destinationName = queueDestination.getQueueName();
+		} else if (destination instanceof Topic topic) {
+            destinationName = topic.getTopicName();
 		} else {
 			throw new IllegalArgumentException("Destination [ " + destination + "] is neither Queue nor Topic");
 		}

--- a/spring-ws-support/src/main/java/org/springframework/ws/transport/mail/MailReceiverConnection.java
+++ b/spring-ws-support/src/main/java/org/springframework/ws/transport/mail/MailReceiverConnection.java
@@ -109,8 +109,8 @@ public class MailReceiverConnection extends AbstractReceiverConnection {
 	public URI getUri() throws URISyntaxException {
 		try {
 			Address[] recipients = requestMessage.getRecipients(Message.RecipientType.TO);
-			if (!ObjectUtils.isEmpty(recipients) && recipients[0] instanceof InternetAddress) {
-				return MailTransportUtils.toUri((InternetAddress) recipients[0], requestMessage.getSubject());
+			if (!ObjectUtils.isEmpty(recipients) && recipients[0] instanceof InternetAddress internetAddress) {
+				return MailTransportUtils.toUri(internetAddress, requestMessage.getSubject());
 			} else {
 				throw new URISyntaxException("", "Could not determine To header");
 			}

--- a/spring-ws-support/src/main/java/org/springframework/ws/transport/xmpp/XmppMessageReceiver.java
+++ b/spring-ws-support/src/main/java/org/springframework/ws/transport/xmpp/XmppMessageReceiver.java
@@ -104,9 +104,8 @@ public class XmppMessageReceiver extends AbstractStandaloneMessageReceiver {
 		@Override
 		public void processStanza(Stanza packet) {
 			logger.info("Received " + packet);
-			if (packet instanceof Message) {
-				Message message = (Message) packet;
-				try {
+			if (packet instanceof Message message) {
+                try {
 					XmppReceiverConnection wsConnection = new XmppReceiverConnection(connection, message);
 					wsConnection.setMessageEncoding(messageEncoding);
 					handleConnection(wsConnection);

--- a/spring-ws-support/src/main/java/org/springframework/ws/transport/xmpp/XmppSenderConnection.java
+++ b/spring-ws-support/src/main/java/org/springframework/ws/transport/xmpp/XmppSenderConnection.java
@@ -153,8 +153,8 @@ public class XmppSenderConnection extends AbstractSenderConnection {
 		StanzaCollector collector = connection.createStanzaCollector(packetFilter);
 		try {
 			Stanza packet = receiveTimeout >= 0 ? collector.nextResult(receiveTimeout) : collector.nextResult();
-			if (packet instanceof Message) {
-				responseMessage = (Message) packet;
+			if (packet instanceof Message message) {
+				responseMessage = message;
 			} else if (packet != null) {
 				throw new IllegalArgumentException(
 						"Wrong packet type: [" + packet.getClass() + "]. Only Messages can be handled.");

--- a/spring-ws-test/src/main/java/org/springframework/ws/test/client/ExceptionResponseCreator.java
+++ b/spring-ws-test/src/main/java/org/springframework/ws/test/client/ExceptionResponseCreator.java
@@ -44,8 +44,8 @@ class ExceptionResponseCreator implements ResponseCreator {
 	@Override
 	public WebServiceMessage createResponse(URI uri, WebServiceMessage request, WebServiceMessageFactory factory)
 			throws IOException {
-		if (exception instanceof IOException) {
-			throw (IOException) exception;
+		if (exception instanceof IOException ioException) {
+			throw ioException;
 		} else {
 			throw (RuntimeException) exception;
 		}

--- a/spring-ws-test/src/main/java/org/springframework/ws/test/client/MockSenderConnection.java
+++ b/spring-ws-test/src/main/java/org/springframework/ws/test/client/MockSenderConnection.java
@@ -102,8 +102,8 @@ class MockSenderConnection implements WebServiceConnection, ResponseActions {
 
 	@Override
 	public String getErrorMessage() throws IOException {
-		if (responseCreator instanceof ErrorResponseCreator) {
-			return ((ErrorResponseCreator) responseCreator).getErrorMessage();
+		if (responseCreator instanceof ErrorResponseCreator errorResponseCreator) {
+			return errorResponseCreator.getErrorMessage();
 		} else {
 			return null;
 		}

--- a/spring-ws-test/src/main/java/org/springframework/ws/test/client/SoapFaultResponseCreator.java
+++ b/spring-ws-test/src/main/java/org/springframework/ws/test/client/SoapFaultResponseCreator.java
@@ -35,12 +35,11 @@ abstract class SoapFaultResponseCreator extends AbstractResponseCreator {
 
 	@Override
 	protected void doWithResponse(URI uri, WebServiceMessage request, WebServiceMessage response) throws IOException {
-		if (!(response instanceof SoapMessage)) {
+		if (!(response instanceof SoapMessage soapResponse)) {
 			fail("Response is not a SOAP message");
 			return;
 		}
-		SoapMessage soapResponse = (SoapMessage) response;
-		SoapBody responseBody = soapResponse.getSoapBody();
+        SoapBody responseBody = soapResponse.getSoapBody();
 		if (responseBody == null) {
 			fail("SOAP message [" + response + "] does not contain SOAP body");
 		}

--- a/spring-ws-test/src/main/java/org/springframework/ws/test/server/ResponseMatchers.java
+++ b/spring-ws-test/src/main/java/org/springframework/ws/test/server/ResponseMatchers.java
@@ -144,9 +144,8 @@ public abstract class ResponseMatchers {
 	public static ResponseMatcher noFault() {
 		return new ResponseMatcher() {
 			public void match(WebServiceMessage request, WebServiceMessage response) throws IOException, AssertionError {
-				if (response instanceof FaultAwareWebServiceMessage) {
-					FaultAwareWebServiceMessage faultMessage = (FaultAwareWebServiceMessage) response;
-					if (faultMessage.hasFault()) {
+				if (response instanceof FaultAwareWebServiceMessage faultMessage) {
+                    if (faultMessage.hasFault()) {
 						fail("Response has a SOAP Fault: \"" + faultMessage.getFaultReason() + "\"");
 					}
 				}

--- a/spring-ws-test/src/main/java/org/springframework/ws/test/support/MockStrategiesHelper.java
+++ b/spring-ws-test/src/main/java/org/springframework/ws/test/support/MockStrategiesHelper.java
@@ -102,13 +102,11 @@ public class MockStrategiesHelper {
 						"No " + ClassUtils.getShortName(type) + " found, using default " + ClassUtils.getShortName(defaultType));
 			}
 			T defaultStrategy = BeanUtils.instantiateClass(defaultType);
-			if (defaultStrategy instanceof ApplicationContextAware) {
-				ApplicationContextAware applicationContextAware = (ApplicationContextAware) defaultStrategy;
-				applicationContextAware.setApplicationContext(applicationContext);
+			if (defaultStrategy instanceof ApplicationContextAware applicationContextAware) {
+                applicationContextAware.setApplicationContext(applicationContext);
 			}
-			if (defaultStrategy instanceof InitializingBean) {
-				InitializingBean initializingBean = (InitializingBean) defaultStrategy;
-				try {
+			if (defaultStrategy instanceof InitializingBean initializingBean) {
+                try {
 					initializingBean.afterPropertiesSet();
 				} catch (Exception ex) {
 					throw new BeanCreationException("Invocation of init method failed", ex);

--- a/spring-xml/src/main/java/org/springframework/xml/dom/DomContentHandler.java
+++ b/spring-xml/src/main/java/org/springframework/xml/dom/DomContentHandler.java
@@ -53,8 +53,8 @@ public class DomContentHandler implements ContentHandler {
 	public DomContentHandler(Node node) {
 		Assert.notNull(node, "node must not be null");
 		this.node = node;
-		if (node instanceof Document) {
-			document = (Document) node;
+		if (node instanceof Document documentNode) {
+			document = documentNode;
 		} else {
 			document = node.getOwnerDocument();
 		}

--- a/spring-xml/src/main/java/org/springframework/xml/transform/TraxUtils.java
+++ b/spring-xml/src/main/java/org/springframework/xml/transform/TraxUtils.java
@@ -61,8 +61,8 @@ public abstract class TraxUtils {
 	 */
 	public static Document getDocument(DOMSource source) {
 		Node node = source.getNode();
-		if (node instanceof Document) {
-			return (Document) node;
+		if (node instanceof Document document) {
+			return document;
 		} else if (node != null) {
 			return node.getOwnerDocument();
 		} else {
@@ -78,8 +78,8 @@ public abstract class TraxUtils {
 	 * @param callback the callback to invoke for each kind of source
 	 */
 	public static void doWithSource(Source source, SourceCallback callback) throws Exception {
-		if (source instanceof DOMSource) {
-			callback.domSource(((DOMSource) source).getNode());
+		if (source instanceof DOMSource domSource) {
+			callback.domSource(domSource.getNode());
 			return;
 		} else if (StaxUtils.isStaxSource(source)) {
 			XMLStreamReader streamReader = StaxUtils.getXMLStreamReader(source);
@@ -93,13 +93,11 @@ public abstract class TraxUtils {
 					return;
 				}
 			}
-		} else if (source instanceof SAXSource) {
-			SAXSource saxSource = (SAXSource) source;
-			callback.saxSource(saxSource.getXMLReader(), saxSource.getInputSource());
+		} else if (source instanceof SAXSource saxSource) {
+            callback.saxSource(saxSource.getXMLReader(), saxSource.getInputSource());
 			return;
-		} else if (source instanceof StreamSource) {
-			StreamSource streamSource = (StreamSource) source;
-			if (streamSource.getInputStream() != null) {
+		} else if (source instanceof StreamSource streamSource) {
+            if (streamSource.getInputStream() != null) {
 				callback.streamSource(streamSource.getInputStream());
 				return;
 			} else if (streamSource.getReader() != null) {
@@ -124,8 +122,8 @@ public abstract class TraxUtils {
 	 * @param callback the callback to invoke for each kind of result
 	 */
 	public static void doWithResult(Result result, ResultCallback callback) throws Exception {
-		if (result instanceof DOMResult) {
-			callback.domResult(((DOMResult) result).getNode());
+		if (result instanceof DOMResult domResult) {
+			callback.domResult(domResult.getNode());
 			return;
 		} else if (StaxUtils.isStaxResult(result)) {
 			XMLStreamWriter streamWriter = StaxUtils.getXMLStreamWriter(result);
@@ -139,13 +137,11 @@ public abstract class TraxUtils {
 					return;
 				}
 			}
-		} else if (result instanceof SAXResult) {
-			SAXResult saxSource = (SAXResult) result;
-			callback.saxResult(saxSource.getHandler(), saxSource.getLexicalHandler());
+		} else if (result instanceof SAXResult saxSource) {
+            callback.saxResult(saxSource.getHandler(), saxSource.getLexicalHandler());
 			return;
-		} else if (result instanceof StreamResult) {
-			StreamResult streamSource = (StreamResult) result;
-			if (streamSource.getOutputStream() != null) {
+		} else if (result instanceof StreamResult streamSource) {
+            if (streamSource.getOutputStream() != null) {
 				callback.streamResult(streamSource.getOutputStream());
 				return;
 			} else if (streamSource.getWriter() != null) {

--- a/spring-xml/src/main/java/org/springframework/xml/xsd/commons/CommonsXsdSchemaCollection.java
+++ b/spring-xml/src/main/java/org/springframework/xml/xsd/commons/CommonsXsdSchemaCollection.java
@@ -184,8 +184,8 @@ public class CommonsXsdSchemaCollection implements XsdSchemaCollection, Initiali
 		List<XmlSchemaObject> schemaItems = schema.getItems();
 		for (int i = 0; i < schemaItems.size(); i++) {
 			XmlSchemaObject schemaObject = schemaItems.get(i);
-			if (schemaObject instanceof XmlSchemaInclude) {
-				XmlSchema includedSchema = ((XmlSchemaInclude) schemaObject).getSchema();
+			if (schemaObject instanceof XmlSchemaInclude xmlSchemaInclude) {
+				XmlSchema includedSchema = xmlSchemaInclude.getSchema();
 				if (!processedIncludes.contains(includedSchema)) {
 					inlineIncludes(includedSchema, processedIncludes, processedImports);
 					findImports(includedSchema, processedImports, processedIncludes);
@@ -202,9 +202,8 @@ public class CommonsXsdSchemaCollection implements XsdSchemaCollection, Initiali
 		processedImports.add(schema);
 		List<XmlSchemaExternal> externals = schema.getExternals();
 		for (XmlSchemaExternal external : externals) {
-			if (external instanceof XmlSchemaImport) {
-				XmlSchemaImport schemaImport = (XmlSchemaImport) external;
-				XmlSchema importedSchema = schemaImport.getSchema();
+			if (external instanceof XmlSchemaImport schemaImport) {
+                XmlSchema importedSchema = schemaImport.getSchema();
 				if (!"http://www.w3.org/XML/1998/namespace".equals(schemaImport.getNamespace()) && importedSchema != null
 						&& !processedImports.contains(importedSchema)) {
 					inlineIncludes(importedSchema, processedIncludes, processedImports);


### PR DESCRIPTION
spring-ws now uses Java 17. I replace the explicit class cast with the new `instanceof` pattern variable. This should make the code more readable.