### PR TITLE
Update HttpComponents5ClientFactory to use setConnectionTimeout

### DIFF
--- a/spring-ws-core/src/main/java/org/springframework/ws/transport/http/HttpComponents5ClientFactory.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/transport/http/HttpComponents5ClientFactory.java
@@ -211,13 +211,12 @@ public class HttpComponents5ClientFactory implements FactoryBean<CloseableHttpCl
 		if (this.connectionManagerBuilderCustomizer != null) {
 			this.connectionManagerBuilderCustomizer.customize(connectionManagerBuilder);
 		}
-
 		this.connectionManager = connectionManagerBuilder.build();
 
 		applyMaxConnectionsPerHost(connectionManager);
 
 		RequestConfig.Builder requestConfigBuilder = RequestConfig.custom() //
-				.setConnectionRequestTimeout(Timeout.of(connectionTimeout)) //
+				.setConnectTimeout(Timeout.of(connectionTimeout)) //
 				.setResponseTimeout(Timeout.of(readTimeout));
 
 		HttpClientBuilder httpClientBuilder = HttpClientBuilder.create() //


### PR DESCRIPTION
Update `HttpComponents5ClientFactory` to use `setConnectionTimeout` instead of `setConnectionRequestTimeout` to restore the behaviour as before.

Fixes #1436