### PR TITLE
Wss4jHandler: override securement password using the message context

### DIFF
--- a/spring-ws-security/src/main/java/org/springframework/ws/soap/security/wss4j2/Wss4jHandler.java
+++ b/spring-ws-security/src/main/java/org/springframework/ws/soap/security/wss4j2/Wss4jHandler.java
@@ -16,6 +16,8 @@
 
 package org.springframework.ws.soap.security.wss4j2;
 
+import static org.springframework.ws.soap.security.wss4j2.Wss4jSecurityInterceptor.SECUREMENT_PASSWORD_PROPERTY_NAME;
+
 import java.util.List;
 import java.util.Properties;
 
@@ -26,6 +28,7 @@ import org.apache.wss4j.dom.engine.WSSecurityEngineResult;
 import org.apache.wss4j.dom.handler.HandlerAction;
 import org.apache.wss4j.dom.handler.RequestData;
 import org.apache.wss4j.dom.handler.WSHandler;
+import org.springframework.util.StringUtils;
 import org.springframework.ws.context.MessageContext;
 import org.w3c.dom.Document;
 
@@ -90,6 +93,10 @@ class Wss4jHandler extends WSHandler {
 
 	@Override
 	public String getPassword(Object msgContext) {
+		String contextPassword = (String)getProperty(msgContext, SECUREMENT_PASSWORD_PROPERTY_NAME);
+		if (StringUtils.hasLength(contextPassword)) {
+			return contextPassword;
+		}
 		return securementPassword;
 	}
 

--- a/spring-ws-security/src/main/java/org/springframework/ws/soap/security/wss4j2/Wss4jHandler.java
+++ b/spring-ws-security/src/main/java/org/springframework/ws/soap/security/wss4j2/Wss4jHandler.java
@@ -36,6 +36,7 @@ import org.w3c.dom.Document;
  * @author Tareq Abed Rabbo
  * @author Arjen Poutsma
  * @author Jamin Hitchcock
+ * @author Lars Uffmann
  * @since 2.3.0
  */
 class Wss4jHandler extends WSHandler {

--- a/spring-ws-security/src/main/java/org/springframework/ws/soap/security/wss4j2/Wss4jSecurityInterceptor.java
+++ b/spring-ws-security/src/main/java/org/springframework/ws/soap/security/wss4j2/Wss4jSecurityInterceptor.java
@@ -137,6 +137,7 @@ import org.w3c.dom.Element;
  * @author Greg Turnquist
  * @author Jamin Hitchcock
  * @author Rob Leland
+ * @author Lars Uffmann
  * @see <a href="http://ws.apache.org/wss4j/">Apache WSS4J 2.0</a>
  * @since 2.3.0
  */

--- a/spring-ws-security/src/main/java/org/springframework/ws/soap/security/wss4j2/Wss4jSecurityInterceptor.java
+++ b/spring-ws-security/src/main/java/org/springframework/ws/soap/security/wss4j2/Wss4jSecurityInterceptor.java
@@ -143,6 +143,8 @@ import org.w3c.dom.Element;
 public class Wss4jSecurityInterceptor extends AbstractWsSecurityInterceptor implements InitializingBean {
 
 	public static final String SECUREMENT_USER_PROPERTY_NAME = "Wss4jSecurityInterceptor.securementUser";
+	
+	public static final String SECUREMENT_PASSWORD_PROPERTY_NAME = "Wss4jSecurityInterceptor.securementPassword";
 
 	private String securementActions;
 

--- a/spring-ws-security/src/test/java/org/springframework/ws/soap/security/wss4j2/Wss4jMessageInterceptorUsernameTokenTestCase.java
+++ b/spring-ws-security/src/test/java/org/springframework/ws/soap/security/wss4j2/Wss4jMessageInterceptorUsernameTokenTestCase.java
@@ -88,7 +88,23 @@ public abstract class Wss4jMessageInterceptorUsernameTokenTestCase extends Wss4j
 
 		interceptor.secureMessage(message, messageContext);
 
-		assertAddUsernameTokenPlainText(message);
+		assertAddUsernameTokenPlainText(message, "Bert", "Ernie");
+	}
+
+	@Test
+	public void testAddUsernameTokenPlainTextContextCredentialsOverride() throws Exception {
+		Wss4jSecurityInterceptor interceptor = prepareInterceptor("UsernameToken", false, false);
+		interceptor.setSecurementUsername("Bert");
+		interceptor.setSecurementPassword("Ernie");
+		SoapMessage message = loadSoap11Message("empty-soap.xml");
+
+		MessageContext messageContext = getSoap11MessageContext(message);
+		messageContext.setProperty(Wss4jSecurityInterceptor.SECUREMENT_USER_PROPERTY_NAME, "Bibo");
+		messageContext.setProperty(Wss4jSecurityInterceptor.SECUREMENT_PASSWORD_PROPERTY_NAME, "Elmo");
+
+		interceptor.secureMessage(message, messageContext);
+
+		assertAddUsernameTokenPlainText(message, "Bibo","Elmo");
 	}
 
 	@Test
@@ -114,7 +130,7 @@ public abstract class Wss4jMessageInterceptorUsernameTokenTestCase extends Wss4j
 				getDocument(message));
 	}
 
-	protected void assertAddUsernameTokenPlainText(SoapMessage message) {
+	protected void assertAddUsernameTokenPlainText(SoapMessage message, String expectedUsername, String expectedPassword) {
 
 		Object result = getMessage(message);
 
@@ -122,9 +138,9 @@ public abstract class Wss4jMessageInterceptorUsernameTokenTestCase extends Wss4j
 
 		Document doc = getDocument(message);
 
-		assertXpathEvaluatesTo("Invalid Username", "Bert",
+		assertXpathEvaluatesTo("Invalid Username", expectedUsername,
 				"/SOAP-ENV:Envelope/SOAP-ENV:Header/wsse:Security/wsse:UsernameToken/wsse:Username/text()", doc);
-		assertXpathEvaluatesTo("Invalid Password", "Ernie",
+		assertXpathEvaluatesTo("Invalid Password", expectedPassword,
 				"/SOAP-ENV:Envelope/SOAP-ENV:Header/wsse:Security/wsse:UsernameToken/wsse:Password[@Type='http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText']/text()",
 				doc);
 	}


### PR DESCRIPTION
# Wss4jHandler: override securement password using the message context

Analog to the ``securementUsername`,` allow to override the `securementPassword` using the `MessageContext` in order to efficiently support per-request credentials.

```
  @Override
  public boolean handleRequest(MessageContext messageContext) throws WebServiceClientException {
    AlternativeCredentials alternativeCredentials = context.get();
    // override default interceptor username/password using per-request messageContext.
    if (alternativeCredentials != null) {
      messageContext.setProperty(Wss4jSecurityInterceptor.SECUREMENT_USER_PROPERTY_NAME,
          alternativeCredentials.getUsername());
      messageContext.setProperty(Wss4jSecurityInterceptor.SECUREMENT_PASSWORD_PROPERTY_NAME,
          alternativeCredentials.getPassword());
    }
    return super.handleRequest(messageContext);
  }

```

This is a non breaking change, test are added accordingly.