### PR TITLE
Allow usage of XMLUnit placeholders in request and response matchers.

### DIFF
--- a/spring-ws-test/pom.xml
+++ b/spring-ws-test/pom.xml
@@ -52,6 +52,12 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.xmlunit</groupId>
+			<artifactId>xmlunit-placeholders</artifactId>
+			<version>${xmlunit.version}</version>
+		</dependency>
+
+		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-test</artifactId>
 			<scope>test</scope>

--- a/spring-ws-test/src/main/java/org/springframework/ws/test/support/matcher/xmlunit2/PayloadDiffMatcher.java
+++ b/spring-ws-test/src/main/java/org/springframework/ws/test/support/matcher/xmlunit2/PayloadDiffMatcher.java
@@ -28,6 +28,8 @@ import org.springframework.xml.transform.TransformerHelper;
 import org.w3c.dom.Document;
 import org.xmlunit.builder.DiffBuilder;
 import org.xmlunit.diff.Diff;
+import org.xmlunit.diff.DifferenceEvaluators;
+import org.xmlunit.placeholder.PlaceholderDifferenceEvaluator;
 
 /**
  * Matches {@link Source} payloads.
@@ -68,6 +70,8 @@ public class PayloadDiffMatcher extends DiffMatcher {
 		return DiffBuilder.compare(expectedDocument) //
 				.withTest(actualDocument) //
 				.ignoreWhitespace() //
+				.withDifferenceEvaluator(
+						DifferenceEvaluators.chain(new PlaceholderDifferenceEvaluator(), DifferenceEvaluators.Default))
 				.checkForSimilar() //
 				.build();
 	}

--- a/spring-ws-test/src/main/java/org/springframework/ws/test/support/matcher/xmlunit2/SoapEnvelopeDiffMatcher.java
+++ b/spring-ws-test/src/main/java/org/springframework/ws/test/support/matcher/xmlunit2/SoapEnvelopeDiffMatcher.java
@@ -32,6 +32,8 @@ import org.springframework.xml.transform.TransformerHelper;
 import org.w3c.dom.Document;
 import org.xmlunit.builder.DiffBuilder;
 import org.xmlunit.diff.Diff;
+import org.xmlunit.diff.DifferenceEvaluators;
+import org.xmlunit.placeholder.PlaceholderDifferenceEvaluator;
 
 /**
  * Matches {@link Source} SOAP envelopes.
@@ -56,7 +58,12 @@ public class SoapEnvelopeDiffMatcher extends AbstractSoapMessageMatcher {
 
 		Document actualDocument = soapMessage.getDocument();
 		Document expectedDocument = createDocumentFromSource(expected);
-		Diff diff = DiffBuilder.compare(expectedDocument).ignoreWhitespace().withTest(actualDocument).checkForSimilar()
+		Diff diff = DiffBuilder.compare(expectedDocument)
+				.ignoreWhitespace()
+				.withTest(actualDocument)
+				.withDifferenceEvaluator(
+						DifferenceEvaluators.chain(new PlaceholderDifferenceEvaluator(), DifferenceEvaluators.Default))
+				.checkForSimilar()
 				.build();
 		assertTrue("Envelopes are different, " + diff.toString(), !diff.hasDifferences());
 	}

--- a/spring-ws-test/src/test/java/org/springframework/ws/test/support/matcher/xmlunit2/PayloadDiffMatcherTest.java
+++ b/spring-ws-test/src/test/java/org/springframework/ws/test/support/matcher/xmlunit2/PayloadDiffMatcherTest.java
@@ -44,6 +44,21 @@ public class PayloadDiffMatcherTest {
 	}
 
 	@Test
+	public void matchWithXmlIgnore() {
+
+		var xml = "<element xmlns='http://example.com'>%s</element>";
+		WebServiceMessage message = createMock(WebServiceMessage.class);
+
+		expect(message.getPayloadSource()).andReturn(new StringSource(xml.formatted("1234"))).times(2);
+		replay(message);
+
+		var matcher = new PayloadDiffMatcher(new StringSource(xml.formatted("${xmlunit.ignore}")));
+		matcher.match(message);
+
+		verify(message);
+	}
+
+	@Test
 	public void matchIgnoringWhitespace() {
 
 		var xml = "<response><success>true</success></response>";

--- a/src/main/asciidoctor/client.adoc
+++ b/src/main/asciidoctor/client.adoc
@@ -457,7 +457,7 @@ The `RequestMatchers` class provides the following request matchers:
 | Expects any sort of request.
 
 | `payload()`
-| Expects a given request payload.
+| Expects a given request payload. May include https://github.com/xmlunit/user-guide/wiki/Placeholders[XMLUnit Placeholders]
 
 | `validPayload()`
 | Expects the request payload to validate against given XSD schemas.
@@ -467,6 +467,9 @@ The `RequestMatchers` class provides the following request matchers:
 
 | `soapHeader()`
 | Expects a given SOAP header to exist in the request message.
+
+| `soapEnvelope()`
+| Expects a given SOAP payload. May include https://github.com/xmlunit/user-guide/wiki/Placeholders[XMLUnit Placeholders]
 
 | `connectionTo()`
 | Expects a connection to the given URL.

--- a/src/main/asciidoctor/server.adoc
+++ b/src/main/asciidoctor/server.adoc
@@ -1244,7 +1244,7 @@ The `ResponseMatchers` class provides the following response matchers:
 | Description
 
 | `payload()`
-| Expects a given response payload.
+| Expects a given response payload. May include https://github.com/xmlunit/user-guide/wiki/Placeholders[XMLUnit Placeholders].
 
 | `validPayload()`
 | Expects the response payload to validate against given XSD schemas.
@@ -1254,6 +1254,9 @@ The `ResponseMatchers` class provides the following response matchers:
 
 | `soapHeader()`
 | Expects a given SOAP header to exist in the response message.
+
+| `soapEnvelope()`
+| Expects a given SOAP payload. May include https://github.com/xmlunit/user-guide/wiki/Placeholders[XMLUnit Placeholders].
 
 | `noFault()`
 | Expects that the response message does not contain a SOAP Fault.


### PR DESCRIPTION
This PR adds support for [XMLUnit Placeholders](https://github.com/xmlunit/user-guide/wiki/Placeholders) in unit tests.