### PR TITLE
SOAP WS-Addressing MessageId header is always required when receiving message using Addressing10

### DIFF
--- a/spring-ws-core/src/main/java/org/springframework/ws/soap/addressing/version/Addressing10.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/soap/addressing/version/Addressing10.java
@@ -52,11 +52,16 @@ public class Addressing10 extends AbstractAddressingVersion {
 		if (map.getAction() == null) {
 			return false;
 		}
-		if (map.getReplyTo() != null || map.getFaultTo() != null) {
+		if (requiresMessageId(map.getReplyTo()) || requiresMessageId(map.getFaultTo())) {
 			return map.getMessageId() != null;
 		}
 		return true;
 
+	}
+
+	private boolean requiresMessageId(@Nullable EndpointReference endpointReference) {
+		return endpointReference != null && !hasAnonymousAddress(endpointReference)
+				&& !hasNoneAddress(endpointReference);
 	}
 
 	@Override

--- a/spring-ws-core/src/test/java/org/springframework/ws/soap/addressing/server/AddressingInterceptor10Tests.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/soap/addressing/server/AddressingInterceptor10Tests.java
@@ -65,4 +65,52 @@ class AddressingInterceptor10Tests extends AbstractAddressingInterceptorTests {
 		verify(this.strategyMock);
 	}
 
+	@Test
+	void testAnonymousReplyToWithoutMessageId() throws Exception {
+
+		SaajSoapMessage valid = loadSaajMessage(getTestPath() + "/request-anonymous-no-message-id.xml");
+		MessageContext context = new DefaultMessageContext(valid, new SaajSoapMessageFactory(this.messageFactory));
+		expect(this.strategyMock.isDuplicate(null)).andReturn(false);
+		replay(this.strategyMock);
+
+		boolean result = this.interceptor.handleRequest(context, null);
+
+		assertThat(result).isTrue();
+		assertThat(context.hasResponse()).isFalse();
+
+		verify(this.strategyMock);
+	}
+
+	@Test
+	void testNoReplyToWithoutMessageId() throws Exception {
+
+		SaajSoapMessage valid = loadSaajMessage(getTestPath() + "/request-no-reply-to-no-message-id.xml");
+		MessageContext context = new DefaultMessageContext(valid, new SaajSoapMessageFactory(this.messageFactory));
+		expect(this.strategyMock.isDuplicate(null)).andReturn(false);
+		replay(this.strategyMock);
+
+		boolean result = this.interceptor.handleRequest(context, null);
+
+		assertThat(result).isTrue();
+		assertThat(context.hasResponse()).isFalse();
+
+		verify(this.strategyMock);
+	}
+
+	@Test
+	void testNoneReplyToWithoutMessageId() throws Exception {
+
+		SaajSoapMessage valid = loadSaajMessage(getTestPath() + "/request-none-no-message-id.xml");
+		MessageContext context = new DefaultMessageContext(valid, new SaajSoapMessageFactory(this.messageFactory));
+		expect(this.strategyMock.isDuplicate(null)).andReturn(false);
+		replay(this.strategyMock);
+
+		boolean result = this.interceptor.handleRequest(context, null);
+
+		assertThat(result).isTrue();
+		assertThat(context.hasResponse()).isFalse();
+
+		verify(this.strategyMock);
+	}
+
 }

