### PR TITLE
Сonvert ActiveMQConnectionFactory to SingleConnectionFactory in jms-sender-applicationContext.xml

### DIFF
--- a/spring-ws-support/src/test/resources/org/springframework/ws/transport/jms/jms-sender-applicationContext.xml
+++ b/spring-ws-support/src/test/resources/org/springframework/ws/transport/jms/jms-sender-applicationContext.xml
@@ -3,8 +3,14 @@
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
 
-	<bean id="connectionFactory" class="org.apache.activemq.ActiveMQConnectionFactory">
+	<bean id="targetConnectionFactory"
+		  class="org.apache.activemq.ActiveMQConnectionFactory">
 		<property name="brokerURL" value="vm://localhost?broker.persistent=false"/>
+	</bean>
+
+	<bean id="connectionFactory"
+		  class="org.springframework.jms.connection.SingleConnectionFactory">
+		<property name="targetConnectionFactory" ref="targetConnectionFactory"/>
 	</bean>
 
 	<bean id="requestQueue" class="org.apache.activemq.command.ActiveMQQueue">


### PR DESCRIPTION
I've been thinking about this for a very long time to be honest, and have come to one conclusion, please correct me if I'm drastically wrong.

However, the point is that I believe that when we test sending from TemporaryQueue that is created when each connection is created, it can't be synchronized. The way I understand it is this:

```
JmsMessageSender creates a TemporaryQueue on its JMS-Connection A

JmsTemplate tries to send a response to the same queue over a new connection B

TemporaryQueue exists only within Connection A and is not available/deleted in B
```

And then it turns out all tests where we test TemporaryQueue, they should be synchronized. I have made all ChannelFactory in the tests to be SingleConnectionFactory, however I guess this is necessary for tests where we use TemporaryQueue, but it would be easier to do it for all tests.

If I am misunderstanding something, please correct it

Fix: #1539