### PR TITLE
Add Revved up by Develocity badge

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -3,6 +3,7 @@ image:https://spring.io/badges/spring-ws/snapshot.svg["Spring Web Services", lin
 
 image:https://jenkins.spring.io/buildStatus/icon?job=spring-ws%2Fmain&subject=main[link=https://jenkins.spring.io/view/SpringWebServices/job/spring-ws/]
 image:https://jenkins.spring.io/buildStatus/icon?job=spring-ws%2F3.1.x&subject=3.1.x[link=https://jenkins.spring.io/view/SpringWebServices/job/spring-ws/]
+image:https://img.shields.io/badge/Revved%20up%20by-Develocity-06A0CE?logo=Gradle&labelColor=02303A["Revved up by Develocity", link="https://ge.spring.io/scans?search.rootProjectNames=Spring Web Services"]
 
 = Spring Web Services
 


### PR DESCRIPTION
This pull request adds a badge to the project's README to indicate that it uses the Develocity instance hosted at https://ge.spring.io/.

Other Spring projects, such as [Spring Boot](https://github.com/spring-projects/spring-boot?tab=readme-ov-file#spring-boot---) and [Spring Framework](https://github.com/spring-projects/spring-framework?tab=readme-ov-file#-spring-framework--), already have the badge present in their README. 