### PR TITLE
Update Develocity Maven Conventations extension to 0.0.22

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,6 +3,6 @@
 	<extension>
 		<groupId>io.spring.develocity.conventions</groupId>
 		<artifactId>develocity-conventions-maven-extension</artifactId>
-		<version>0.0.19</version>
+		<version>0.0.22</version>
 	</extension>
 </extensions>


### PR DESCRIPTION
Updates `io.spring.develocity.conventions:develocity-conventions-maven:0.0.19` to `0.0.22`