### PR TITLE
Adding header element is not reflected in SAAJ message

### DIFF
--- a/spring-ws-core/src/main/java/org/springframework/ws/soap/saaj/SaajSoapMessage.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/soap/saaj/SaajSoapMessage.java
@@ -196,8 +196,10 @@ public class SaajSoapMessage extends AbstractSoapMessage {
 		// return saajSoapMessage.getSaajMessage().getSOAPPart(); // does not work, see
 		// SWS-345
 		try {
+			SOAPMessage message = getSaajMessage();
+			message.saveChanges();
 			ByteArrayOutputStream bos = new ByteArrayOutputStream();
-			getSaajMessage().writeTo(bos);
+			message.writeTo(bos);
 			ByteArrayInputStream bis = new ByteArrayInputStream(bos.toByteArray());
 			SOAPMessage saajMessage = this.messageFactory.createMessage(getSaajMessage().getMimeHeaders(), bis);
 			setSaajMessage(saajMessage);

--- a/spring-ws-core/src/main/java/org/springframework/ws/soap/saaj/SaajSoapMessage.java
+++ b/spring-ws-core/src/main/java/org/springframework/ws/soap/saaj/SaajSoapMessage.java
@@ -196,12 +196,12 @@ public class SaajSoapMessage extends AbstractSoapMessage {
 		// return saajSoapMessage.getSaajMessage().getSOAPPart(); // does not work, see
 		// SWS-345
 		try {
-			SOAPMessage message = getSaajMessage();
-			message.saveChanges();
+			SOAPMessage currentSaajMessage = getSaajMessage();
+			currentSaajMessage.saveChanges();
 			ByteArrayOutputStream bos = new ByteArrayOutputStream();
-			message.writeTo(bos);
+			currentSaajMessage.writeTo(bos);
 			ByteArrayInputStream bis = new ByteArrayInputStream(bos.toByteArray());
-			SOAPMessage saajMessage = this.messageFactory.createMessage(getSaajMessage().getMimeHeaders(), bis);
+			SOAPMessage saajMessage = this.messageFactory.createMessage(currentSaajMessage.getMimeHeaders(), bis);
 			setSaajMessage(saajMessage);
 			return saajMessage.getSOAPPart();
 		}

--- a/spring-ws-core/src/test/java/org/springframework/ws/soap/saaj/SaajSoap11MessageTests.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/soap/saaj/SaajSoap11MessageTests.java
@@ -18,6 +18,7 @@ package org.springframework.ws.soap.saaj;
 
 import java.util.Iterator;
 
+import javax.xml.namespace.QName;
 import javax.xml.transform.Result;
 import javax.xml.transform.Source;
 
@@ -29,6 +30,8 @@ import jakarta.xml.soap.SOAPMessage;
 import org.junit.jupiter.api.Test;
 import org.xmlunit.assertj.XmlAssert;
 
+import org.springframework.ws.soap.SoapHeader;
+import org.springframework.ws.soap.SoapHeaderElement;
 import org.springframework.ws.soap.SoapMessage;
 import org.springframework.ws.soap.soap11.AbstractSoap11MessageTests;
 import org.springframework.xml.transform.StringResult;
@@ -58,6 +61,22 @@ class SaajSoap11MessageTests extends AbstractSoap11MessageTests {
 		this.saajMessage.getSOAPHeader().detachNode();
 
 		return new SaajSoapMessage(this.saajMessage, true, messageFactory);
+	}
+
+	@Test
+	void getDocumentReflectsAddedHeaderElement() throws Exception {
+
+		MessageFactory messageFactory = MessageFactory.newInstance(SOAPConstants.SOAP_1_1_PROTOCOL);
+		SaajSoapMessage message = new SaajSoapMessage(messageFactory.createMessage(), true, messageFactory);
+		SoapHeader soapHeader = message.getSoapHeader();
+		QName qName = new QName("http://www.w3.org/2005/08/addressing", "Action", "a");
+		SoapHeaderElement soapHeaderElement = soapHeader.addHeaderElement(qName);
+		soapHeaderElement.setMustUnderstand(true);
+		soapHeaderElement.setText("some text");
+
+		XmlAssert.assertThat(message.getDocument())
+			.valueByXPath("count(//*[local-name()='Action' and namespace-uri()='http://www.w3.org/2005/08/addressing' and text()='some text'])")
+			.isEqualTo("1");
 	}
 
 	@Test

--- a/spring-ws-core/src/test/java/org/springframework/ws/soap/saaj/SaajSoap11MessageTests.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/soap/saaj/SaajSoap11MessageTests.java
@@ -17,6 +17,7 @@
 package org.springframework.ws.soap.saaj;
 
 import java.util.Iterator;
+import java.util.Map;
 
 import javax.xml.namespace.QName;
 import javax.xml.transform.Result;
@@ -65,7 +66,6 @@ class SaajSoap11MessageTests extends AbstractSoap11MessageTests {
 
 	@Test
 	void getDocumentReflectsAddedHeaderElement() throws Exception {
-
 		MessageFactory messageFactory = MessageFactory.newInstance(SOAPConstants.SOAP_1_1_PROTOCOL);
 		SaajSoapMessage message = new SaajSoapMessage(messageFactory.createMessage(), true, messageFactory);
 		SoapHeader soapHeader = message.getSoapHeader();
@@ -74,9 +74,10 @@ class SaajSoap11MessageTests extends AbstractSoap11MessageTests {
 		soapHeaderElement.setMustUnderstand(true);
 		soapHeaderElement.setText("some text");
 
-		XmlAssert.assertThat(message.getDocument())
-			.valueByXPath("count(//*[local-name()='Action' and namespace-uri()='http://www.w3.org/2005/08/addressing' and text()='some text'])")
-			.isEqualTo("1");
+		XmlAssert xmlAssert = XmlAssert.assertThat(message.getDocument())
+			.withNamespaceContext(Map.of("a", "http://www.w3.org/2005/08/addressing"));
+		xmlAssert.hasXPath("//a:Action");
+		xmlAssert.valueByXPath("//a:Action").isEqualTo("some text");
 	}
 
 	@Test

--- a/spring-ws-core/src/test/java/org/springframework/ws/soap/saaj/SaajSoap12MessageTests.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/soap/saaj/SaajSoap12MessageTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.ws.soap.saaj;
 
+import javax.xml.namespace.QName;
 import javax.xml.transform.Result;
 import javax.xml.transform.Source;
 
@@ -25,6 +26,8 @@ import jakarta.xml.soap.SOAPMessage;
 import org.junit.jupiter.api.Test;
 import org.xmlunit.assertj.XmlAssert;
 
+import org.springframework.ws.soap.SoapHeader;
+import org.springframework.ws.soap.SoapHeaderElement;
 import org.springframework.ws.soap.SoapMessage;
 import org.springframework.ws.soap.soap12.AbstractSoap12MessageTests;
 import org.springframework.xml.transform.StringResult;
@@ -53,6 +56,22 @@ class SaajSoap12MessageTests extends AbstractSoap12MessageTests {
 		this.saajMessage = messageFactory.createMessage();
 		this.saajMessage.getSOAPHeader().detachNode();
 		return new SaajSoapMessage(this.saajMessage, true, messageFactory);
+	}
+
+	@Test
+	void getDocumentReflectsAddedHeaderElement() throws Exception {
+
+		MessageFactory messageFactory = MessageFactory.newInstance(SOAPConstants.SOAP_1_2_PROTOCOL);
+		SaajSoapMessage message = new SaajSoapMessage(messageFactory.createMessage(), true, messageFactory);
+		SoapHeader soapHeader = message.getSoapHeader();
+		QName qName = new QName("http://www.w3.org/2005/08/addressing", "Action", "a");
+		SoapHeaderElement soapHeaderElement = soapHeader.addHeaderElement(qName);
+		soapHeaderElement.setMustUnderstand(true);
+		soapHeaderElement.setText("some text");
+
+		XmlAssert.assertThat(message.getDocument())
+			.valueByXPath("count(//*[local-name()='Action' and namespace-uri()='http://www.w3.org/2005/08/addressing' and text()='some text'])")
+			.isEqualTo("1");
 	}
 
 	@Test

--- a/spring-ws-core/src/test/java/org/springframework/ws/soap/saaj/SaajSoap12MessageTests.java
+++ b/spring-ws-core/src/test/java/org/springframework/ws/soap/saaj/SaajSoap12MessageTests.java
@@ -16,6 +16,8 @@
 
 package org.springframework.ws.soap.saaj;
 
+import java.util.Map;
+
 import javax.xml.namespace.QName;
 import javax.xml.transform.Result;
 import javax.xml.transform.Source;
@@ -60,7 +62,6 @@ class SaajSoap12MessageTests extends AbstractSoap12MessageTests {
 
 	@Test
 	void getDocumentReflectsAddedHeaderElement() throws Exception {
-
 		MessageFactory messageFactory = MessageFactory.newInstance(SOAPConstants.SOAP_1_2_PROTOCOL);
 		SaajSoapMessage message = new SaajSoapMessage(messageFactory.createMessage(), true, messageFactory);
 		SoapHeader soapHeader = message.getSoapHeader();
@@ -69,9 +70,10 @@ class SaajSoap12MessageTests extends AbstractSoap12MessageTests {
 		soapHeaderElement.setMustUnderstand(true);
 		soapHeaderElement.setText("some text");
 
-		XmlAssert.assertThat(message.getDocument())
-			.valueByXPath("count(//*[local-name()='Action' and namespace-uri()='http://www.w3.org/2005/08/addressing' and text()='some text'])")
-			.isEqualTo("1");
+		XmlAssert xmlAssert = XmlAssert.assertThat(message.getDocument())
+			.withNamespaceContext(Map.of("a", "http://www.w3.org/2005/08/addressing"));
+		xmlAssert.hasXPath("//a:Action");
+		xmlAssert.valueByXPath("//a:Action").isEqualTo("some text");
 	}
 
 	@Test


### PR DESCRIPTION
## Summary

- Call `saveChanges()` in `SaajSoapMessage.getDocument()` before serializing the backing SAAJ message
- Ensures header elements added via `SoapHeader.addHeaderElement()` are reflected in the returned `Document` (fixes MockWebServiceServer / `SoapEnvelopeDiffMatcher` mismatches)

Fixes #1153

## Root cause

`getDocument()` serializes the SAAJ message via `writeTo()` without first calling `saveChanges()`. In-memory header mutations from `addHeaderElement()` are therefore omitted from the serialized DOM even though they appear when the message is sent via `writeTo()` (which already calls `saveChanges()`).

## Test plan

- [x] `./gradlew :spring-ws-core:test --tests "org.springframework.ws.soap.saaj.SaajSoap11MessageTests.getDocumentReflectsAddedHeaderElement"`
- [x] `./gradlew :spring-ws-core:test --tests "org.springframework.ws.soap.saaj.SaajSoap12MessageTests.getDocumentReflectsAddedHeaderElement"`
- [x] `./gradlew :spring-ws-core:test --tests "org.springframework.ws.soap.saaj.*"`

Signed-off-by: arimu1 <19286898+arimu1@users.noreply.github.com>

Made with [Cursor](https://cursor.com)