--- a/spring-ws-core/src/test/java/org/springframework/ws/soap/addressing/server/AddressingInterceptor10Tests.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/soap/addressing/server/AddressingInterceptor10Tests.java
@@ -47,69 +47,72 @@ class AddressingInterceptor10Tests extends AbstractAddressingInterceptorTests {
 
 	@Test
 	void testNoTo() throws Exception {
-
 		SaajSoapMessage valid = loadSaajMessage(getTestPath() + "/request-no-to.xml");
 		MessageContext context = new DefaultMessageContext(valid, new SaajSoapMessageFactory(this.messageFactory));
 		URI messageId = new URI("uid:1234");
 		expect(this.strategyMock.newMessageId((SoapMessage) context.getResponse())).andReturn(messageId);
 		replay(this.strategyMock);
-		boolean result = this.interceptor.handleResponse(context, null);
 
+		boolean result = this.interceptor.handleResponse(context, null);
 		assertThat(result).isTrue();
 		assertThat(context.hasResponse()).isTrue();
-
 		SaajSoapMessage expectedResponse = loadSaajMessage(getTestPath() + "/response-anonymous.xml");
-
 		assertXMLSimilar(expectedResponse, (SaajSoapMessage) context.getResponse());
-
 		verify(this.strategyMock);
 	}
 
 	@Test
 	void testAnonymousReplyToWithoutMessageId() throws Exception {
-
 		SaajSoapMessage valid = loadSaajMessage(getTestPath() + "/request-anonymous-no-message-id.xml");
 		MessageContext context = new DefaultMessageContext(valid, new SaajSoapMessageFactory(this.messageFactory));
 		expect(this.strategyMock.isDuplicate(null)).andReturn(false);
 		replay(this.strategyMock);
 
 		boolean result = this.interceptor.handleRequest(context, null);
-
 		assertThat(result).isTrue();
 		assertThat(context.hasResponse()).isFalse();
-
 		verify(this.strategyMock);
 	}
 
 	@Test
 	void testNoReplyToWithoutMessageId() throws Exception {
-
 		SaajSoapMessage valid = loadSaajMessage(getTestPath() + "/request-no-reply-to-no-message-id.xml");
 		MessageContext context = new DefaultMessageContext(valid, new SaajSoapMessageFactory(this.messageFactory));
 		expect(this.strategyMock.isDuplicate(null)).andReturn(false);
 		replay(this.strategyMock);
 
 		boolean result = this.interceptor.handleRequest(context, null);
-
 		assertThat(result).isTrue();
 		assertThat(context.hasResponse()).isFalse();
-
 		verify(this.strategyMock);
 	}
 
 	@Test
 	void testNoneReplyToWithoutMessageId() throws Exception {
-
 		SaajSoapMessage valid = loadSaajMessage(getTestPath() + "/request-none-no-message-id.xml");
 		MessageContext context = new DefaultMessageContext(valid, new SaajSoapMessageFactory(this.messageFactory));
 		expect(this.strategyMock.isDuplicate(null)).andReturn(false);
 		replay(this.strategyMock);
 
 		boolean result = this.interceptor.handleRequest(context, null);
-
 		assertThat(result).isTrue();
 		assertThat(context.hasResponse()).isFalse();
+		verify(this.strategyMock);
+	}
 
+	@Test
+	void testAnonymousReplyToWithNonAnonymousFaultToWithoutMessageId() throws Exception {
+		SaajSoapMessage valid = loadSaajMessage(
+				getTestPath() + "/request-anonymous-reply-to-fault-to-no-message-id.xml");
+		MessageContext context = new DefaultMessageContext(valid, new SaajSoapMessageFactory(this.messageFactory));
+		replay(this.strategyMock);
+
+		boolean result = this.interceptor.handleRequest(context, null);
+		assertThat(result).isFalse();
+		assertThat(context.hasResponse()).isTrue();
+		SaajSoapMessage expectedResponse = loadSaajMessage(
+				getTestPath() + "/response-anonymous-reply-to-fault-to-no-message-id.xml");
+		assertXMLSimilar(expectedResponse, (SaajSoapMessage) context.getResponse());
 		verify(this.strategyMock);
 	}
 

--- a/spring-ws-core/src/test/resources/org/springframework/ws/soap/addressing/10/request-anonymous-no-message-id.xml
+++ b/spring-ws-core/src/test/resources/org/springframework/ws/soap/addressing/10/request-anonymous-no-message-id.xml
@@ -1,0 +1,15 @@
+<S:Envelope xmlns:S="http://www.w3.org/2003/05/soap-envelope"
+			xmlns:wsa="http://www.w3.org/2005/08/addressing">
+	<S:Header>
+		<wsa:ReplyTo>
+			<wsa:Address>http://www.w3.org/2005/08/addressing/anonymous</wsa:Address>
+		</wsa:ReplyTo>
+		<wsa:To>mailto:fabrikam@example.com</wsa:To>
+		<wsa:Action>http://example.com/fabrikam/mail/Delete</wsa:Action>
+	</S:Header>
+	<S:Body>
+		<f:Delete xmlns:f="http://example.com/fabrikam">
+			<maxCount>42</maxCount>
+		</f:Delete>
+	</S:Body>
+</S:Envelope>

--- a/spring-ws-core/src/test/resources/org/springframework/ws/soap/addressing/10/request-anonymous-reply-to-fault-to-no-message-id.xml
+++ b/spring-ws-core/src/test/resources/org/springframework/ws/soap/addressing/10/request-anonymous-reply-to-fault-to-no-message-id.xml
@@ -1,0 +1,18 @@
+<S:Envelope xmlns:S="http://www.w3.org/2003/05/soap-envelope"
+			xmlns:wsa="http://www.w3.org/2005/08/addressing">
+	<S:Header>
+		<wsa:ReplyTo>
+			<wsa:Address>http://www.w3.org/2005/08/addressing/anonymous</wsa:Address>
+		</wsa:ReplyTo>
+		<wsa:FaultTo>
+			<wsa:Address>http://example.com/business/client1</wsa:Address>
+		</wsa:FaultTo>
+		<wsa:To>mailto:fabrikam@example.com</wsa:To>
+		<wsa:Action>http://example.com/fabrikam/mail/Delete</wsa:Action>
+	</S:Header>
+	<S:Body>
+		<f:Delete xmlns:f="http://example.com/fabrikam">
+			<maxCount>42</maxCount>
+		</f:Delete>
+	</S:Body>
+</S:Envelope>

--- a/spring-ws-core/src/test/resources/org/springframework/ws/soap/addressing/10/request-no-reply-to-no-message-id.xml
+++ b/spring-ws-core/src/test/resources/org/springframework/ws/soap/addressing/10/request-no-reply-to-no-message-id.xml
@@ -1,0 +1,11 @@
+<S:Envelope xmlns:S="http://www.w3.org/2003/05/soap-envelope"
+			xmlns:wsa="http://www.w3.org/2005/08/addressing">
+	<S:Header>
+		<wsa:Action>http://example.com/fabrikam/mail/Delete</wsa:Action>
+	</S:Header>
+	<S:Body>
+		<f:Delete xmlns:f="http://example.com/fabrikam">
+			<f:maxCount>42</f:maxCount>
+		</f:Delete>
+	</S:Body>
+</S:Envelope>

--- a/spring-ws-core/src/test/resources/org/springframework/ws/soap/addressing/10/request-none-no-message-id.xml
+++ b/spring-ws-core/src/test/resources/org/springframework/ws/soap/addressing/10/request-none-no-message-id.xml
@@ -1,0 +1,15 @@
+<S:Envelope xmlns:S="http://www.w3.org/2003/05/soap-envelope"
+			xmlns:wsa="http://www.w3.org/2005/08/addressing">
+	<S:Header>
+		<wsa:ReplyTo>
+			<wsa:Address>http://www.w3.org/2005/08/addressing/none</wsa:Address>
+		</wsa:ReplyTo>
+		<wsa:To>mailto:fabrikam@example.com</wsa:To>
+		<wsa:Action>http://example.com/fabrikam/mail/Delete</wsa:Action>
+	</S:Header>
+	<S:Body>
+		<f:Delete xmlns:f="http://example.com/fabrikam">
+			<maxCount>42</maxCount>
+		</f:Delete>
+	</S:Body>
+</S:Envelope>

--- a/spring-ws-core/src/test/resources/org/springframework/ws/soap/addressing/10/response-anonymous-reply-to-fault-to-no-message-id.xml
+++ b/spring-ws-core/src/test/resources/org/springframework/ws/soap/addressing/10/response-anonymous-reply-to-fault-to-no-message-id.xml
@@ -1,0 +1,17 @@
+<env:Envelope xmlns:env="http://www.w3.org/2003/05/soap-envelope"
+			  xmlns:wsa="http://www.w3.org/2005/08/addressing">
+	<env:Header/>
+	<env:Body>
+		<env:Fault>
+			<env:Code>
+				<env:Value>env:Sender</env:Value>
+				<env:Subcode>
+					<env:Value>wsa:MessageAddressingHeaderRequired</env:Value>
+				</env:Subcode>
+			</env:Code>
+			<env:Reason>
+				<env:Text xml:lang="en">A required header representing a Message Addressing Property is not present</env:Text>
+			</env:Reason>
+		</env:Fault>
+	</env:Body>
+</env:Envelope>


### PR DESCRIPTION
WS-Addressing 1.0 requests may omit `MessageID` when replies are sent to the anonymous endpoint or discarded via the none endpoint. Spring WS currently defaults a missing `ReplyTo` to anonymous, but still treats the non-null default endpoint as requiring `MessageID`.

This updates the WS-Addressing 1.0 required-property check so `MessageID` is only required when `ReplyTo` or `FaultTo` targets a non-anonymous, non-none endpoint. The regression coverage includes explicit anonymous `ReplyTo`, missing `ReplyTo`, and none `ReplyTo` requests without `MessageID`.

Closes gh-1427

Testing:

- `./gradlew :spring-ws-core:test --tests org.springframework.ws.soap.addressing.server.AddressingInterceptor10Tests --max-workers=2`
- `./gradlew :spring-ws-core:test --tests 'org.springframework.ws.soap.addressing.*' --max-workers=2`
- `./gradlew :spring-ws-core:test --max-workers=2`
- `./gradlew :spring-ws-core:check --max-workers=2`
- `git diff --check`