### PR TITLE
Fix transformLocation for X-Forwarded-Host containing host:port

### DIFF
--- a/spring-ws-core/src/main/java/org/springframework/ws/transport/http/LocationTransformerObjectSupport.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/transport/http/LocationTransformerObjectSupport.java
@@ -97,7 +97,11 @@ public abstract class LocationTransformerObjectSupport extends TransformerObject
 		int serverPort = StringUtils.hasText(xForwardedPort) ? Integer.parseInt(xForwardedPort) : request.getServerPort();
 
 		StringBuilder url = new StringBuilder(scheme);
-		url.append("://").append(serverName).append(':').append(serverPort);
+		url.append("://").append(serverName);
+		boolean serverHasColonAfterAt = serverName.indexOf("@") < serverName.indexOf(":");
+		if(!serverHasColonAfterAt) {
+			url.append(':').append(serverPort);
+		}
 		if (location.startsWith("/")) {
 			// a relative path, prepend the context path
 			url.append(request.getContextPath()).append(location);


### PR DESCRIPTION
Update `transformLocation` to not append port when `serverName` has `:` after `@`.

Fixes #1420